### PR TITLE
feat(review-suite,skills): deliver review-packet and epic-dispatch context via files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,16 +40,18 @@ summary: Chronological history of repository and skill changes.
   executing context appends to across rounds — plus the no-pasted-history rule
   with its failure mode: each pasted round lengthens the next prompt, so
   dispatch reproduces stale context faster than it delivers current
-  requirements. Delegated execution stays out of the mandate because the
-  coordinator is contractually opaque and this repository cannot bind its prompt
-  format, so `implement-ticket`'s delegated-worker paragraph carries the rule as
+  requirements. That dot directory ships the skill-local `.gitignore`
+  `AGENTS.md` requires, in the shape `skills/ready-ticket` established.
+  Delegated execution stays out of the mandate because the coordinator is
+  contractually opaque and this repository cannot bind its prompt format, so
+  `implement-ticket`'s delegated-worker paragraph carries the rule as
   recommend-only prose that never returns `blocked` for its absence, and
   `references/delegated-execution/CONTRACT.md` is unchanged. Ported with
   attribution from superpowers' `subagent-driven-development` fresh-context
   construction, already recorded as that skill's secondary registry entry. Adds
   a `missing-diff-evidence-file` orchestration eval case proving the fail-closed
   path, and twelve behavioral tests bound to the ticket's acceptance criteria,
-  each observed failing at base `83a526b` and passing at head
+  each observed failing at base `73f1aa8` and passing at head
 
 - feat(skills): add the ready-ticket skill for peer-aware ticket authoring
   (issue #124, epic #118, the epic's first seam leaf) — add
@@ -93,7 +95,9 @@ summary: Chronological history of repository and skill changes.
   contorting either description. Ships 24 result-blind eval cases with their
   expectations held separately and a 31-assertion contract test;
   pressure-testing from baseline is #137's, so the rationalization table carries
-  anticipated rather than verbatim wording and says so (`73f1aa8e2fc34fa93f989c0e146efacfe41133e7`)
+  anticipated rather than verbatim wording and says so
+  (`73f1aa8e2fc34fa93f989c0e146efacfe41133e7`)
+
 ## 2026-08-03 — Established the written skill-authoring methodology including the house testing doctrine, then added the peer-skill convention with a complete named-peer registry and rewrote all nine trigger descriptions to the description-states-when rule
 
 - feat(skills): define the peer-skill convention and registry, and rewrite all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,18 +40,24 @@ summary: Chronological history of repository and skill changes.
   executing context appends to across rounds — plus the no-pasted-history rule
   with its failure mode: each pasted round lengthens the next prompt, so
   dispatch reproduces stale context faster than it delivers current
-  requirements. That dot directory ships the skill-local `.gitignore`
-  `AGENTS.md` requires, in the shape `skills/ready-ticket` established.
-  Delegated execution stays out of the mandate because the coordinator is
-  contractually opaque and this repository cannot bind its prompt format, so
-  `implement-ticket`'s delegated-worker paragraph carries the rule as
-  recommend-only prose that never returns `blocked` for its absence, and
-  `references/delegated-execution/CONTRACT.md` is unchanged. Ported with
-  attribution from superpowers' `subagent-driven-development` fresh-context
-  construction, already recorded as that skill's secondary registry entry. Adds
-  a `missing-diff-evidence-file` orchestration eval case proving the fail-closed
-  path, and twelve behavioral tests bound to the ticket's acceptance criteria,
-  each observed failing at base `73f1aa8` and passing at head
+  requirements. Those two paths are absolute and the directory sits at the
+  coordinator's working root outside every candidate worktree, for the same
+  cross-context reason as the diff reference: the executing context owns a
+  different worktree, and because the prompt deliberately does not restate the
+  brief, an unresolvable path dispatches a worker with no requirements at all
+  while the prompt still looks complete. That dot directory ships the
+  skill-local `.gitignore` `AGENTS.md` requires, in the shape
+  `skills/ready-ticket` established. Delegated execution stays out of the
+  mandate because the coordinator is contractually opaque and this repository
+  cannot bind its prompt format, so `implement-ticket`'s delegated-worker
+  paragraph carries the rule as recommend-only prose that never returns
+  `blocked` for its absence, and `references/delegated-execution/CONTRACT.md` is
+  unchanged. Ported with attribution from superpowers'
+  `subagent-driven-development` fresh-context construction, already recorded as
+  that skill's secondary registry entry. Adds a `missing-diff-evidence-file`
+  orchestration eval case proving the fail-closed path, and twelve behavioral
+  tests bound to the ticket's acceptance criteria, each observed failing at base
+  `73f1aa8` and passing at head
 
 - feat(skills): add the ready-ticket skill for peer-aware ticket authoring
   (issue #124, epic #118, the epic's first seam leaf) — add

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,45 @@ summary: Chronological history of repository and skill changes.
 
 # Changelog
 
-## 2026-08-04 — Authored `ready-ticket`, the first peer-aware seam skill, at the pipeline's upstream edge
+## 2026-08-04 — Authored `ready-ticket`, the first peer-aware seam skill, at the pipeline's upstream edge, then moved review-packet diff evidence and epic child dispatch onto files instead of inlined context
+
+- feat(review-suite,skills): deliver review-packet and epic-dispatch context via
+  files instead of inlined context (issue #130, epic #119, the epic's only
+  unblocked child) — stop spending a reviewer's and a dispatched worker's
+  context on artifacts they can read for themselves. `candidate.diff` becomes a
+  schema `oneOf`: the existing inline unified-diff string, or an evidence-path
+  object naming a file whose content is that diff. The packet builder writes the
+  complete diff to a temporary directory **outside** the candidate worktree and
+  records the path, so the existing before/after read-only integrity check stays
+  trivially satisfied by construction rather than needing an exemption; lens
+  dispatch in `review-code-change`'s `SKILL.md` and
+  `references/orchestration-protocol.md`, and the caller-side invocation prose
+  in `implement-ticket`'s `references/review-and-merge-gates.md`, now hand the
+  path and no longer inline the complete `base...HEAD` diff. `validate.py` gains
+  generic `oneOf` support — reporting the closest branch's own errors rather
+  than a generic no-form-matched message, so every existing blockable-error
+  pattern keeps matching — and fails closed when a referenced diff file is
+  absent or empty, classifying both as missing review evidence so the review
+  yields `blocked` instead of reading an unreadable reference as a smaller diff.
+  Fixtures under `review-suite/fixtures/` and the eval strata stay inline and
+  pass unmodified; all seven bundled `references/review-suite/` copies
+  (including `review-fix-loop`'s) are re-synced via `just sync-contracts` and
+  the drift tests pass. On the dispatch side, `implement-epic` gains file-based
+  child-dispatch artifacts under `.implement-epic/` — a brief file as the single
+  source of a child's task requirements and a per-dispatch report file the
+  executing context appends to across rounds — plus the no-pasted-history rule
+  with its failure mode: each pasted round lengthens the next prompt, so
+  dispatch reproduces stale context faster than it delivers current
+  requirements. Delegated execution stays out of the mandate because the
+  coordinator is contractually opaque and this repository cannot bind its prompt
+  format, so `implement-ticket`'s delegated-worker paragraph carries the rule as
+  recommend-only prose that never returns `blocked` for its absence, and
+  `references/delegated-execution/CONTRACT.md` is unchanged. Ported with
+  attribution from superpowers' `subagent-driven-development` fresh-context
+  construction, already recorded as that skill's secondary registry entry. Adds
+  a `missing-diff-evidence-file` orchestration eval case proving the fail-closed
+  path, and eleven behavioral tests bound to the ticket's acceptance criteria,
+  each observed failing at base `83a526b` and passing at head
 
 - feat(skills): add the ready-ticket skill for peer-aware ticket authoring
   (issue #124, epic #118, the epic's first seam leaf) — add
@@ -48,8 +86,7 @@ summary: Chronological history of repository and skill changes.
   contorting either description. Ships 24 result-blind eval cases with their
   expectations held separately and a 31-assertion contract test;
   pressure-testing from baseline is #137's, so the rationalization table carries
-  anticipated rather than verbatim wording and says so
-
+  anticipated rather than verbatim wording and says so (`73f1aa8e2fc34fa93f989c0e146efacfe41133e7`)
 ## 2026-08-03 — Established the written skill-authoring methodology including the house testing doctrine, then added the peer-skill convention with a complete named-peer registry and rewrote all nine trigger descriptions to the description-states-when rule
 
 - feat(skills): define the peer-skill convention and registry, and rewrite all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,12 +22,19 @@ summary: Chronological history of repository and skill changes.
   generic `oneOf` support — reporting the closest branch's own errors rather
   than a generic no-form-matched message, so every existing blockable-error
   pattern keeps matching — and fails closed when a referenced diff file is
-  absent or empty, classifying both as missing review evidence so the review
-  yields `blocked` instead of reading an unreadable reference as a smaller diff.
-  Fixtures under `review-suite/fixtures/` and the eval strata stay inline and
-  pass unmodified; all seven bundled `references/review-suite/` copies
-  (including `review-fix-loop`'s) are re-synced via `just sync-contracts` and
-  the drift tests pass. On the dispatch side, `implement-epic` gains file-based
+  absent, empty, or named by a relative path, classifying all three as missing
+  review evidence so the review yields `blocked` instead of reading an
+  unresolvable reference as a smaller diff. The absolute-path requirement came
+  out of this change's own review: because the reference is now the sole binding
+  between a lens and the diff it reviews, and the builder and each lens
+  revalidate the same packet from their own working directories, a relative
+  reference could resolve to a different same-named file and bind a lens to a
+  diff that is not the candidate's — a substitution no candidate-identity check
+  can catch, since those compare SHAs and never the diff's provenance. Fixtures
+  under `review-suite/fixtures/` and the eval strata stay inline and pass
+  unmodified; all seven bundled `references/review-suite/` copies (including
+  `review-fix-loop`'s) are re-synced via `just sync-contracts` and the drift
+  tests pass. On the dispatch side, `implement-epic` gains file-based
   child-dispatch artifacts under `.implement-epic/` — a brief file as the single
   source of a child's task requirements and a per-dispatch report file the
   executing context appends to across rounds — plus the no-pasted-history rule
@@ -41,7 +48,7 @@ summary: Chronological history of repository and skill changes.
   attribution from superpowers' `subagent-driven-development` fresh-context
   construction, already recorded as that skill's secondary registry entry. Adds
   a `missing-diff-evidence-file` orchestration eval case proving the fail-closed
-  path, and eleven behavioral tests bound to the ticket's acceptance criteria,
+  path, and twelve behavioral tests bound to the ticket's acceptance criteria,
   each observed failing at base `83a526b` and passing at head
 
 - feat(skills): add the ready-ticket skill for peer-aware ticket authoring

--- a/review-suite/CONTRACT.md
+++ b/review-suite/CONTRACT.md
@@ -55,7 +55,7 @@ Required packet sections are:
 
 1. `repository`: repository identity and base branch.
 2. `candidate`: the captured head, the comparison base or merge base, and the
-   complete candidate diff.
+   complete candidate diff in one of the two forms below.
 3. `change_contract`: observable goal, non-empty acceptance criteria, explicit
    non-goals, and behavior or invariants to preserve.
 4. `sources`: applicable repository instructions, named design or contract
@@ -72,8 +72,32 @@ on it. Optional `base_drift` records why evidence was retained or reset after
 the base advanced.
 
 Do not infer missing intent. Missing repository identity, goal, acceptance
-criteria, candidate identity, a complete diff, or required validation evidence
-prevents a trustworthy review and must yield a `blocked` result.
+criteria, candidate identity, a complete diff in either form below, or required
+validation evidence prevents a trustworthy review and must yield a `blocked`
+result.
+
+### The candidate diff: inline or referenced by path
+
+`candidate.diff` carries the complete diff in exactly one of two forms:
+
+- **inline** — `content` holds the unified diff itself; and
+- **referenced** — `path` holds the location of a file whose content is that
+  diff.
+
+The forms are mutually exclusive: a diff object carrying both or neither is
+malformed. Both assert `complete: true` and mean the same thing to a lens — the
+reviewed candidate is the whole diff, never a summary of it.
+
+A packet builder that writes the diff to a file writes it **outside the
+candidate worktree**. Evidence written inside the worktree registers as a
+candidate mutation and fails the before/after integrity check that proves the
+review was read-only, so keeping the evidence elsewhere is what keeps that check
+trivially satisfied rather than something the builder must exempt itself from.
+
+A referenced file that is absent or empty is missing review evidence, exactly as
+an absent inline `content` is: `scripts/validate.py` fails closed on it and the
+review yields `blocked`. Never read an unreadable reference as a candidate whose
+diff is merely smaller.
 
 ## Finding semantics
 

--- a/review-suite/CONTRACT.md
+++ b/review-suite/CONTRACT.md
@@ -89,10 +89,16 @@ malformed. Both assert `complete: true` and mean the same thing to a lens — th
 reviewed candidate is the whole diff, never a summary of it.
 
 A packet builder that writes the diff to a file writes it **outside the
-candidate worktree**. Evidence written inside the worktree registers as a
-candidate mutation and fails the before/after integrity check that proves the
-review was read-only, so keeping the evidence elsewhere is what keeps that check
-trivially satisfied rather than something the builder must exempt itself from.
+candidate worktree**, and records an **absolute** path. Evidence written inside
+the worktree registers as a candidate mutation and fails the before/after
+integrity check that proves the review was read-only, so keeping the evidence
+elsewhere is what keeps that check trivially satisfied rather than something the
+builder must exempt itself from. A relative path is rejected because the builder
+and every lens revalidate the same packet from their own working directories: a
+relative reference either reports evidence absent that exists, or resolves to a
+different file of the same name and binds a lens to a diff that is not the
+candidate's — a substitution no candidate-identity check can catch, because
+those compare SHAs and never the diff's provenance.
 
 A referenced file that is absent or empty is missing review evidence, exactly as
 an absent inline `content` is: `scripts/validate.py` fails closed on it and the

--- a/review-suite/contracts/review-packet.schema.json
+++ b/review-suite/contracts/review-packet.schema.json
@@ -36,14 +36,28 @@
           "pattern": "^[0-9a-f]{40}$"
         },
         "diff": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["format", "complete", "content"],
-          "properties": {
-            "format": {"enum": ["unified_diff"]},
-            "complete": {"const": true},
-            "content": {"type": "string", "minLength": 1}
-          }
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["format", "complete", "content"],
+              "properties": {
+                "format": {"enum": ["unified_diff"]},
+                "complete": {"const": true},
+                "content": {"type": "string", "minLength": 1}
+              }
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["format", "complete", "path"],
+              "properties": {
+                "format": {"enum": ["unified_diff"]},
+                "complete": {"const": true},
+                "path": {"type": "string", "minLength": 1}
+              }
+            }
+          ]
         }
       }
     },

--- a/review-suite/scripts/tests/test_contracts.py
+++ b/review-suite/scripts/tests/test_contracts.py
@@ -4,6 +4,8 @@ import copy
 import importlib.util
 import json
 import subprocess
+import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -118,6 +120,96 @@ class PacketValidationTests(unittest.TestCase):
     def test_malformed_validation_item_returns_errors(self):
         self.packet["validation"] = ["pytest"]
         self.assertTrue(VALIDATOR.validate_packet(self.packet))
+
+
+class DiffEvidencePathTests(unittest.TestCase):
+    """A packet may carry the complete diff inline or reference it by path.
+
+    #130: lens dispatch stopped inlining the complete diff, so the packet
+    builder writes it to a file outside the candidate worktree and records the
+    path. Both forms must validate, and a referenced file that is absent or
+    empty is missing review evidence, not a smaller diff.
+    """
+
+    def setUp(self):
+        self.packet = load(ROOT / "fixtures" / "clean-change" / "packet.json")
+        self.diff = self.packet["candidate"]["diff"]["content"]
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        self.evidence = Path(self.directory.name) / "candidate.diff"
+
+    def referencing(self, location: Path):
+        packet = copy.deepcopy(self.packet)
+        packet["candidate"]["diff"] = {
+            "format": "unified_diff",
+            "complete": True,
+            "path": str(location),
+        }
+        return packet
+
+    def test_packet_referencing_a_written_diff_file_is_accepted(self):
+        self.evidence.write_text(self.diff)
+        self.assertEqual([], VALIDATOR.validate_packet(self.referencing(self.evidence)))
+
+    def test_inline_diff_packet_is_still_accepted(self):
+        self.assertEqual([], VALIDATOR.validate_packet(self.packet))
+
+    def test_absent_diff_file_is_reported_as_missing_review_evidence(self):
+        errors = VALIDATOR.validate_packet(self.referencing(self.evidence))
+        self.assertEqual(
+            ["$.candidate.diff.path: referenced diff evidence file is missing"],
+            errors,
+        )
+        self.assertTrue(VALIDATOR.is_blockable_packet_error(errors[0]))
+
+    def test_empty_diff_file_is_reported_as_missing_review_evidence(self):
+        self.evidence.write_text("")
+        errors = VALIDATOR.validate_packet(self.referencing(self.evidence))
+        self.assertEqual(
+            ["$.candidate.diff.path: referenced diff evidence file is empty"],
+            errors,
+        )
+        self.assertTrue(VALIDATOR.is_blockable_packet_error(errors[0]))
+
+    def test_a_diff_cannot_carry_both_forms(self):
+        self.evidence.write_text(self.diff)
+        packet = self.referencing(self.evidence)
+        packet["candidate"]["diff"]["content"] = self.diff
+        self.assertTrue(VALIDATOR.validate_packet(packet))
+
+    def test_a_diff_carrying_neither_form_is_rejected(self):
+        packet = self.referencing(self.evidence)
+        del packet["candidate"]["diff"]["path"]
+        self.assertIn(
+            "$.candidate.diff: missing required property 'content'",
+            VALIDATOR.validate_packet(packet),
+        )
+
+    def test_missing_diff_evidence_pairs_with_blocked_but_never_clean(self):
+        packet = self.referencing(self.evidence)
+        result = load(ROOT / "fixtures" / "clean-change" / "expected.json")
+        blocked = copy.deepcopy(result)
+        blocked["verdict"] = "blocked"
+        blocked["blocking_reasons"] = ["The referenced candidate diff is unreadable."]
+        self.assertEqual([], VALIDATOR.validate_pair(packet, blocked))
+        self.assertTrue(VALIDATOR.validate_pair(packet, result))
+
+    def test_cli_rejects_a_packet_whose_referenced_diff_is_absent(self):
+        packet_file = Path(self.directory.name) / "packet.json"
+        packet_file.write_text(json.dumps(self.referencing(self.evidence)))
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(ROOT / "scripts" / "validate.py"),
+                "packet",
+                str(packet_file),
+            ],
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+        self.assertEqual(1, completed.returncode)
+        self.assertIn("referenced diff evidence file is missing", completed.stderr)
 
 
 class ResultValidationTests(unittest.TestCase):

--- a/review-suite/scripts/tests/test_contracts.py
+++ b/review-suite/scripts/tests/test_contracts.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import importlib.util
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -167,6 +168,30 @@ class DiffEvidencePathTests(unittest.TestCase):
         errors = VALIDATOR.validate_packet(self.referencing(self.evidence))
         self.assertEqual(
             ["$.candidate.diff.path: referenced diff evidence file is empty"],
+            errors,
+        )
+        self.assertTrue(VALIDATOR.is_blockable_packet_error(errors[0]))
+
+    def test_a_relative_reference_is_rejected_even_when_it_resolves(self):
+        """A relative reference binds a lens to whatever its own cwd holds.
+
+        The builder and each lens revalidate the same packet from different
+        working directories, so the check must reject the reference itself
+        rather than accept whichever same-named file happens to be nearby.
+        """
+        self.evidence.write_text(self.diff)
+        packet = self.referencing(Path(self.evidence.name))
+        previous = Path.cwd()
+        os.chdir(self.directory.name)
+        try:
+            errors = VALIDATOR.validate_packet(packet)
+        finally:
+            os.chdir(previous)
+        self.assertEqual(
+            [
+                "$.candidate.diff.path: referenced diff evidence file must be "
+                "an absolute path"
+            ],
             errors,
         )
         self.assertTrue(VALIDATOR.is_blockable_packet_error(errors[0]))

--- a/review-suite/scripts/validate.py
+++ b/review-suite/scripts/validate.py
@@ -67,6 +67,10 @@ BLOCKABLE_PACKET_ERROR_PATTERNS = (
         r"(missing|empty)$"
     ),
     re.compile(
+        r"^\$\.candidate\.diff\.path: referenced diff evidence file must be an "
+        r"absolute path$"
+    ),
+    re.compile(
         r"^\$\.change_contract: missing required property "
         r"'(goal|acceptance_criteria|non_goals|preserved_behaviors)'$"
     ),
@@ -207,12 +211,26 @@ def _check_diff_evidence_path(packet: dict[str, Any]) -> list[str]:
     inline `content` reports — and not a candidate with a smaller diff. The
     emptiness bar mirrors the inline form's `minLength: 1` exactly so neither
     form is stricter than the other.
+
+    The reference must be absolute. A relative path resolves against whatever
+    working directory happens to be current, and the builder and each lens
+    revalidate the same packet from different directories, so a relative
+    reference either reports absent evidence that exists or — worse — resolves
+    to a different file of the same name and binds a lens to a diff that is not
+    the candidate's. Candidate-identity checks compare SHAs and cannot detect
+    that substitution. This mirrors why `_schema_file` above resolves its own
+    schemas `__file__`-relative rather than from the current directory.
     """
     diff = packet.get("candidate", {}).get("diff")
     location = diff.get("path") if isinstance(diff, dict) else None
     if not location:
         return []
     evidence = Path(location)
+    if not evidence.is_absolute():
+        return [
+            "$.candidate.diff.path: referenced diff evidence file must be an "
+            "absolute path"
+        ]
     if not evidence.is_file():
         return ["$.candidate.diff.path: referenced diff evidence file is missing"]
     if evidence.stat().st_size == 0:

--- a/review-suite/scripts/validate.py
+++ b/review-suite/scripts/validate.py
@@ -58,10 +58,14 @@ BLOCKABLE_PACKET_ERROR_PATTERNS = (
     ),
     re.compile(
         r"^\$\.candidate\.diff: missing required property "
-        r"'(format|complete|content)'$"
+        r"'(format|complete|content|path)'$"
     ),
     re.compile(r"^\$\.candidate\.diff\.complete: expected constant True$"),
-    re.compile(r"^\$\.candidate\.diff\.content: string is too short$"),
+    re.compile(r"^\$\.candidate\.diff\.(content|path): string is too short$"),
+    re.compile(
+        r"^\$\.candidate\.diff\.path: referenced diff evidence file is "
+        r"(missing|empty)$"
+    ),
     re.compile(
         r"^\$\.change_contract: missing required property "
         r"'(goal|acceptance_criteria|non_goals|preserved_behaviors)'$"
@@ -105,6 +109,18 @@ def validate_schema(value: Any, schema: dict[str, Any], at: str = "$") -> list[s
     expected_type = schema.get("type")
     if expected_type and not _is_type(value, expected_type):
         return [f"{at}: expected {expected_type}"]
+
+    if branches := schema.get("oneOf"):
+        # Every `oneOf` in this repository's schemas has branches made mutually
+        # exclusive by `additionalProperties: false`, so no value can satisfy
+        # two of them and a match by any branch is the match. On failure,
+        # report the closest branch's own errors instead of a generic
+        # "no form matched": the caller needs the actionable message for the
+        # form it was evidently aiming at, and BLOCKABLE_PACKET_ERROR_PATTERNS
+        # is written against those exact messages.
+        attempts = [validate_schema(value, branch, at) for branch in branches]
+        if all(attempts):
+            errors.extend(min(attempts, key=len))
 
     if "const" in schema:
         const = schema["const"]
@@ -150,6 +166,8 @@ def validate_packet(packet: dict[str, Any]) -> list[str]:
     if errors:
         return errors
 
+    errors.extend(_check_diff_evidence_path(packet))
+
     for index, validation in enumerate(packet.get("validation", [])):
         status = validation.get("status")
         if status in {"passed", "failed"} and not validation.get("result"):
@@ -178,6 +196,28 @@ def validate_packet(packet: dict[str, Any]) -> list[str]:
                 + ", ".join(active)
             )
     return errors
+
+
+def _check_diff_evidence_path(packet: dict[str, Any]) -> list[str]:
+    """Fail closed when a path-form candidate diff references no readable file.
+
+    The path form exists so lens dispatch carries a reference instead of the
+    complete diff, which means the file is the evidence. An absent or empty
+    file is therefore missing review evidence — the same condition an absent
+    inline `content` reports — and not a candidate with a smaller diff. The
+    emptiness bar mirrors the inline form's `minLength: 1` exactly so neither
+    form is stricter than the other.
+    """
+    diff = packet.get("candidate", {}).get("diff")
+    location = diff.get("path") if isinstance(diff, dict) else None
+    if not location:
+        return []
+    evidence = Path(location)
+    if not evidence.is_file():
+        return ["$.candidate.diff.path: referenced diff evidence file is missing"]
+    if evidence.stat().st_size == 0:
+        return ["$.candidate.diff.path: referenced diff evidence file is empty"]
+    return []
 
 
 def validate_result(result: dict[str, Any]) -> list[str]:

--- a/skills/babysit-pr/references/review-suite/CONTRACT.md
+++ b/skills/babysit-pr/references/review-suite/CONTRACT.md
@@ -55,7 +55,7 @@ Required packet sections are:
 
 1. `repository`: repository identity and base branch.
 2. `candidate`: the captured head, the comparison base or merge base, and the
-   complete candidate diff.
+   complete candidate diff in one of the two forms below.
 3. `change_contract`: observable goal, non-empty acceptance criteria, explicit
    non-goals, and behavior or invariants to preserve.
 4. `sources`: applicable repository instructions, named design or contract
@@ -72,8 +72,32 @@ on it. Optional `base_drift` records why evidence was retained or reset after
 the base advanced.
 
 Do not infer missing intent. Missing repository identity, goal, acceptance
-criteria, candidate identity, a complete diff, or required validation evidence
-prevents a trustworthy review and must yield a `blocked` result.
+criteria, candidate identity, a complete diff in either form below, or required
+validation evidence prevents a trustworthy review and must yield a `blocked`
+result.
+
+### The candidate diff: inline or referenced by path
+
+`candidate.diff` carries the complete diff in exactly one of two forms:
+
+- **inline** — `content` holds the unified diff itself; and
+- **referenced** — `path` holds the location of a file whose content is that
+  diff.
+
+The forms are mutually exclusive: a diff object carrying both or neither is
+malformed. Both assert `complete: true` and mean the same thing to a lens — the
+reviewed candidate is the whole diff, never a summary of it.
+
+A packet builder that writes the diff to a file writes it **outside the
+candidate worktree**. Evidence written inside the worktree registers as a
+candidate mutation and fails the before/after integrity check that proves the
+review was read-only, so keeping the evidence elsewhere is what keeps that check
+trivially satisfied rather than something the builder must exempt itself from.
+
+A referenced file that is absent or empty is missing review evidence, exactly as
+an absent inline `content` is: `scripts/validate.py` fails closed on it and the
+review yields `blocked`. Never read an unreadable reference as a candidate whose
+diff is merely smaller.
 
 ## Finding semantics
 

--- a/skills/babysit-pr/references/review-suite/CONTRACT.md
+++ b/skills/babysit-pr/references/review-suite/CONTRACT.md
@@ -89,10 +89,16 @@ malformed. Both assert `complete: true` and mean the same thing to a lens — th
 reviewed candidate is the whole diff, never a summary of it.
 
 A packet builder that writes the diff to a file writes it **outside the
-candidate worktree**. Evidence written inside the worktree registers as a
-candidate mutation and fails the before/after integrity check that proves the
-review was read-only, so keeping the evidence elsewhere is what keeps that check
-trivially satisfied rather than something the builder must exempt itself from.
+candidate worktree**, and records an **absolute** path. Evidence written inside
+the worktree registers as a candidate mutation and fails the before/after
+integrity check that proves the review was read-only, so keeping the evidence
+elsewhere is what keeps that check trivially satisfied rather than something the
+builder must exempt itself from. A relative path is rejected because the builder
+and every lens revalidate the same packet from their own working directories: a
+relative reference either reports evidence absent that exists, or resolves to a
+different file of the same name and binds a lens to a diff that is not the
+candidate's — a substitution no candidate-identity check can catch, because
+those compare SHAs and never the diff's provenance.
 
 A referenced file that is absent or empty is missing review evidence, exactly as
 an absent inline `content` is: `scripts/validate.py` fails closed on it and the

--- a/skills/babysit-pr/references/review-suite/review-packet.schema.json
+++ b/skills/babysit-pr/references/review-suite/review-packet.schema.json
@@ -36,14 +36,28 @@
           "pattern": "^[0-9a-f]{40}$"
         },
         "diff": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["format", "complete", "content"],
-          "properties": {
-            "format": {"enum": ["unified_diff"]},
-            "complete": {"const": true},
-            "content": {"type": "string", "minLength": 1}
-          }
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["format", "complete", "content"],
+              "properties": {
+                "format": {"enum": ["unified_diff"]},
+                "complete": {"const": true},
+                "content": {"type": "string", "minLength": 1}
+              }
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["format", "complete", "path"],
+              "properties": {
+                "format": {"enum": ["unified_diff"]},
+                "complete": {"const": true},
+                "path": {"type": "string", "minLength": 1}
+              }
+            }
+          ]
         }
       }
     },

--- a/skills/babysit-pr/references/review-suite/validate.py
+++ b/skills/babysit-pr/references/review-suite/validate.py
@@ -67,6 +67,10 @@ BLOCKABLE_PACKET_ERROR_PATTERNS = (
         r"(missing|empty)$"
     ),
     re.compile(
+        r"^\$\.candidate\.diff\.path: referenced diff evidence file must be an "
+        r"absolute path$"
+    ),
+    re.compile(
         r"^\$\.change_contract: missing required property "
         r"'(goal|acceptance_criteria|non_goals|preserved_behaviors)'$"
     ),
@@ -207,12 +211,26 @@ def _check_diff_evidence_path(packet: dict[str, Any]) -> list[str]:
     inline `content` reports — and not a candidate with a smaller diff. The
     emptiness bar mirrors the inline form's `minLength: 1` exactly so neither
     form is stricter than the other.
+
+    The reference must be absolute. A relative path resolves against whatever
+    working directory happens to be current, and the builder and each lens
+    revalidate the same packet from different directories, so a relative
+    reference either reports absent evidence that exists or — worse — resolves
+    to a different file of the same name and binds a lens to a diff that is not
+    the candidate's. Candidate-identity checks compare SHAs and cannot detect
+    that substitution. This mirrors why `_schema_file` above resolves its own
+    schemas `__file__`-relative rather than from the current directory.
     """
     diff = packet.get("candidate", {}).get("diff")
     location = diff.get("path") if isinstance(diff, dict) else None
     if not location:
         return []
     evidence = Path(location)
+    if not evidence.is_absolute():
+        return [
+            "$.candidate.diff.path: referenced diff evidence file must be an "
+            "absolute path"
+        ]
     if not evidence.is_file():
         return ["$.candidate.diff.path: referenced diff evidence file is missing"]
     if evidence.stat().st_size == 0:

--- a/skills/babysit-pr/references/review-suite/validate.py
+++ b/skills/babysit-pr/references/review-suite/validate.py
@@ -58,10 +58,14 @@ BLOCKABLE_PACKET_ERROR_PATTERNS = (
     ),
     re.compile(
         r"^\$\.candidate\.diff: missing required property "
-        r"'(format|complete|content)'$"
+        r"'(format|complete|content|path)'$"
     ),
     re.compile(r"^\$\.candidate\.diff\.complete: expected constant True$"),
-    re.compile(r"^\$\.candidate\.diff\.content: string is too short$"),
+    re.compile(r"^\$\.candidate\.diff\.(content|path): string is too short$"),
+    re.compile(
+        r"^\$\.candidate\.diff\.path: referenced diff evidence file is "
+        r"(missing|empty)$"
+    ),
     re.compile(
         r"^\$\.change_contract: missing required property "
         r"'(goal|acceptance_criteria|non_goals|preserved_behaviors)'$"
@@ -105,6 +109,18 @@ def validate_schema(value: Any, schema: dict[str, Any], at: str = "$") -> list[s
     expected_type = schema.get("type")
     if expected_type and not _is_type(value, expected_type):
         return [f"{at}: expected {expected_type}"]
+
+    if branches := schema.get("oneOf"):
+        # Every `oneOf` in this repository's schemas has branches made mutually
+        # exclusive by `additionalProperties: false`, so no value can satisfy
+        # two of them and a match by any branch is the match. On failure,
+        # report the closest branch's own errors instead of a generic
+        # "no form matched": the caller needs the actionable message for the
+        # form it was evidently aiming at, and BLOCKABLE_PACKET_ERROR_PATTERNS
+        # is written against those exact messages.
+        attempts = [validate_schema(value, branch, at) for branch in branches]
+        if all(attempts):
+            errors.extend(min(attempts, key=len))
 
     if "const" in schema:
         const = schema["const"]
@@ -150,6 +166,8 @@ def validate_packet(packet: dict[str, Any]) -> list[str]:
     if errors:
         return errors
 
+    errors.extend(_check_diff_evidence_path(packet))
+
     for index, validation in enumerate(packet.get("validation", [])):
         status = validation.get("status")
         if status in {"passed", "failed"} and not validation.get("result"):
@@ -178,6 +196,28 @@ def validate_packet(packet: dict[str, Any]) -> list[str]:
                 + ", ".join(active)
             )
     return errors
+
+
+def _check_diff_evidence_path(packet: dict[str, Any]) -> list[str]:
+    """Fail closed when a path-form candidate diff references no readable file.
+
+    The path form exists so lens dispatch carries a reference instead of the
+    complete diff, which means the file is the evidence. An absent or empty
+    file is therefore missing review evidence — the same condition an absent
+    inline `content` reports — and not a candidate with a smaller diff. The
+    emptiness bar mirrors the inline form's `minLength: 1` exactly so neither
+    form is stricter than the other.
+    """
+    diff = packet.get("candidate", {}).get("diff")
+    location = diff.get("path") if isinstance(diff, dict) else None
+    if not location:
+        return []
+    evidence = Path(location)
+    if not evidence.is_file():
+        return ["$.candidate.diff.path: referenced diff evidence file is missing"]
+    if evidence.stat().st_size == 0:
+        return ["$.candidate.diff.path: referenced diff evidence file is empty"]
+    return []
 
 
 def validate_result(result: dict[str, Any]) -> list[str]:

--- a/skills/implement-epic/.gitignore
+++ b/skills/implement-epic/.gitignore
@@ -1,0 +1,2 @@
+# Skill-local child-dispatch artifacts; never part of the repository history.
+.implement-epic/

--- a/skills/implement-epic/SKILL.md
+++ b/skills/implement-epic/SKILL.md
@@ -191,6 +191,20 @@ Invoke `implement-ticket` once with a concise handoff containing:
 - the explicit decomposition grant or its explicit absence; and
 - any epic-level rollout or merge-order constraint that qualifies the child.
 
+Deliver that handoff as files. Under `.implement-epic/` write one **brief** file
+per selected child — the single source of its task requirements — and one
+**report** file per dispatch, which the executing context appends its status to
+across rounds. The dispatch prompt carries those two paths plus a short contract
+naming what the report must record; it does not restate the brief.
+
+Never paste accumulated history — an earlier round, a prior report, or previous
+dispatch prose — into a later prompt. Each pasted round makes the next prompt
+longer than the last, so dispatch reproduces stale context faster than it
+delivers current requirements, and the executing context receives superseded and
+live instructions mixed together with nothing marking which is which. Revise the
+brief and let the report accumulate on disk. Keep `.implement-epic/` ignored and
+out of commits and PRs.
+
 The primary context may follow `implement-ticket` directly. A delegated worker,
 subagent, or equivalent context must have exclusive ownership of one verified
 ticket worktree and branch. Never run two mutating contexts against the same

--- a/skills/implement-epic/SKILL.md
+++ b/skills/implement-epic/SKILL.md
@@ -191,11 +191,19 @@ Invoke `implement-ticket` once with a concise handoff containing:
 - the explicit decomposition grant or its explicit absence; and
 - any epic-level rollout or merge-order constraint that qualifies the child.
 
-Deliver that handoff as files. Under `.implement-epic/` write one **brief** file
-per selected child — the single source of its task requirements — and one
-**report** file per dispatch, which the executing context appends its status to
-across rounds. The dispatch prompt carries those two paths plus a short contract
-naming what the report must record; it does not restate the brief.
+Deliver that handoff as files. Create `.implement-epic/` at the coordinator's
+own working root, outside every candidate ticket worktree, and write one
+**brief** file per selected child — the single source of its task requirements —
+and one **report** file per dispatch, which the executing context appends its
+status to across rounds. The dispatch prompt carries those two locations as
+absolute paths plus a short contract naming what the report must record; it does
+not restate the brief.
+
+Absolute paths are required because the executing context owns a different
+worktree, so a relative path resolves against its directory rather than the
+coordinator's. Since the prompt deliberately does not restate the brief, an
+unresolvable path dispatches a worker with no requirements at all rather than
+with degraded ones, and the prompt itself looks complete either way.
 
 Never paste accumulated history — an earlier round, a prior report, or previous
 dispatch prose — into a later prompt. Each pasted round makes the next prompt

--- a/skills/implement-epic/scripts/tests/test_orchestration_contract.py
+++ b/skills/implement-epic/scripts/tests/test_orchestration_contract.py
@@ -183,6 +183,13 @@ class ImplementEpicContractTests(unittest.TestCase):
         self.assertIn("full-chain representation on the base", self.contract)
         self.assertIn("gains no decomposition mechanics", self.contract)
 
+    def test_child_dispatch_uses_file_artifacts_and_forbids_pasted_history(self):
+        self.assertIn("`.implement-epic/`", self.contract)
+        self.assertIn("brief", self.contract)
+        self.assertIn("report", self.contract)
+        self.assertIn("Never paste accumulated history", self.contract)
+        self.assertIn("ignored and out of commits and PRs", self.contract)
+
     def test_epic_does_not_own_lens_mechanics(self):
         self.assertNotIn("review-solution-simplicity", self.contract)
         self.assertNotIn("review-correctness", self.contract)

--- a/skills/implement-epic/scripts/tests/test_orchestration_contract.py
+++ b/skills/implement-epic/scripts/tests/test_orchestration_contract.py
@@ -184,11 +184,19 @@ class ImplementEpicContractTests(unittest.TestCase):
         self.assertIn("gains no decomposition mechanics", self.contract)
 
     def test_child_dispatch_uses_file_artifacts_and_forbids_pasted_history(self):
+        # Assert the phrases that name each artifact, not the bare words
+        # "brief"/"report": the base text already contains "report" five
+        # times, so a bare token would pass without the dispatch prose.
         self.assertIn("`.implement-epic/`", self.contract)
-        self.assertIn("brief", self.contract)
-        self.assertIn("report", self.contract)
+        self.assertIn("one **brief** file per selected child", self.contract)
+        self.assertIn("one **report** file per dispatch", self.contract)
         self.assertIn("Never paste accumulated history", self.contract)
         self.assertIn("ignored and out of commits and PRs", self.contract)
+
+    def test_child_dispatch_artifacts_resolve_across_worktrees(self):
+        self.assertIn("outside every candidate ticket worktree", self.contract)
+        self.assertIn("those two locations as absolute paths", self.contract)
+        self.assertIn("a relative path resolves against its directory", self.contract)
 
     def test_epic_does_not_own_lens_mechanics(self):
         self.assertNotIn("review-solution-simplicity", self.contract)

--- a/skills/implement-ticket/SKILL.md
+++ b/skills/implement-ticket/SKILL.md
@@ -348,6 +348,13 @@ subagent, or equivalent context must own exactly one verified worktree and
 feature branch exclusively. Never allow two implementation contexts to mutate
 the same candidate. Preserve unrelated branches, worktrees, and user changes.
 
+When a delegated context is used, prefer handing it file paths for requirements
+and status over pasting accumulated history into its prompt: each pasted round
+lengthens the next prompt and reproduces superseded context beside the current
+requirement. This is a recommendation, not a gate — the delegated-execution
+contract binds a coordinator's checkpoint protocol, not its prompt format, so
+this skill cannot require it and never returns `blocked` for its absence.
+
 ### 2. Implement only the live contract
 
 - Read nearby code and tests before editing.

--- a/skills/implement-ticket/references/review-and-merge-gates.md
+++ b/skills/implement-ticket/references/review-and-merge-gates.md
@@ -45,9 +45,14 @@ fresh or minimally inherited read-only context with:
   current SHA/environment, source, and status;
 - every named architecture, design, contract, migration, and rollout document;
 - repository instructions and representative nearby code and tests;
-- the exact captured head and comparison-base SHAs plus the complete
-  `base...HEAD` diff; and
+- the exact captured head and comparison-base SHAs plus the location of a file
+  holding the complete `base...HEAD` diff; and
 - exact focused and full validation evidence, including unavailable checks.
+
+Write that diff file to a temporary directory outside the ticket worktree and
+hand over its path, not the diff text. Writing it inside the worktree would show
+up as a candidate mutation in the integrity check below, and inlining it spends
+the reviewer's context on an artifact it can read for itself.
 
 Exclude the implementation transcript, intended solution, prior conclusions,
 suspected findings, and fixture expected outputs. After review, verify that

--- a/skills/implement-ticket/references/review-suite/CONTRACT.md
+++ b/skills/implement-ticket/references/review-suite/CONTRACT.md
@@ -55,7 +55,7 @@ Required packet sections are:
 
 1. `repository`: repository identity and base branch.
 2. `candidate`: the captured head, the comparison base or merge base, and the
-   complete candidate diff.
+   complete candidate diff in one of the two forms below.
 3. `change_contract`: observable goal, non-empty acceptance criteria, explicit
    non-goals, and behavior or invariants to preserve.
 4. `sources`: applicable repository instructions, named design or contract
@@ -72,8 +72,32 @@ on it. Optional `base_drift` records why evidence was retained or reset after
 the base advanced.
 
 Do not infer missing intent. Missing repository identity, goal, acceptance
-criteria, candidate identity, a complete diff, or required validation evidence
-prevents a trustworthy review and must yield a `blocked` result.
+criteria, candidate identity, a complete diff in either form below, or required
+validation evidence prevents a trustworthy review and must yield a `blocked`
+result.
+
+### The candidate diff: inline or referenced by path
+
+`candidate.diff` carries the complete diff in exactly one of two forms:
+
+- **inline** — `content` holds the unified diff itself; and
+- **referenced** — `path` holds the location of a file whose content is that
+  diff.
+
+The forms are mutually exclusive: a diff object carrying both or neither is
+malformed. Both assert `complete: true` and mean the same thing to a lens — the
+reviewed candidate is the whole diff, never a summary of it.
+
+A packet builder that writes the diff to a file writes it **outside the
+candidate worktree**. Evidence written inside the worktree registers as a
+candidate mutation and fails the before/after integrity check that proves the
+review was read-only, so keeping the evidence elsewhere is what keeps that check
+trivially satisfied rather than something the builder must exempt itself from.
+
+A referenced file that is absent or empty is missing review evidence, exactly as
+an absent inline `content` is: `scripts/validate.py` fails closed on it and the
+review yields `blocked`. Never read an unreadable reference as a candidate whose
+diff is merely smaller.
 
 ## Finding semantics
 

--- a/skills/implement-ticket/references/review-suite/CONTRACT.md
+++ b/skills/implement-ticket/references/review-suite/CONTRACT.md
@@ -89,10 +89,16 @@ malformed. Both assert `complete: true` and mean the same thing to a lens — th
 reviewed candidate is the whole diff, never a summary of it.
 
 A packet builder that writes the diff to a file writes it **outside the
-candidate worktree**. Evidence written inside the worktree registers as a
-candidate mutation and fails the before/after integrity check that proves the
-review was read-only, so keeping the evidence elsewhere is what keeps that check
-trivially satisfied rather than something the builder must exempt itself from.
+candidate worktree**, and records an **absolute** path. Evidence written inside
+the worktree registers as a candidate mutation and fails the before/after
+integrity check that proves the review was read-only, so keeping the evidence
+elsewhere is what keeps that check trivially satisfied rather than something the
+builder must exempt itself from. A relative path is rejected because the builder
+and every lens revalidate the same packet from their own working directories: a
+relative reference either reports evidence absent that exists, or resolves to a
+different file of the same name and binds a lens to a diff that is not the
+candidate's — a substitution no candidate-identity check can catch, because
+those compare SHAs and never the diff's provenance.
 
 A referenced file that is absent or empty is missing review evidence, exactly as
 an absent inline `content` is: `scripts/validate.py` fails closed on it and the

--- a/skills/implement-ticket/references/review-suite/review-packet.schema.json
+++ b/skills/implement-ticket/references/review-suite/review-packet.schema.json
@@ -36,14 +36,28 @@
           "pattern": "^[0-9a-f]{40}$"
         },
         "diff": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["format", "complete", "content"],
-          "properties": {
-            "format": {"enum": ["unified_diff"]},
-            "complete": {"const": true},
-            "content": {"type": "string", "minLength": 1}
-          }
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["format", "complete", "content"],
+              "properties": {
+                "format": {"enum": ["unified_diff"]},
+                "complete": {"const": true},
+                "content": {"type": "string", "minLength": 1}
+              }
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["format", "complete", "path"],
+              "properties": {
+                "format": {"enum": ["unified_diff"]},
+                "complete": {"const": true},
+                "path": {"type": "string", "minLength": 1}
+              }
+            }
+          ]
         }
       }
     },

--- a/skills/implement-ticket/references/review-suite/validate.py
+++ b/skills/implement-ticket/references/review-suite/validate.py
@@ -67,6 +67,10 @@ BLOCKABLE_PACKET_ERROR_PATTERNS = (
         r"(missing|empty)$"
     ),
     re.compile(
+        r"^\$\.candidate\.diff\.path: referenced diff evidence file must be an "
+        r"absolute path$"
+    ),
+    re.compile(
         r"^\$\.change_contract: missing required property "
         r"'(goal|acceptance_criteria|non_goals|preserved_behaviors)'$"
     ),
@@ -207,12 +211,26 @@ def _check_diff_evidence_path(packet: dict[str, Any]) -> list[str]:
     inline `content` reports — and not a candidate with a smaller diff. The
     emptiness bar mirrors the inline form's `minLength: 1` exactly so neither
     form is stricter than the other.
+
+    The reference must be absolute. A relative path resolves against whatever
+    working directory happens to be current, and the builder and each lens
+    revalidate the same packet from different directories, so a relative
+    reference either reports absent evidence that exists or — worse — resolves
+    to a different file of the same name and binds a lens to a diff that is not
+    the candidate's. Candidate-identity checks compare SHAs and cannot detect
+    that substitution. This mirrors why `_schema_file` above resolves its own
+    schemas `__file__`-relative rather than from the current directory.
     """
     diff = packet.get("candidate", {}).get("diff")
     location = diff.get("path") if isinstance(diff, dict) else None
     if not location:
         return []
     evidence = Path(location)
+    if not evidence.is_absolute():
+        return [
+            "$.candidate.diff.path: referenced diff evidence file must be an "
+            "absolute path"
+        ]
     if not evidence.is_file():
         return ["$.candidate.diff.path: referenced diff evidence file is missing"]
     if evidence.stat().st_size == 0:

--- a/skills/implement-ticket/references/review-suite/validate.py
+++ b/skills/implement-ticket/references/review-suite/validate.py
@@ -58,10 +58,14 @@ BLOCKABLE_PACKET_ERROR_PATTERNS = (
     ),
     re.compile(
         r"^\$\.candidate\.diff: missing required property "
-        r"'(format|complete|content)'$"
+        r"'(format|complete|content|path)'$"
     ),
     re.compile(r"^\$\.candidate\.diff\.complete: expected constant True$"),
-    re.compile(r"^\$\.candidate\.diff\.content: string is too short$"),
+    re.compile(r"^\$\.candidate\.diff\.(content|path): string is too short$"),
+    re.compile(
+        r"^\$\.candidate\.diff\.path: referenced diff evidence file is "
+        r"(missing|empty)$"
+    ),
     re.compile(
         r"^\$\.change_contract: missing required property "
         r"'(goal|acceptance_criteria|non_goals|preserved_behaviors)'$"
@@ -105,6 +109,18 @@ def validate_schema(value: Any, schema: dict[str, Any], at: str = "$") -> list[s
     expected_type = schema.get("type")
     if expected_type and not _is_type(value, expected_type):
         return [f"{at}: expected {expected_type}"]
+
+    if branches := schema.get("oneOf"):
+        # Every `oneOf` in this repository's schemas has branches made mutually
+        # exclusive by `additionalProperties: false`, so no value can satisfy
+        # two of them and a match by any branch is the match. On failure,
+        # report the closest branch's own errors instead of a generic
+        # "no form matched": the caller needs the actionable message for the
+        # form it was evidently aiming at, and BLOCKABLE_PACKET_ERROR_PATTERNS
+        # is written against those exact messages.
+        attempts = [validate_schema(value, branch, at) for branch in branches]
+        if all(attempts):
+            errors.extend(min(attempts, key=len))
 
     if "const" in schema:
         const = schema["const"]
@@ -150,6 +166,8 @@ def validate_packet(packet: dict[str, Any]) -> list[str]:
     if errors:
         return errors
 
+    errors.extend(_check_diff_evidence_path(packet))
+
     for index, validation in enumerate(packet.get("validation", [])):
         status = validation.get("status")
         if status in {"passed", "failed"} and not validation.get("result"):
@@ -178,6 +196,28 @@ def validate_packet(packet: dict[str, Any]) -> list[str]:
                 + ", ".join(active)
             )
     return errors
+
+
+def _check_diff_evidence_path(packet: dict[str, Any]) -> list[str]:
+    """Fail closed when a path-form candidate diff references no readable file.
+
+    The path form exists so lens dispatch carries a reference instead of the
+    complete diff, which means the file is the evidence. An absent or empty
+    file is therefore missing review evidence — the same condition an absent
+    inline `content` reports — and not a candidate with a smaller diff. The
+    emptiness bar mirrors the inline form's `minLength: 1` exactly so neither
+    form is stricter than the other.
+    """
+    diff = packet.get("candidate", {}).get("diff")
+    location = diff.get("path") if isinstance(diff, dict) else None
+    if not location:
+        return []
+    evidence = Path(location)
+    if not evidence.is_file():
+        return ["$.candidate.diff.path: referenced diff evidence file is missing"]
+    if evidence.stat().st_size == 0:
+        return ["$.candidate.diff.path: referenced diff evidence file is empty"]
+    return []
 
 
 def validate_result(result: dict[str, Any]) -> list[str]:

--- a/skills/implement-ticket/scripts/tests/test_implement_ticket_contract.py
+++ b/skills/implement-ticket/scripts/tests/test_implement_ticket_contract.py
@@ -269,6 +269,20 @@ class ImplementTicketContractTests(unittest.TestCase):
         self.assertIn("category-mismatched", self.skill_compact)
         self.assertIn("return `blocked`", self.skill_compact)
 
+    def test_review_dispatch_hands_the_diff_by_path_outside_the_worktree(self):
+        gates = compact(self.gates)
+        self.assertIn(
+            "the location of a file holding the complete `base...HEAD` diff", gates
+        )
+        self.assertIn("outside the ticket worktree", gates)
+        self.assertIn("hand over its path, not the diff text", gates)
+
+    def test_delegated_dispatch_recommends_paths_over_pasted_history(self):
+        self.assertIn("prefer handing it file paths", self.skill_compact)
+        self.assertIn("pasting accumulated history", self.skill_compact)
+        self.assertIn("recommendation, not a gate", self.skill_compact)
+        self.assertIn("never returns `blocked` for its absence", self.skill_compact)
+
     def test_closing_syntax_and_post_merge_transition_are_acceptance_gated(self):
         self.assertIn("non-closing reference", self.skill_compact)
         self.assertIn("`Fixes #<issue>`", self.github)

--- a/skills/review-code-change/SKILL.md
+++ b/skills/review-code-change/SKILL.md
@@ -34,12 +34,11 @@ validation artifacts. Capture:
 - focused and full validation commands with exact results; and
 - worktree state required to prove read-only integrity.
 
-Write the complete diff to a file in a temporary directory **outside the
-candidate worktree**, and record that location as the packet's
-`candidate.diff.path`. Never write review evidence inside the worktree: doing so
-registers as a candidate mutation and fails the before/after integrity check
-below. Return `blocked` when the file cannot be written or read back, exactly as
-for any other missing required evidence.
+Write the complete diff to a file outside the candidate worktree and record its
+absolute location as the packet's `candidate.diff.path`, following the shared
+contract's "The candidate diff: inline or referenced by path" section, which
+owns that rule and its rationale. Return `blocked` when the file cannot be
+written or read back, exactly as for any other missing required evidence.
 
 Exclude implementation transcripts, intended answers, prior conclusions,
 suspected findings, and fixture expected outputs. Validate the packet before
@@ -55,11 +54,9 @@ packet:
 2. `review-correctness`
 3. `review-code-simplicity`
 
-Each invocation carries the packet, whose `candidate.diff.path` points the lens
-at the diff file it reads for itself. Do not paste the complete diff into a lens
-invocation. The same evidence inlined three times is three copies of the
-review's largest artifact competing with the reasoning each lens must do over
-it, and the copies drift from the file the moment either is edited.
+Each invocation carries the packet; every lens reads the diff from
+`candidate.diff.path` for itself. Do not paste the complete diff into a lens
+invocation.
 
 Validate each result before continuing. Stop on a `blocked` result. Stop after a
 solution-simplicity result that requires replacing the implementation strategy;

--- a/skills/review-code-change/SKILL.md
+++ b/skills/review-code-change/SKILL.md
@@ -34,6 +34,13 @@ validation artifacts. Capture:
 - focused and full validation commands with exact results; and
 - worktree state required to prove read-only integrity.
 
+Write the complete diff to a file in a temporary directory **outside the
+candidate worktree**, and record that location as the packet's
+`candidate.diff.path`. Never write review evidence inside the worktree: doing so
+registers as a candidate mutation and fails the before/after integrity check
+below. Return `blocked` when the file cannot be written or read back, exactly as
+for any other missing required evidence.
+
 Exclude implementation transcripts, intended answers, prior conclusions,
 suspected findings, and fixture expected outputs. Validate the packet before
 invoking any lens. Return `blocked` when required evidence cannot be recovered
@@ -47,6 +54,12 @@ packet:
 1. `review-solution-simplicity`
 2. `review-correctness`
 3. `review-code-simplicity`
+
+Each invocation carries the packet, whose `candidate.diff.path` points the lens
+at the diff file it reads for itself. Do not paste the complete diff into a lens
+invocation. The same evidence inlined three times is three copies of the
+review's largest artifact competing with the reasoning each lens must do over
+it, and the copies drift from the file the moment either is edited.
 
 Validate each result before continuing. Stop on a `blocked` result. Stop after a
 solution-simplicity result that requires replacing the implementation strategy;

--- a/skills/review-code-change/evals/cases.json
+++ b/skills/review-code-change/evals/cases.json
@@ -1,114 +1,672 @@
 [
   {
     "id": "ordered-clean",
-    "candidate": {"head_sha": "1010101010101010101010101010101010101010", "comparison_base_sha": "a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0"},
-    "available_dependencies": ["review-solution-simplicity", "review-correctness", "review-code-simplicity"],
-    "evidence": {"complete": true}, "cycle": 1, "phase": "full",
+    "candidate": {
+      "head_sha": "1010101010101010101010101010101010101010",
+      "comparison_base_sha": "a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0"
+    },
+    "available_dependencies": [
+      "review-solution-simplicity",
+      "review-correctness",
+      "review-code-simplicity"
+    ],
+    "evidence": {
+      "complete": true
+    },
+    "cycle": 1,
+    "phase": "full",
     "harness_outcomes": {
-      "solution_simplicity": {"schema_version": "1.4", "lens": "solution_simplicity", "candidate": {"head_sha": "1010101010101010101010101010101010101010", "comparison_base_sha": "a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0"}, "verdict": "clean", "findings": [], "blocking_reasons": []},
-      "correctness": {"schema_version": "1.4", "lens": "correctness", "candidate": {"head_sha": "1010101010101010101010101010101010101010", "comparison_base_sha": "a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0"}, "verdict": "clean", "findings": [], "blocking_reasons": []},
-      "code_simplicity": {"schema_version": "1.4", "lens": "code_simplicity", "candidate": {"head_sha": "1010101010101010101010101010101010101010", "comparison_base_sha": "a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0"}, "verdict": "clean", "findings": [], "blocking_reasons": []}
+      "solution_simplicity": {
+        "schema_version": "1.4",
+        "lens": "solution_simplicity",
+        "candidate": {
+          "head_sha": "1010101010101010101010101010101010101010",
+          "comparison_base_sha": "a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0"
+        },
+        "verdict": "clean",
+        "findings": [],
+        "blocking_reasons": []
+      },
+      "correctness": {
+        "schema_version": "1.4",
+        "lens": "correctness",
+        "candidate": {
+          "head_sha": "1010101010101010101010101010101010101010",
+          "comparison_base_sha": "a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0"
+        },
+        "verdict": "clean",
+        "findings": [],
+        "blocking_reasons": []
+      },
+      "code_simplicity": {
+        "schema_version": "1.4",
+        "lens": "code_simplicity",
+        "candidate": {
+          "head_sha": "1010101010101010101010101010101010101010",
+          "comparison_base_sha": "a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0"
+        },
+        "verdict": "clean",
+        "findings": [],
+        "blocking_reasons": []
+      }
     }
   },
   {
     "id": "early-solution-redesign",
-    "candidate": {"head_sha": "2020202020202020202020202020202020202020", "comparison_base_sha": "b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0"},
-    "available_dependencies": ["review-solution-simplicity", "review-correctness", "review-code-simplicity"],
-    "evidence": {"complete": true}, "cycle": 1, "phase": "full",
+    "candidate": {
+      "head_sha": "2020202020202020202020202020202020202020",
+      "comparison_base_sha": "b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0"
+    },
+    "available_dependencies": [
+      "review-solution-simplicity",
+      "review-correctness",
+      "review-code-simplicity"
+    ],
+    "evidence": {
+      "complete": true
+    },
+    "cycle": 1,
+    "phase": "full",
     "harness_outcomes": {
-      "solution_simplicity": {"schema_version": "1.4", "lens": "solution_simplicity", "candidate": {"head_sha": "2020202020202020202020202020202020202020", "comparison_base_sha": "b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0"}, "verdict": "changes_required", "findings": [{"id": "solution-simplicity.remove-provider-platform", "lens": "solution_simplicity", "severity": "blocking", "confidence": "high", "rule": "Remote providers are out of scope.", "evidence": [{"location": "candidate diff", "detail": "A registry, provider API, configuration, and dispatch exist for one local write."}], "concern": "The candidate implements an out-of-scope provider platform.", "impact": "It adds configuration, dispatch, and provider failure modes.", "proposed_change": "Replace the provider platform with one direct local write.", "expected_effect": "Remove the platform, configuration, and provider failure modes."}], "blocking_reasons": [], "next_action": "Redesign the implementation and restart the full review on a new head."},
-      "correctness": {"schema_version": "1.4", "lens": "correctness", "candidate": {"head_sha": "2020202020202020202020202020202020202020", "comparison_base_sha": "b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0"}, "verdict": "clean", "findings": [], "blocking_reasons": []},
-      "code_simplicity": {"schema_version": "1.4", "lens": "code_simplicity", "candidate": {"head_sha": "2020202020202020202020202020202020202020", "comparison_base_sha": "b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0"}, "verdict": "clean", "findings": [], "blocking_reasons": []}
+      "solution_simplicity": {
+        "schema_version": "1.4",
+        "lens": "solution_simplicity",
+        "candidate": {
+          "head_sha": "2020202020202020202020202020202020202020",
+          "comparison_base_sha": "b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0"
+        },
+        "verdict": "changes_required",
+        "findings": [
+          {
+            "id": "solution-simplicity.remove-provider-platform",
+            "lens": "solution_simplicity",
+            "severity": "blocking",
+            "confidence": "high",
+            "rule": "Remote providers are out of scope.",
+            "evidence": [
+              {
+                "location": "candidate diff",
+                "detail": "A registry, provider API, configuration, and dispatch exist for one local write."
+              }
+            ],
+            "concern": "The candidate implements an out-of-scope provider platform.",
+            "impact": "It adds configuration, dispatch, and provider failure modes.",
+            "proposed_change": "Replace the provider platform with one direct local write.",
+            "expected_effect": "Remove the platform, configuration, and provider failure modes."
+          }
+        ],
+        "blocking_reasons": [],
+        "next_action": "Redesign the implementation and restart the full review on a new head."
+      },
+      "correctness": {
+        "schema_version": "1.4",
+        "lens": "correctness",
+        "candidate": {
+          "head_sha": "2020202020202020202020202020202020202020",
+          "comparison_base_sha": "b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0"
+        },
+        "verdict": "clean",
+        "findings": [],
+        "blocking_reasons": []
+      },
+      "code_simplicity": {
+        "schema_version": "1.4",
+        "lens": "code_simplicity",
+        "candidate": {
+          "head_sha": "2020202020202020202020202020202020202020",
+          "comparison_base_sha": "b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0"
+        },
+        "verdict": "clean",
+        "findings": [],
+        "blocking_reasons": []
+      }
     }
   },
   {
     "id": "correctness-overrides-simplification",
-    "candidate": {"head_sha": "3030303030303030303030303030303030303030", "comparison_base_sha": "c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0"},
-    "available_dependencies": ["review-solution-simplicity", "review-correctness", "review-code-simplicity"],
-    "evidence": {"complete": true}, "cycle": 1, "phase": "full",
+    "candidate": {
+      "head_sha": "3030303030303030303030303030303030303030",
+      "comparison_base_sha": "c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0"
+    },
+    "available_dependencies": [
+      "review-solution-simplicity",
+      "review-correctness",
+      "review-code-simplicity"
+    ],
+    "evidence": {
+      "complete": true
+    },
+    "cycle": 1,
+    "phase": "full",
     "harness_outcomes": {
-      "solution_simplicity": {"schema_version": "1.4", "lens": "solution_simplicity", "candidate": {"head_sha": "3030303030303030303030303030303030303030", "comparison_base_sha": "c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0"}, "verdict": "changes_required", "findings": [{"id": "solution-simplicity.remove-conditional-write", "lens": "solution_simplicity", "severity": "strong_recommendation", "confidence": "medium", "rule": "Prefer a direct status update when extra predicates are unnecessary.", "evidence": [{"location": "candidate update", "detail": "The conditional update has more predicates than a direct update."}], "concern": "The predicates may be unnecessary local machinery.", "impact": "They add conditions and a failure path.", "proposed_change": "Remove claim-token and running-state predicates.", "expected_effect": "Fewer predicates and one less failure path."}], "blocking_reasons": [], "next_action": "Continue to correctness before accepting this in-strategy simplification."},
-      "correctness": {"schema_version": "1.4", "lens": "correctness", "candidate": {"head_sha": "3030303030303030303030303030303030303030", "comparison_base_sha": "c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0"}, "verdict": "clean", "findings": [], "blocking_reasons": [], "proposal_dispositions": [{"finding_id": "solution-simplicity.remove-conditional-write", "source_lens": "solution_simplicity", "disposition": "unsafe", "reason": "The proposed removal would discard the required atomic claim fence; the current candidate already preserves it.", "evidence": [{"location": "candidate conditional update", "detail": "The claim-token and running-state predicates prevent an expired worker from completing another worker's claim."}]}], "next_action": "Reject the unsafe simplification and continue reviewing the unchanged candidate."},
-      "code_simplicity": {"schema_version": "1.4", "lens": "code_simplicity", "candidate": {"head_sha": "3030303030303030303030303030303030303030", "comparison_base_sha": "c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0"}, "verdict": "clean", "findings": [], "blocking_reasons": []}
+      "solution_simplicity": {
+        "schema_version": "1.4",
+        "lens": "solution_simplicity",
+        "candidate": {
+          "head_sha": "3030303030303030303030303030303030303030",
+          "comparison_base_sha": "c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0"
+        },
+        "verdict": "changes_required",
+        "findings": [
+          {
+            "id": "solution-simplicity.remove-conditional-write",
+            "lens": "solution_simplicity",
+            "severity": "strong_recommendation",
+            "confidence": "medium",
+            "rule": "Prefer a direct status update when extra predicates are unnecessary.",
+            "evidence": [
+              {
+                "location": "candidate update",
+                "detail": "The conditional update has more predicates than a direct update."
+              }
+            ],
+            "concern": "The predicates may be unnecessary local machinery.",
+            "impact": "They add conditions and a failure path.",
+            "proposed_change": "Remove claim-token and running-state predicates.",
+            "expected_effect": "Fewer predicates and one less failure path."
+          }
+        ],
+        "blocking_reasons": [],
+        "next_action": "Continue to correctness before accepting this in-strategy simplification."
+      },
+      "correctness": {
+        "schema_version": "1.4",
+        "lens": "correctness",
+        "candidate": {
+          "head_sha": "3030303030303030303030303030303030303030",
+          "comparison_base_sha": "c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0"
+        },
+        "verdict": "clean",
+        "findings": [],
+        "blocking_reasons": [],
+        "proposal_dispositions": [
+          {
+            "finding_id": "solution-simplicity.remove-conditional-write",
+            "source_lens": "solution_simplicity",
+            "disposition": "unsafe",
+            "reason": "The proposed removal would discard the required atomic claim fence; the current candidate already preserves it.",
+            "evidence": [
+              {
+                "location": "candidate conditional update",
+                "detail": "The claim-token and running-state predicates prevent an expired worker from completing another worker's claim."
+              }
+            ]
+          }
+        ],
+        "next_action": "Reject the unsafe simplification and continue reviewing the unchanged candidate."
+      },
+      "code_simplicity": {
+        "schema_version": "1.4",
+        "lens": "code_simplicity",
+        "candidate": {
+          "head_sha": "3030303030303030303030303030303030303030",
+          "comparison_base_sha": "c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0"
+        },
+        "verdict": "clean",
+        "findings": [],
+        "blocking_reasons": []
+      }
     }
   },
   {
     "id": "deduplicate-overlap",
-    "candidate": {"head_sha": "4040404040404040404040404040404040404040", "comparison_base_sha": "d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0"},
-    "available_dependencies": ["review-solution-simplicity", "review-correctness", "review-code-simplicity"],
-    "evidence": {"complete": true}, "cycle": 1, "phase": "full",
+    "candidate": {
+      "head_sha": "4040404040404040404040404040404040404040",
+      "comparison_base_sha": "d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0"
+    },
+    "available_dependencies": [
+      "review-solution-simplicity",
+      "review-correctness",
+      "review-code-simplicity"
+    ],
+    "evidence": {
+      "complete": true
+    },
+    "cycle": 1,
+    "phase": "full",
     "harness_outcomes": {
-      "solution_simplicity": {"schema_version": "1.4", "lens": "solution_simplicity", "candidate": {"head_sha": "4040404040404040404040404040404040404040", "comparison_base_sha": "d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0"}, "verdict": "changes_required", "findings": [{"id": "solution-simplicity.remove-local-policy-service", "lens": "solution_simplicity", "severity": "strong_recommendation", "confidence": "high", "rule": "Use the existing authorization boundary.", "evidence": [{"location": "policy service", "detail": "A new service duplicates the active-admin rule."}], "concern": "The service duplicates repository policy.", "impact": "It adds a service and another policy owner.", "proposed_change": "Call require_active_admin directly.", "expected_effect": "Remove one service and one duplicate policy."}], "blocking_reasons": [], "next_action": "Continue through correctness because this is a bounded in-strategy removal."},
-      "correctness": {"schema_version": "1.4", "lens": "correctness", "candidate": {"head_sha": "4040404040404040404040404040404040404040", "comparison_base_sha": "d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0"}, "verdict": "clean", "findings": [], "blocking_reasons": [], "proposal_dispositions": [{"finding_id": "solution-simplicity.remove-local-policy-service", "source_lens": "solution_simplicity", "disposition": "compatible", "reason": "Reusing the existing active-admin helper preserves the repository's authorization boundary.", "evidence": [{"location": "repository policy helper", "detail": "require_active_admin implements the same required authorization check."}]}]},
-      "code_simplicity": {"schema_version": "1.4", "lens": "code_simplicity", "candidate": {"head_sha": "4040404040404040404040404040404040404040", "comparison_base_sha": "d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0"}, "verdict": "changes_required", "findings": [{"id": "code-simplicity.reuse-active-admin", "lens": "code_simplicity", "severity": "strong_recommendation", "confidence": "high", "rule": "Reuse repository policy helpers.", "evidence": [{"location": "new actions", "detail": "Two actions repeat the active-admin condition."}], "concern": "The actions duplicate the same repository policy.", "impact": "Three policy definitions can drift.", "proposed_change": "Call require_active_admin directly.", "expected_effect": "Reduce three policy definitions to one."}], "blocking_reasons": []}
+      "solution_simplicity": {
+        "schema_version": "1.4",
+        "lens": "solution_simplicity",
+        "candidate": {
+          "head_sha": "4040404040404040404040404040404040404040",
+          "comparison_base_sha": "d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0"
+        },
+        "verdict": "changes_required",
+        "findings": [
+          {
+            "id": "solution-simplicity.remove-local-policy-service",
+            "lens": "solution_simplicity",
+            "severity": "strong_recommendation",
+            "confidence": "high",
+            "rule": "Use the existing authorization boundary.",
+            "evidence": [
+              {
+                "location": "policy service",
+                "detail": "A new service duplicates the active-admin rule."
+              }
+            ],
+            "concern": "The service duplicates repository policy.",
+            "impact": "It adds a service and another policy owner.",
+            "proposed_change": "Call require_active_admin directly.",
+            "expected_effect": "Remove one service and one duplicate policy."
+          }
+        ],
+        "blocking_reasons": [],
+        "next_action": "Continue through correctness because this is a bounded in-strategy removal."
+      },
+      "correctness": {
+        "schema_version": "1.4",
+        "lens": "correctness",
+        "candidate": {
+          "head_sha": "4040404040404040404040404040404040404040",
+          "comparison_base_sha": "d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0"
+        },
+        "verdict": "clean",
+        "findings": [],
+        "blocking_reasons": [],
+        "proposal_dispositions": [
+          {
+            "finding_id": "solution-simplicity.remove-local-policy-service",
+            "source_lens": "solution_simplicity",
+            "disposition": "compatible",
+            "reason": "Reusing the existing active-admin helper preserves the repository's authorization boundary.",
+            "evidence": [
+              {
+                "location": "repository policy helper",
+                "detail": "require_active_admin implements the same required authorization check."
+              }
+            ]
+          }
+        ]
+      },
+      "code_simplicity": {
+        "schema_version": "1.4",
+        "lens": "code_simplicity",
+        "candidate": {
+          "head_sha": "4040404040404040404040404040404040404040",
+          "comparison_base_sha": "d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0"
+        },
+        "verdict": "changes_required",
+        "findings": [
+          {
+            "id": "code-simplicity.reuse-active-admin",
+            "lens": "code_simplicity",
+            "severity": "strong_recommendation",
+            "confidence": "high",
+            "rule": "Reuse repository policy helpers.",
+            "evidence": [
+              {
+                "location": "new actions",
+                "detail": "Two actions repeat the active-admin condition."
+              }
+            ],
+            "concern": "The actions duplicate the same repository policy.",
+            "impact": "Three policy definitions can drift.",
+            "proposed_change": "Call require_active_admin directly.",
+            "expected_effect": "Reduce three policy definitions to one."
+          }
+        ],
+        "blocking_reasons": []
+      }
     }
   },
   {
     "id": "full-restart-after-code-simplicity-fix",
-    "candidate": {"head_sha": "5050505050505050505050505050505050505050", "comparison_base_sha": "e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0"},
-    "available_dependencies": ["review-solution-simplicity", "review-correctness", "review-code-simplicity"],
-    "evidence": {"complete": true, "new_packet_after_code_simplification": true}, "cycle": 2, "phase": "post_code_simplification_full_restart",
+    "candidate": {
+      "head_sha": "5050505050505050505050505050505050505050",
+      "comparison_base_sha": "e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0"
+    },
+    "available_dependencies": [
+      "review-solution-simplicity",
+      "review-correctness",
+      "review-code-simplicity"
+    ],
+    "evidence": {
+      "complete": true,
+      "new_packet_after_code_simplification": true
+    },
+    "cycle": 2,
+    "phase": "post_code_simplification_full_restart",
     "harness_outcomes": {
-      "solution_simplicity": {"schema_version": "1.4", "lens": "solution_simplicity", "candidate": {"head_sha": "5050505050505050505050505050505050505050", "comparison_base_sha": "e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0"}, "verdict": "clean", "findings": [], "blocking_reasons": []},
-      "correctness": {"schema_version": "1.4", "lens": "correctness", "candidate": {"head_sha": "5050505050505050505050505050505050505050", "comparison_base_sha": "e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0"}, "verdict": "clean", "findings": [], "blocking_reasons": []},
-      "code_simplicity": {"schema_version": "1.4", "lens": "code_simplicity", "candidate": {"head_sha": "5050505050505050505050505050505050505050", "comparison_base_sha": "e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0"}, "verdict": "clean", "findings": [], "blocking_reasons": []}
+      "solution_simplicity": {
+        "schema_version": "1.4",
+        "lens": "solution_simplicity",
+        "candidate": {
+          "head_sha": "5050505050505050505050505050505050505050",
+          "comparison_base_sha": "e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0"
+        },
+        "verdict": "clean",
+        "findings": [],
+        "blocking_reasons": []
+      },
+      "correctness": {
+        "schema_version": "1.4",
+        "lens": "correctness",
+        "candidate": {
+          "head_sha": "5050505050505050505050505050505050505050",
+          "comparison_base_sha": "e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0"
+        },
+        "verdict": "clean",
+        "findings": [],
+        "blocking_reasons": []
+      },
+      "code_simplicity": {
+        "schema_version": "1.4",
+        "lens": "code_simplicity",
+        "candidate": {
+          "head_sha": "5050505050505050505050505050505050505050",
+          "comparison_base_sha": "e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0"
+        },
+        "verdict": "clean",
+        "findings": [],
+        "blocking_reasons": []
+      }
     }
   },
   {
     "id": "full-restart-after-correctness-fix",
-    "candidate": {"head_sha": "5151515151515151515151515151515151515151", "comparison_base_sha": "e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1"},
-    "available_dependencies": ["review-solution-simplicity", "review-correctness", "review-code-simplicity"],
-    "evidence": {"complete": true, "new_packet_after_correctness_fix": true}, "cycle": 2, "phase": "post_correctness_fix_full_restart",
+    "candidate": {
+      "head_sha": "5151515151515151515151515151515151515151",
+      "comparison_base_sha": "e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1"
+    },
+    "available_dependencies": [
+      "review-solution-simplicity",
+      "review-correctness",
+      "review-code-simplicity"
+    ],
+    "evidence": {
+      "complete": true,
+      "new_packet_after_correctness_fix": true
+    },
+    "cycle": 2,
+    "phase": "post_correctness_fix_full_restart",
     "harness_outcomes": {
-      "solution_simplicity": {"schema_version": "1.4", "lens": "solution_simplicity", "candidate": {"head_sha": "5151515151515151515151515151515151515151", "comparison_base_sha": "e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1"}, "verdict": "clean", "findings": [], "blocking_reasons": []},
-      "correctness": {"schema_version": "1.4", "lens": "correctness", "candidate": {"head_sha": "5151515151515151515151515151515151515151", "comparison_base_sha": "e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1"}, "verdict": "clean", "findings": [], "blocking_reasons": []},
-      "code_simplicity": {"schema_version": "1.4", "lens": "code_simplicity", "candidate": {"head_sha": "5151515151515151515151515151515151515151", "comparison_base_sha": "e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1"}, "verdict": "clean", "findings": [], "blocking_reasons": []}
+      "solution_simplicity": {
+        "schema_version": "1.4",
+        "lens": "solution_simplicity",
+        "candidate": {
+          "head_sha": "5151515151515151515151515151515151515151",
+          "comparison_base_sha": "e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1"
+        },
+        "verdict": "clean",
+        "findings": [],
+        "blocking_reasons": []
+      },
+      "correctness": {
+        "schema_version": "1.4",
+        "lens": "correctness",
+        "candidate": {
+          "head_sha": "5151515151515151515151515151515151515151",
+          "comparison_base_sha": "e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1"
+        },
+        "verdict": "clean",
+        "findings": [],
+        "blocking_reasons": []
+      },
+      "code_simplicity": {
+        "schema_version": "1.4",
+        "lens": "code_simplicity",
+        "candidate": {
+          "head_sha": "5151515151515151515151515151515151515151",
+          "comparison_base_sha": "e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1"
+        },
+        "verdict": "clean",
+        "findings": [],
+        "blocking_reasons": []
+      }
     }
   },
   {
     "id": "missing-dependency",
-    "candidate": {"head_sha": "6060606060606060606060606060606060606060", "comparison_base_sha": "f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0"},
-    "available_dependencies": ["review-solution-simplicity", "review-correctness"],
-    "evidence": {"complete": true}, "cycle": 1, "phase": "full", "harness_outcomes": {}
+    "candidate": {
+      "head_sha": "6060606060606060606060606060606060606060",
+      "comparison_base_sha": "f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0"
+    },
+    "available_dependencies": [
+      "review-solution-simplicity",
+      "review-correctness"
+    ],
+    "evidence": {
+      "complete": true
+    },
+    "cycle": 1,
+    "phase": "full",
+    "harness_outcomes": {}
   },
   {
     "id": "missing-evidence",
-    "candidate": {"head_sha": "7070707070707070707070707070707070707070", "comparison_base_sha": "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1"},
-    "available_dependencies": ["review-solution-simplicity", "review-correctness", "review-code-simplicity"],
-    "evidence": {"complete": false, "blocking_reasons": ["Acceptance criteria are missing.", "Full validation has no result or unavailable reason."]},
-    "cycle": 1, "phase": "full", "harness_outcomes": {}
+    "candidate": {
+      "head_sha": "7070707070707070707070707070707070707070",
+      "comparison_base_sha": "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1"
+    },
+    "available_dependencies": [
+      "review-solution-simplicity",
+      "review-correctness",
+      "review-code-simplicity"
+    ],
+    "evidence": {
+      "complete": false,
+      "blocking_reasons": [
+        "Acceptance criteria are missing.",
+        "Full validation has no result or unavailable reason."
+      ]
+    },
+    "cycle": 1,
+    "phase": "full",
+    "harness_outcomes": {}
   },
   {
     "id": "deferred-only-clean",
-    "candidate": {"head_sha": "8080808080808080808080808080808080808080", "comparison_base_sha": "b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1"},
-    "available_dependencies": ["review-solution-simplicity", "review-correctness", "review-code-simplicity"],
-    "evidence": {"complete": true}, "cycle": 1, "phase": "full",
+    "candidate": {
+      "head_sha": "8080808080808080808080808080808080808080",
+      "comparison_base_sha": "b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1"
+    },
+    "available_dependencies": [
+      "review-solution-simplicity",
+      "review-correctness",
+      "review-code-simplicity"
+    ],
+    "evidence": {
+      "complete": true
+    },
+    "cycle": 1,
+    "phase": "full",
     "harness_outcomes": {
-      "solution_simplicity": {"schema_version": "1.4", "lens": "solution_simplicity", "candidate": {"head_sha": "8080808080808080808080808080808080808080", "comparison_base_sha": "b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1"}, "verdict": "clean", "findings": [{"id": "solution-simplicity.future-cleanup", "lens": "solution_simplicity", "severity": "defer", "confidence": "high", "rule": "A real legacy path remains outside this ticket.", "evidence": [{"location": "ticket", "detail": "Migration cleanup is explicitly deferred to issue #90."}], "concern": "A compatibility path remains outside active scope.", "impact": "The branch remains until callers migrate.", "proposed_change": "Remove the path in issue #90.", "expected_effect": "Retire one compatibility branch after migration."}], "blocking_reasons": []},
-      "correctness": {"schema_version": "1.4", "lens": "correctness", "candidate": {"head_sha": "8080808080808080808080808080808080808080", "comparison_base_sha": "b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1"}, "verdict": "clean", "findings": [], "blocking_reasons": []},
-      "code_simplicity": {"schema_version": "1.4", "lens": "code_simplicity", "candidate": {"head_sha": "8080808080808080808080808080808080808080", "comparison_base_sha": "b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1"}, "verdict": "clean", "findings": [], "blocking_reasons": []}
+      "solution_simplicity": {
+        "schema_version": "1.4",
+        "lens": "solution_simplicity",
+        "candidate": {
+          "head_sha": "8080808080808080808080808080808080808080",
+          "comparison_base_sha": "b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1"
+        },
+        "verdict": "clean",
+        "findings": [
+          {
+            "id": "solution-simplicity.future-cleanup",
+            "lens": "solution_simplicity",
+            "severity": "defer",
+            "confidence": "high",
+            "rule": "A real legacy path remains outside this ticket.",
+            "evidence": [
+              {
+                "location": "ticket",
+                "detail": "Migration cleanup is explicitly deferred to issue #90."
+              }
+            ],
+            "concern": "A compatibility path remains outside active scope.",
+            "impact": "The branch remains until callers migrate.",
+            "proposed_change": "Remove the path in issue #90.",
+            "expected_effect": "Retire one compatibility branch after migration."
+          }
+        ],
+        "blocking_reasons": []
+      },
+      "correctness": {
+        "schema_version": "1.4",
+        "lens": "correctness",
+        "candidate": {
+          "head_sha": "8080808080808080808080808080808080808080",
+          "comparison_base_sha": "b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1"
+        },
+        "verdict": "clean",
+        "findings": [],
+        "blocking_reasons": []
+      },
+      "code_simplicity": {
+        "schema_version": "1.4",
+        "lens": "code_simplicity",
+        "candidate": {
+          "head_sha": "8080808080808080808080808080808080808080",
+          "comparison_base_sha": "b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1"
+        },
+        "verdict": "clean",
+        "findings": [],
+        "blocking_reasons": []
+      }
     }
   },
   {
     "id": "cycle-budget-exhausted",
-    "candidate": {"head_sha": "9090909090909090909090909090909090909090", "comparison_base_sha": "c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1"},
-    "available_dependencies": ["review-solution-simplicity", "review-correctness", "review-code-simplicity"],
-    "evidence": {"complete": true}, "cycle": 3, "phase": "full",
+    "candidate": {
+      "head_sha": "9090909090909090909090909090909090909090",
+      "comparison_base_sha": "c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1"
+    },
+    "available_dependencies": [
+      "review-solution-simplicity",
+      "review-correctness",
+      "review-code-simplicity"
+    ],
+    "evidence": {
+      "complete": true
+    },
+    "cycle": 3,
+    "phase": "full",
     "harness_outcomes": {
-      "solution_simplicity": {"schema_version": "1.4", "lens": "solution_simplicity", "candidate": {"head_sha": "9090909090909090909090909090909090909090", "comparison_base_sha": "c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1"}, "verdict": "clean", "findings": [], "blocking_reasons": []},
-      "correctness": {"schema_version": "1.4", "lens": "correctness", "candidate": {"head_sha": "9090909090909090909090909090909090909090", "comparison_base_sha": "c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1"}, "verdict": "changes_required", "findings": [{"id": "correctness.retry-still-unbounded", "lens": "correctness", "severity": "blocking", "confidence": "high", "rule": "Retries must stop at the configured maximum.", "evidence": [{"location": "candidate diff", "detail": "The third candidate still schedules after the maximum."}], "concern": "Retry scheduling remains unbounded.", "impact": "The required retry limit is violated.", "proposed_change": "Stop scheduling at max_retries.", "expected_effect": "Bound repeated work at the required limit."}], "blocking_reasons": []},
-      "code_simplicity": {"schema_version": "1.4", "lens": "code_simplicity", "candidate": {"head_sha": "9090909090909090909090909090909090909090", "comparison_base_sha": "c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1"}, "verdict": "clean", "findings": [], "blocking_reasons": []}
+      "solution_simplicity": {
+        "schema_version": "1.4",
+        "lens": "solution_simplicity",
+        "candidate": {
+          "head_sha": "9090909090909090909090909090909090909090",
+          "comparison_base_sha": "c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1"
+        },
+        "verdict": "clean",
+        "findings": [],
+        "blocking_reasons": []
+      },
+      "correctness": {
+        "schema_version": "1.4",
+        "lens": "correctness",
+        "candidate": {
+          "head_sha": "9090909090909090909090909090909090909090",
+          "comparison_base_sha": "c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1"
+        },
+        "verdict": "changes_required",
+        "findings": [
+          {
+            "id": "correctness.retry-still-unbounded",
+            "lens": "correctness",
+            "severity": "blocking",
+            "confidence": "high",
+            "rule": "Retries must stop at the configured maximum.",
+            "evidence": [
+              {
+                "location": "candidate diff",
+                "detail": "The third candidate still schedules after the maximum."
+              }
+            ],
+            "concern": "Retry scheduling remains unbounded.",
+            "impact": "The required retry limit is violated.",
+            "proposed_change": "Stop scheduling at max_retries.",
+            "expected_effect": "Bound repeated work at the required limit."
+          }
+        ],
+        "blocking_reasons": []
+      },
+      "code_simplicity": {
+        "schema_version": "1.4",
+        "lens": "code_simplicity",
+        "candidate": {
+          "head_sha": "9090909090909090909090909090909090909090",
+          "comparison_base_sha": "c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1"
+        },
+        "verdict": "clean",
+        "findings": [],
+        "blocking_reasons": []
+      }
     }
   },
   {
     "id": "mismatched-lens-result",
-    "candidate": {"head_sha": "a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2", "comparison_base_sha": "b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"},
-    "available_dependencies": ["review-solution-simplicity", "review-correctness", "review-code-simplicity"],
-    "evidence": {"complete": true}, "cycle": 1, "phase": "full",
+    "candidate": {
+      "head_sha": "a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2",
+      "comparison_base_sha": "b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
+    },
+    "available_dependencies": [
+      "review-solution-simplicity",
+      "review-correctness",
+      "review-code-simplicity"
+    ],
+    "evidence": {
+      "complete": true
+    },
+    "cycle": 1,
+    "phase": "full",
     "harness_outcomes": {
-      "solution_simplicity": {"schema_version": "1.4", "lens": "correctness", "candidate": {"head_sha": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", "comparison_base_sha": "b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"}, "verdict": "clean", "findings": [], "blocking_reasons": []},
-      "correctness": {"schema_version": "1.4", "lens": "correctness", "candidate": {"head_sha": "a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2", "comparison_base_sha": "b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"}, "verdict": "clean", "findings": [], "blocking_reasons": []},
-      "code_simplicity": {"schema_version": "1.4", "lens": "code_simplicity", "candidate": {"head_sha": "a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2", "comparison_base_sha": "b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"}, "verdict": "clean", "findings": [], "blocking_reasons": []}
+      "solution_simplicity": {
+        "schema_version": "1.4",
+        "lens": "correctness",
+        "candidate": {
+          "head_sha": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+          "comparison_base_sha": "b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
+        },
+        "verdict": "clean",
+        "findings": [],
+        "blocking_reasons": []
+      },
+      "correctness": {
+        "schema_version": "1.4",
+        "lens": "correctness",
+        "candidate": {
+          "head_sha": "a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2",
+          "comparison_base_sha": "b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
+        },
+        "verdict": "clean",
+        "findings": [],
+        "blocking_reasons": []
+      },
+      "code_simplicity": {
+        "schema_version": "1.4",
+        "lens": "code_simplicity",
+        "candidate": {
+          "head_sha": "a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2",
+          "comparison_base_sha": "b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
+        },
+        "verdict": "clean",
+        "findings": [],
+        "blocking_reasons": []
+      }
     }
+  },
+  {
+    "id": "missing-diff-evidence-file",
+    "candidate": {
+      "head_sha": "8080808080808080808080808080808080808080",
+      "comparison_base_sha": "b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1"
+    },
+    "available_dependencies": [
+      "review-solution-simplicity",
+      "review-correctness",
+      "review-code-simplicity"
+    ],
+    "evidence": {
+      "complete": false,
+      "blocking_reasons": [
+        "The packet references a candidate diff file that does not exist."
+      ]
+    },
+    "cycle": 1,
+    "phase": "full",
+    "harness_outcomes": {}
   }
 ]

--- a/skills/review-code-change/evals/cases.json
+++ b/skills/review-code-change/evals/cases.json
@@ -1,672 +1,122 @@
 [
   {
     "id": "ordered-clean",
-    "candidate": {
-      "head_sha": "1010101010101010101010101010101010101010",
-      "comparison_base_sha": "a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0"
-    },
-    "available_dependencies": [
-      "review-solution-simplicity",
-      "review-correctness",
-      "review-code-simplicity"
-    ],
-    "evidence": {
-      "complete": true
-    },
-    "cycle": 1,
-    "phase": "full",
+    "candidate": {"head_sha": "1010101010101010101010101010101010101010", "comparison_base_sha": "a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0"},
+    "available_dependencies": ["review-solution-simplicity", "review-correctness", "review-code-simplicity"],
+    "evidence": {"complete": true}, "cycle": 1, "phase": "full",
     "harness_outcomes": {
-      "solution_simplicity": {
-        "schema_version": "1.4",
-        "lens": "solution_simplicity",
-        "candidate": {
-          "head_sha": "1010101010101010101010101010101010101010",
-          "comparison_base_sha": "a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0"
-        },
-        "verdict": "clean",
-        "findings": [],
-        "blocking_reasons": []
-      },
-      "correctness": {
-        "schema_version": "1.4",
-        "lens": "correctness",
-        "candidate": {
-          "head_sha": "1010101010101010101010101010101010101010",
-          "comparison_base_sha": "a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0"
-        },
-        "verdict": "clean",
-        "findings": [],
-        "blocking_reasons": []
-      },
-      "code_simplicity": {
-        "schema_version": "1.4",
-        "lens": "code_simplicity",
-        "candidate": {
-          "head_sha": "1010101010101010101010101010101010101010",
-          "comparison_base_sha": "a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0"
-        },
-        "verdict": "clean",
-        "findings": [],
-        "blocking_reasons": []
-      }
+      "solution_simplicity": {"schema_version": "1.4", "lens": "solution_simplicity", "candidate": {"head_sha": "1010101010101010101010101010101010101010", "comparison_base_sha": "a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0"}, "verdict": "clean", "findings": [], "blocking_reasons": []},
+      "correctness": {"schema_version": "1.4", "lens": "correctness", "candidate": {"head_sha": "1010101010101010101010101010101010101010", "comparison_base_sha": "a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0"}, "verdict": "clean", "findings": [], "blocking_reasons": []},
+      "code_simplicity": {"schema_version": "1.4", "lens": "code_simplicity", "candidate": {"head_sha": "1010101010101010101010101010101010101010", "comparison_base_sha": "a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0"}, "verdict": "clean", "findings": [], "blocking_reasons": []}
     }
   },
   {
     "id": "early-solution-redesign",
-    "candidate": {
-      "head_sha": "2020202020202020202020202020202020202020",
-      "comparison_base_sha": "b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0"
-    },
-    "available_dependencies": [
-      "review-solution-simplicity",
-      "review-correctness",
-      "review-code-simplicity"
-    ],
-    "evidence": {
-      "complete": true
-    },
-    "cycle": 1,
-    "phase": "full",
+    "candidate": {"head_sha": "2020202020202020202020202020202020202020", "comparison_base_sha": "b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0"},
+    "available_dependencies": ["review-solution-simplicity", "review-correctness", "review-code-simplicity"],
+    "evidence": {"complete": true}, "cycle": 1, "phase": "full",
     "harness_outcomes": {
-      "solution_simplicity": {
-        "schema_version": "1.4",
-        "lens": "solution_simplicity",
-        "candidate": {
-          "head_sha": "2020202020202020202020202020202020202020",
-          "comparison_base_sha": "b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0"
-        },
-        "verdict": "changes_required",
-        "findings": [
-          {
-            "id": "solution-simplicity.remove-provider-platform",
-            "lens": "solution_simplicity",
-            "severity": "blocking",
-            "confidence": "high",
-            "rule": "Remote providers are out of scope.",
-            "evidence": [
-              {
-                "location": "candidate diff",
-                "detail": "A registry, provider API, configuration, and dispatch exist for one local write."
-              }
-            ],
-            "concern": "The candidate implements an out-of-scope provider platform.",
-            "impact": "It adds configuration, dispatch, and provider failure modes.",
-            "proposed_change": "Replace the provider platform with one direct local write.",
-            "expected_effect": "Remove the platform, configuration, and provider failure modes."
-          }
-        ],
-        "blocking_reasons": [],
-        "next_action": "Redesign the implementation and restart the full review on a new head."
-      },
-      "correctness": {
-        "schema_version": "1.4",
-        "lens": "correctness",
-        "candidate": {
-          "head_sha": "2020202020202020202020202020202020202020",
-          "comparison_base_sha": "b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0"
-        },
-        "verdict": "clean",
-        "findings": [],
-        "blocking_reasons": []
-      },
-      "code_simplicity": {
-        "schema_version": "1.4",
-        "lens": "code_simplicity",
-        "candidate": {
-          "head_sha": "2020202020202020202020202020202020202020",
-          "comparison_base_sha": "b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0"
-        },
-        "verdict": "clean",
-        "findings": [],
-        "blocking_reasons": []
-      }
+      "solution_simplicity": {"schema_version": "1.4", "lens": "solution_simplicity", "candidate": {"head_sha": "2020202020202020202020202020202020202020", "comparison_base_sha": "b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0"}, "verdict": "changes_required", "findings": [{"id": "solution-simplicity.remove-provider-platform", "lens": "solution_simplicity", "severity": "blocking", "confidence": "high", "rule": "Remote providers are out of scope.", "evidence": [{"location": "candidate diff", "detail": "A registry, provider API, configuration, and dispatch exist for one local write."}], "concern": "The candidate implements an out-of-scope provider platform.", "impact": "It adds configuration, dispatch, and provider failure modes.", "proposed_change": "Replace the provider platform with one direct local write.", "expected_effect": "Remove the platform, configuration, and provider failure modes."}], "blocking_reasons": [], "next_action": "Redesign the implementation and restart the full review on a new head."},
+      "correctness": {"schema_version": "1.4", "lens": "correctness", "candidate": {"head_sha": "2020202020202020202020202020202020202020", "comparison_base_sha": "b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0"}, "verdict": "clean", "findings": [], "blocking_reasons": []},
+      "code_simplicity": {"schema_version": "1.4", "lens": "code_simplicity", "candidate": {"head_sha": "2020202020202020202020202020202020202020", "comparison_base_sha": "b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0"}, "verdict": "clean", "findings": [], "blocking_reasons": []}
     }
   },
   {
     "id": "correctness-overrides-simplification",
-    "candidate": {
-      "head_sha": "3030303030303030303030303030303030303030",
-      "comparison_base_sha": "c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0"
-    },
-    "available_dependencies": [
-      "review-solution-simplicity",
-      "review-correctness",
-      "review-code-simplicity"
-    ],
-    "evidence": {
-      "complete": true
-    },
-    "cycle": 1,
-    "phase": "full",
+    "candidate": {"head_sha": "3030303030303030303030303030303030303030", "comparison_base_sha": "c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0"},
+    "available_dependencies": ["review-solution-simplicity", "review-correctness", "review-code-simplicity"],
+    "evidence": {"complete": true}, "cycle": 1, "phase": "full",
     "harness_outcomes": {
-      "solution_simplicity": {
-        "schema_version": "1.4",
-        "lens": "solution_simplicity",
-        "candidate": {
-          "head_sha": "3030303030303030303030303030303030303030",
-          "comparison_base_sha": "c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0"
-        },
-        "verdict": "changes_required",
-        "findings": [
-          {
-            "id": "solution-simplicity.remove-conditional-write",
-            "lens": "solution_simplicity",
-            "severity": "strong_recommendation",
-            "confidence": "medium",
-            "rule": "Prefer a direct status update when extra predicates are unnecessary.",
-            "evidence": [
-              {
-                "location": "candidate update",
-                "detail": "The conditional update has more predicates than a direct update."
-              }
-            ],
-            "concern": "The predicates may be unnecessary local machinery.",
-            "impact": "They add conditions and a failure path.",
-            "proposed_change": "Remove claim-token and running-state predicates.",
-            "expected_effect": "Fewer predicates and one less failure path."
-          }
-        ],
-        "blocking_reasons": [],
-        "next_action": "Continue to correctness before accepting this in-strategy simplification."
-      },
-      "correctness": {
-        "schema_version": "1.4",
-        "lens": "correctness",
-        "candidate": {
-          "head_sha": "3030303030303030303030303030303030303030",
-          "comparison_base_sha": "c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0"
-        },
-        "verdict": "clean",
-        "findings": [],
-        "blocking_reasons": [],
-        "proposal_dispositions": [
-          {
-            "finding_id": "solution-simplicity.remove-conditional-write",
-            "source_lens": "solution_simplicity",
-            "disposition": "unsafe",
-            "reason": "The proposed removal would discard the required atomic claim fence; the current candidate already preserves it.",
-            "evidence": [
-              {
-                "location": "candidate conditional update",
-                "detail": "The claim-token and running-state predicates prevent an expired worker from completing another worker's claim."
-              }
-            ]
-          }
-        ],
-        "next_action": "Reject the unsafe simplification and continue reviewing the unchanged candidate."
-      },
-      "code_simplicity": {
-        "schema_version": "1.4",
-        "lens": "code_simplicity",
-        "candidate": {
-          "head_sha": "3030303030303030303030303030303030303030",
-          "comparison_base_sha": "c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0"
-        },
-        "verdict": "clean",
-        "findings": [],
-        "blocking_reasons": []
-      }
+      "solution_simplicity": {"schema_version": "1.4", "lens": "solution_simplicity", "candidate": {"head_sha": "3030303030303030303030303030303030303030", "comparison_base_sha": "c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0"}, "verdict": "changes_required", "findings": [{"id": "solution-simplicity.remove-conditional-write", "lens": "solution_simplicity", "severity": "strong_recommendation", "confidence": "medium", "rule": "Prefer a direct status update when extra predicates are unnecessary.", "evidence": [{"location": "candidate update", "detail": "The conditional update has more predicates than a direct update."}], "concern": "The predicates may be unnecessary local machinery.", "impact": "They add conditions and a failure path.", "proposed_change": "Remove claim-token and running-state predicates.", "expected_effect": "Fewer predicates and one less failure path."}], "blocking_reasons": [], "next_action": "Continue to correctness before accepting this in-strategy simplification."},
+      "correctness": {"schema_version": "1.4", "lens": "correctness", "candidate": {"head_sha": "3030303030303030303030303030303030303030", "comparison_base_sha": "c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0"}, "verdict": "clean", "findings": [], "blocking_reasons": [], "proposal_dispositions": [{"finding_id": "solution-simplicity.remove-conditional-write", "source_lens": "solution_simplicity", "disposition": "unsafe", "reason": "The proposed removal would discard the required atomic claim fence; the current candidate already preserves it.", "evidence": [{"location": "candidate conditional update", "detail": "The claim-token and running-state predicates prevent an expired worker from completing another worker's claim."}]}], "next_action": "Reject the unsafe simplification and continue reviewing the unchanged candidate."},
+      "code_simplicity": {"schema_version": "1.4", "lens": "code_simplicity", "candidate": {"head_sha": "3030303030303030303030303030303030303030", "comparison_base_sha": "c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0"}, "verdict": "clean", "findings": [], "blocking_reasons": []}
     }
   },
   {
     "id": "deduplicate-overlap",
-    "candidate": {
-      "head_sha": "4040404040404040404040404040404040404040",
-      "comparison_base_sha": "d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0"
-    },
-    "available_dependencies": [
-      "review-solution-simplicity",
-      "review-correctness",
-      "review-code-simplicity"
-    ],
-    "evidence": {
-      "complete": true
-    },
-    "cycle": 1,
-    "phase": "full",
+    "candidate": {"head_sha": "4040404040404040404040404040404040404040", "comparison_base_sha": "d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0"},
+    "available_dependencies": ["review-solution-simplicity", "review-correctness", "review-code-simplicity"],
+    "evidence": {"complete": true}, "cycle": 1, "phase": "full",
     "harness_outcomes": {
-      "solution_simplicity": {
-        "schema_version": "1.4",
-        "lens": "solution_simplicity",
-        "candidate": {
-          "head_sha": "4040404040404040404040404040404040404040",
-          "comparison_base_sha": "d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0"
-        },
-        "verdict": "changes_required",
-        "findings": [
-          {
-            "id": "solution-simplicity.remove-local-policy-service",
-            "lens": "solution_simplicity",
-            "severity": "strong_recommendation",
-            "confidence": "high",
-            "rule": "Use the existing authorization boundary.",
-            "evidence": [
-              {
-                "location": "policy service",
-                "detail": "A new service duplicates the active-admin rule."
-              }
-            ],
-            "concern": "The service duplicates repository policy.",
-            "impact": "It adds a service and another policy owner.",
-            "proposed_change": "Call require_active_admin directly.",
-            "expected_effect": "Remove one service and one duplicate policy."
-          }
-        ],
-        "blocking_reasons": [],
-        "next_action": "Continue through correctness because this is a bounded in-strategy removal."
-      },
-      "correctness": {
-        "schema_version": "1.4",
-        "lens": "correctness",
-        "candidate": {
-          "head_sha": "4040404040404040404040404040404040404040",
-          "comparison_base_sha": "d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0"
-        },
-        "verdict": "clean",
-        "findings": [],
-        "blocking_reasons": [],
-        "proposal_dispositions": [
-          {
-            "finding_id": "solution-simplicity.remove-local-policy-service",
-            "source_lens": "solution_simplicity",
-            "disposition": "compatible",
-            "reason": "Reusing the existing active-admin helper preserves the repository's authorization boundary.",
-            "evidence": [
-              {
-                "location": "repository policy helper",
-                "detail": "require_active_admin implements the same required authorization check."
-              }
-            ]
-          }
-        ]
-      },
-      "code_simplicity": {
-        "schema_version": "1.4",
-        "lens": "code_simplicity",
-        "candidate": {
-          "head_sha": "4040404040404040404040404040404040404040",
-          "comparison_base_sha": "d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0"
-        },
-        "verdict": "changes_required",
-        "findings": [
-          {
-            "id": "code-simplicity.reuse-active-admin",
-            "lens": "code_simplicity",
-            "severity": "strong_recommendation",
-            "confidence": "high",
-            "rule": "Reuse repository policy helpers.",
-            "evidence": [
-              {
-                "location": "new actions",
-                "detail": "Two actions repeat the active-admin condition."
-              }
-            ],
-            "concern": "The actions duplicate the same repository policy.",
-            "impact": "Three policy definitions can drift.",
-            "proposed_change": "Call require_active_admin directly.",
-            "expected_effect": "Reduce three policy definitions to one."
-          }
-        ],
-        "blocking_reasons": []
-      }
+      "solution_simplicity": {"schema_version": "1.4", "lens": "solution_simplicity", "candidate": {"head_sha": "4040404040404040404040404040404040404040", "comparison_base_sha": "d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0"}, "verdict": "changes_required", "findings": [{"id": "solution-simplicity.remove-local-policy-service", "lens": "solution_simplicity", "severity": "strong_recommendation", "confidence": "high", "rule": "Use the existing authorization boundary.", "evidence": [{"location": "policy service", "detail": "A new service duplicates the active-admin rule."}], "concern": "The service duplicates repository policy.", "impact": "It adds a service and another policy owner.", "proposed_change": "Call require_active_admin directly.", "expected_effect": "Remove one service and one duplicate policy."}], "blocking_reasons": [], "next_action": "Continue through correctness because this is a bounded in-strategy removal."},
+      "correctness": {"schema_version": "1.4", "lens": "correctness", "candidate": {"head_sha": "4040404040404040404040404040404040404040", "comparison_base_sha": "d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0"}, "verdict": "clean", "findings": [], "blocking_reasons": [], "proposal_dispositions": [{"finding_id": "solution-simplicity.remove-local-policy-service", "source_lens": "solution_simplicity", "disposition": "compatible", "reason": "Reusing the existing active-admin helper preserves the repository's authorization boundary.", "evidence": [{"location": "repository policy helper", "detail": "require_active_admin implements the same required authorization check."}]}]},
+      "code_simplicity": {"schema_version": "1.4", "lens": "code_simplicity", "candidate": {"head_sha": "4040404040404040404040404040404040404040", "comparison_base_sha": "d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0"}, "verdict": "changes_required", "findings": [{"id": "code-simplicity.reuse-active-admin", "lens": "code_simplicity", "severity": "strong_recommendation", "confidence": "high", "rule": "Reuse repository policy helpers.", "evidence": [{"location": "new actions", "detail": "Two actions repeat the active-admin condition."}], "concern": "The actions duplicate the same repository policy.", "impact": "Three policy definitions can drift.", "proposed_change": "Call require_active_admin directly.", "expected_effect": "Reduce three policy definitions to one."}], "blocking_reasons": []}
     }
   },
   {
     "id": "full-restart-after-code-simplicity-fix",
-    "candidate": {
-      "head_sha": "5050505050505050505050505050505050505050",
-      "comparison_base_sha": "e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0"
-    },
-    "available_dependencies": [
-      "review-solution-simplicity",
-      "review-correctness",
-      "review-code-simplicity"
-    ],
-    "evidence": {
-      "complete": true,
-      "new_packet_after_code_simplification": true
-    },
-    "cycle": 2,
-    "phase": "post_code_simplification_full_restart",
+    "candidate": {"head_sha": "5050505050505050505050505050505050505050", "comparison_base_sha": "e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0"},
+    "available_dependencies": ["review-solution-simplicity", "review-correctness", "review-code-simplicity"],
+    "evidence": {"complete": true, "new_packet_after_code_simplification": true}, "cycle": 2, "phase": "post_code_simplification_full_restart",
     "harness_outcomes": {
-      "solution_simplicity": {
-        "schema_version": "1.4",
-        "lens": "solution_simplicity",
-        "candidate": {
-          "head_sha": "5050505050505050505050505050505050505050",
-          "comparison_base_sha": "e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0"
-        },
-        "verdict": "clean",
-        "findings": [],
-        "blocking_reasons": []
-      },
-      "correctness": {
-        "schema_version": "1.4",
-        "lens": "correctness",
-        "candidate": {
-          "head_sha": "5050505050505050505050505050505050505050",
-          "comparison_base_sha": "e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0"
-        },
-        "verdict": "clean",
-        "findings": [],
-        "blocking_reasons": []
-      },
-      "code_simplicity": {
-        "schema_version": "1.4",
-        "lens": "code_simplicity",
-        "candidate": {
-          "head_sha": "5050505050505050505050505050505050505050",
-          "comparison_base_sha": "e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0"
-        },
-        "verdict": "clean",
-        "findings": [],
-        "blocking_reasons": []
-      }
+      "solution_simplicity": {"schema_version": "1.4", "lens": "solution_simplicity", "candidate": {"head_sha": "5050505050505050505050505050505050505050", "comparison_base_sha": "e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0"}, "verdict": "clean", "findings": [], "blocking_reasons": []},
+      "correctness": {"schema_version": "1.4", "lens": "correctness", "candidate": {"head_sha": "5050505050505050505050505050505050505050", "comparison_base_sha": "e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0"}, "verdict": "clean", "findings": [], "blocking_reasons": []},
+      "code_simplicity": {"schema_version": "1.4", "lens": "code_simplicity", "candidate": {"head_sha": "5050505050505050505050505050505050505050", "comparison_base_sha": "e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0"}, "verdict": "clean", "findings": [], "blocking_reasons": []}
     }
   },
   {
     "id": "full-restart-after-correctness-fix",
-    "candidate": {
-      "head_sha": "5151515151515151515151515151515151515151",
-      "comparison_base_sha": "e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1"
-    },
-    "available_dependencies": [
-      "review-solution-simplicity",
-      "review-correctness",
-      "review-code-simplicity"
-    ],
-    "evidence": {
-      "complete": true,
-      "new_packet_after_correctness_fix": true
-    },
-    "cycle": 2,
-    "phase": "post_correctness_fix_full_restart",
+    "candidate": {"head_sha": "5151515151515151515151515151515151515151", "comparison_base_sha": "e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1"},
+    "available_dependencies": ["review-solution-simplicity", "review-correctness", "review-code-simplicity"],
+    "evidence": {"complete": true, "new_packet_after_correctness_fix": true}, "cycle": 2, "phase": "post_correctness_fix_full_restart",
     "harness_outcomes": {
-      "solution_simplicity": {
-        "schema_version": "1.4",
-        "lens": "solution_simplicity",
-        "candidate": {
-          "head_sha": "5151515151515151515151515151515151515151",
-          "comparison_base_sha": "e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1"
-        },
-        "verdict": "clean",
-        "findings": [],
-        "blocking_reasons": []
-      },
-      "correctness": {
-        "schema_version": "1.4",
-        "lens": "correctness",
-        "candidate": {
-          "head_sha": "5151515151515151515151515151515151515151",
-          "comparison_base_sha": "e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1"
-        },
-        "verdict": "clean",
-        "findings": [],
-        "blocking_reasons": []
-      },
-      "code_simplicity": {
-        "schema_version": "1.4",
-        "lens": "code_simplicity",
-        "candidate": {
-          "head_sha": "5151515151515151515151515151515151515151",
-          "comparison_base_sha": "e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1"
-        },
-        "verdict": "clean",
-        "findings": [],
-        "blocking_reasons": []
-      }
+      "solution_simplicity": {"schema_version": "1.4", "lens": "solution_simplicity", "candidate": {"head_sha": "5151515151515151515151515151515151515151", "comparison_base_sha": "e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1"}, "verdict": "clean", "findings": [], "blocking_reasons": []},
+      "correctness": {"schema_version": "1.4", "lens": "correctness", "candidate": {"head_sha": "5151515151515151515151515151515151515151", "comparison_base_sha": "e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1"}, "verdict": "clean", "findings": [], "blocking_reasons": []},
+      "code_simplicity": {"schema_version": "1.4", "lens": "code_simplicity", "candidate": {"head_sha": "5151515151515151515151515151515151515151", "comparison_base_sha": "e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1"}, "verdict": "clean", "findings": [], "blocking_reasons": []}
     }
   },
   {
     "id": "missing-dependency",
-    "candidate": {
-      "head_sha": "6060606060606060606060606060606060606060",
-      "comparison_base_sha": "f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0"
-    },
-    "available_dependencies": [
-      "review-solution-simplicity",
-      "review-correctness"
-    ],
-    "evidence": {
-      "complete": true
-    },
-    "cycle": 1,
-    "phase": "full",
-    "harness_outcomes": {}
+    "candidate": {"head_sha": "6060606060606060606060606060606060606060", "comparison_base_sha": "f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0"},
+    "available_dependencies": ["review-solution-simplicity", "review-correctness"],
+    "evidence": {"complete": true}, "cycle": 1, "phase": "full", "harness_outcomes": {}
   },
   {
     "id": "missing-evidence",
-    "candidate": {
-      "head_sha": "7070707070707070707070707070707070707070",
-      "comparison_base_sha": "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1"
-    },
-    "available_dependencies": [
-      "review-solution-simplicity",
-      "review-correctness",
-      "review-code-simplicity"
-    ],
-    "evidence": {
-      "complete": false,
-      "blocking_reasons": [
-        "Acceptance criteria are missing.",
-        "Full validation has no result or unavailable reason."
-      ]
-    },
-    "cycle": 1,
-    "phase": "full",
-    "harness_outcomes": {}
+    "candidate": {"head_sha": "7070707070707070707070707070707070707070", "comparison_base_sha": "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1"},
+    "available_dependencies": ["review-solution-simplicity", "review-correctness", "review-code-simplicity"],
+    "evidence": {"complete": false, "blocking_reasons": ["Acceptance criteria are missing.", "Full validation has no result or unavailable reason."]},
+    "cycle": 1, "phase": "full", "harness_outcomes": {}
   },
   {
     "id": "deferred-only-clean",
-    "candidate": {
-      "head_sha": "8080808080808080808080808080808080808080",
-      "comparison_base_sha": "b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1"
-    },
-    "available_dependencies": [
-      "review-solution-simplicity",
-      "review-correctness",
-      "review-code-simplicity"
-    ],
-    "evidence": {
-      "complete": true
-    },
-    "cycle": 1,
-    "phase": "full",
+    "candidate": {"head_sha": "8080808080808080808080808080808080808080", "comparison_base_sha": "b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1"},
+    "available_dependencies": ["review-solution-simplicity", "review-correctness", "review-code-simplicity"],
+    "evidence": {"complete": true}, "cycle": 1, "phase": "full",
     "harness_outcomes": {
-      "solution_simplicity": {
-        "schema_version": "1.4",
-        "lens": "solution_simplicity",
-        "candidate": {
-          "head_sha": "8080808080808080808080808080808080808080",
-          "comparison_base_sha": "b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1"
-        },
-        "verdict": "clean",
-        "findings": [
-          {
-            "id": "solution-simplicity.future-cleanup",
-            "lens": "solution_simplicity",
-            "severity": "defer",
-            "confidence": "high",
-            "rule": "A real legacy path remains outside this ticket.",
-            "evidence": [
-              {
-                "location": "ticket",
-                "detail": "Migration cleanup is explicitly deferred to issue #90."
-              }
-            ],
-            "concern": "A compatibility path remains outside active scope.",
-            "impact": "The branch remains until callers migrate.",
-            "proposed_change": "Remove the path in issue #90.",
-            "expected_effect": "Retire one compatibility branch after migration."
-          }
-        ],
-        "blocking_reasons": []
-      },
-      "correctness": {
-        "schema_version": "1.4",
-        "lens": "correctness",
-        "candidate": {
-          "head_sha": "8080808080808080808080808080808080808080",
-          "comparison_base_sha": "b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1"
-        },
-        "verdict": "clean",
-        "findings": [],
-        "blocking_reasons": []
-      },
-      "code_simplicity": {
-        "schema_version": "1.4",
-        "lens": "code_simplicity",
-        "candidate": {
-          "head_sha": "8080808080808080808080808080808080808080",
-          "comparison_base_sha": "b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1"
-        },
-        "verdict": "clean",
-        "findings": [],
-        "blocking_reasons": []
-      }
+      "solution_simplicity": {"schema_version": "1.4", "lens": "solution_simplicity", "candidate": {"head_sha": "8080808080808080808080808080808080808080", "comparison_base_sha": "b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1"}, "verdict": "clean", "findings": [{"id": "solution-simplicity.future-cleanup", "lens": "solution_simplicity", "severity": "defer", "confidence": "high", "rule": "A real legacy path remains outside this ticket.", "evidence": [{"location": "ticket", "detail": "Migration cleanup is explicitly deferred to issue #90."}], "concern": "A compatibility path remains outside active scope.", "impact": "The branch remains until callers migrate.", "proposed_change": "Remove the path in issue #90.", "expected_effect": "Retire one compatibility branch after migration."}], "blocking_reasons": []},
+      "correctness": {"schema_version": "1.4", "lens": "correctness", "candidate": {"head_sha": "8080808080808080808080808080808080808080", "comparison_base_sha": "b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1"}, "verdict": "clean", "findings": [], "blocking_reasons": []},
+      "code_simplicity": {"schema_version": "1.4", "lens": "code_simplicity", "candidate": {"head_sha": "8080808080808080808080808080808080808080", "comparison_base_sha": "b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1"}, "verdict": "clean", "findings": [], "blocking_reasons": []}
     }
   },
   {
     "id": "cycle-budget-exhausted",
-    "candidate": {
-      "head_sha": "9090909090909090909090909090909090909090",
-      "comparison_base_sha": "c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1"
-    },
-    "available_dependencies": [
-      "review-solution-simplicity",
-      "review-correctness",
-      "review-code-simplicity"
-    ],
-    "evidence": {
-      "complete": true
-    },
-    "cycle": 3,
-    "phase": "full",
+    "candidate": {"head_sha": "9090909090909090909090909090909090909090", "comparison_base_sha": "c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1"},
+    "available_dependencies": ["review-solution-simplicity", "review-correctness", "review-code-simplicity"],
+    "evidence": {"complete": true}, "cycle": 3, "phase": "full",
     "harness_outcomes": {
-      "solution_simplicity": {
-        "schema_version": "1.4",
-        "lens": "solution_simplicity",
-        "candidate": {
-          "head_sha": "9090909090909090909090909090909090909090",
-          "comparison_base_sha": "c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1"
-        },
-        "verdict": "clean",
-        "findings": [],
-        "blocking_reasons": []
-      },
-      "correctness": {
-        "schema_version": "1.4",
-        "lens": "correctness",
-        "candidate": {
-          "head_sha": "9090909090909090909090909090909090909090",
-          "comparison_base_sha": "c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1"
-        },
-        "verdict": "changes_required",
-        "findings": [
-          {
-            "id": "correctness.retry-still-unbounded",
-            "lens": "correctness",
-            "severity": "blocking",
-            "confidence": "high",
-            "rule": "Retries must stop at the configured maximum.",
-            "evidence": [
-              {
-                "location": "candidate diff",
-                "detail": "The third candidate still schedules after the maximum."
-              }
-            ],
-            "concern": "Retry scheduling remains unbounded.",
-            "impact": "The required retry limit is violated.",
-            "proposed_change": "Stop scheduling at max_retries.",
-            "expected_effect": "Bound repeated work at the required limit."
-          }
-        ],
-        "blocking_reasons": []
-      },
-      "code_simplicity": {
-        "schema_version": "1.4",
-        "lens": "code_simplicity",
-        "candidate": {
-          "head_sha": "9090909090909090909090909090909090909090",
-          "comparison_base_sha": "c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1"
-        },
-        "verdict": "clean",
-        "findings": [],
-        "blocking_reasons": []
-      }
+      "solution_simplicity": {"schema_version": "1.4", "lens": "solution_simplicity", "candidate": {"head_sha": "9090909090909090909090909090909090909090", "comparison_base_sha": "c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1"}, "verdict": "clean", "findings": [], "blocking_reasons": []},
+      "correctness": {"schema_version": "1.4", "lens": "correctness", "candidate": {"head_sha": "9090909090909090909090909090909090909090", "comparison_base_sha": "c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1"}, "verdict": "changes_required", "findings": [{"id": "correctness.retry-still-unbounded", "lens": "correctness", "severity": "blocking", "confidence": "high", "rule": "Retries must stop at the configured maximum.", "evidence": [{"location": "candidate diff", "detail": "The third candidate still schedules after the maximum."}], "concern": "Retry scheduling remains unbounded.", "impact": "The required retry limit is violated.", "proposed_change": "Stop scheduling at max_retries.", "expected_effect": "Bound repeated work at the required limit."}], "blocking_reasons": []},
+      "code_simplicity": {"schema_version": "1.4", "lens": "code_simplicity", "candidate": {"head_sha": "9090909090909090909090909090909090909090", "comparison_base_sha": "c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1"}, "verdict": "clean", "findings": [], "blocking_reasons": []}
     }
   },
   {
     "id": "mismatched-lens-result",
-    "candidate": {
-      "head_sha": "a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2",
-      "comparison_base_sha": "b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
-    },
-    "available_dependencies": [
-      "review-solution-simplicity",
-      "review-correctness",
-      "review-code-simplicity"
-    ],
-    "evidence": {
-      "complete": true
-    },
-    "cycle": 1,
-    "phase": "full",
+    "candidate": {"head_sha": "a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2", "comparison_base_sha": "b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"},
+    "available_dependencies": ["review-solution-simplicity", "review-correctness", "review-code-simplicity"],
+    "evidence": {"complete": true}, "cycle": 1, "phase": "full",
     "harness_outcomes": {
-      "solution_simplicity": {
-        "schema_version": "1.4",
-        "lens": "correctness",
-        "candidate": {
-          "head_sha": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
-          "comparison_base_sha": "b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
-        },
-        "verdict": "clean",
-        "findings": [],
-        "blocking_reasons": []
-      },
-      "correctness": {
-        "schema_version": "1.4",
-        "lens": "correctness",
-        "candidate": {
-          "head_sha": "a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2",
-          "comparison_base_sha": "b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
-        },
-        "verdict": "clean",
-        "findings": [],
-        "blocking_reasons": []
-      },
-      "code_simplicity": {
-        "schema_version": "1.4",
-        "lens": "code_simplicity",
-        "candidate": {
-          "head_sha": "a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2",
-          "comparison_base_sha": "b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
-        },
-        "verdict": "clean",
-        "findings": [],
-        "blocking_reasons": []
-      }
+      "solution_simplicity": {"schema_version": "1.4", "lens": "correctness", "candidate": {"head_sha": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", "comparison_base_sha": "b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"}, "verdict": "clean", "findings": [], "blocking_reasons": []},
+      "correctness": {"schema_version": "1.4", "lens": "correctness", "candidate": {"head_sha": "a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2", "comparison_base_sha": "b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"}, "verdict": "clean", "findings": [], "blocking_reasons": []},
+      "code_simplicity": {"schema_version": "1.4", "lens": "code_simplicity", "candidate": {"head_sha": "a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2", "comparison_base_sha": "b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"}, "verdict": "clean", "findings": [], "blocking_reasons": []}
     }
   },
   {
     "id": "missing-diff-evidence-file",
-    "candidate": {
-      "head_sha": "8080808080808080808080808080808080808080",
-      "comparison_base_sha": "b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1"
-    },
-    "available_dependencies": [
-      "review-solution-simplicity",
-      "review-correctness",
-      "review-code-simplicity"
-    ],
-    "evidence": {
-      "complete": false,
-      "blocking_reasons": [
-        "The packet references a candidate diff file that does not exist."
-      ]
-    },
-    "cycle": 1,
-    "phase": "full",
+    "candidate": {"head_sha": "a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3", "comparison_base_sha": "b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3"},
+    "available_dependencies": ["review-solution-simplicity", "review-correctness", "review-code-simplicity"],
+    "evidence": {"complete": false, "blocking_reasons": ["The packet references a candidate diff file that does not exist."]},
+    "cycle": 1, "phase": "full",
     "harness_outcomes": {}
   }
 ]

--- a/skills/review-code-change/evals/expectations.json
+++ b/skills/review-code-change/evals/expectations.json
@@ -459,8 +459,8 @@
       "schema_version": "1.4",
       "lens": "aggregate",
       "candidate": {
-        "head_sha": "8080808080808080808080808080808080808080",
-        "comparison_base_sha": "b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1"
+        "head_sha": "a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3",
+        "comparison_base_sha": "b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3"
       },
       "verdict": "blocked",
       "findings": [],

--- a/skills/review-code-change/evals/expectations.json
+++ b/skills/review-code-change/evals/expectations.json
@@ -450,5 +450,24 @@
       ],
       "next_action": "No further review action is required; the correctness fix restarted and cleanly completed the full three-lens sequence on the new head."
     }
+  },
+  {
+    "case_id": "missing-diff-evidence-file",
+    "observed_sequence": [],
+    "stopped_reason": "evidence_packet_incomplete",
+    "result": {
+      "schema_version": "1.4",
+      "lens": "aggregate",
+      "candidate": {
+        "head_sha": "8080808080808080808080808080808080808080",
+        "comparison_base_sha": "b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1"
+      },
+      "verdict": "blocked",
+      "findings": [],
+      "blocking_reasons": [
+        "The packet references a candidate diff file that does not exist."
+      ],
+      "next_action": "Rewrite the complete diff to a file outside the candidate worktree, record that path in the packet, revalidate it, then restart the full review sequence."
+    }
   }
 ]

--- a/skills/review-code-change/evals/standalone-clean/prompt.md
+++ b/skills/review-code-change/evals/standalone-clean/prompt.md
@@ -1,9 +1,10 @@
 Use the `review-code-change` skill to review the candidate described by the raw
 evidence in this directory. Read `ticket.md`, `repository-evidence.md`,
 `candidate.diff`, and `validation.md`; do not inspect answer keys (stored
-outside this directory) or prior conclusions. Build one shared packet, then
-apply the three repository-owned lens skills in their required order. Do not
-modify files or repository state.
+outside this directory) or prior conclusions. Build one shared packet whose
+candidate diff is referenced by path rather than inlined, then apply the three
+repository-owned lens skills in their required order. Do not modify files or
+repository state.
 
 For evaluation recording only, return an object with `observed_sequence` (the
 lens tokens actually invoked, in order, e.g. `solution_simplicity`) and

--- a/skills/review-code-change/references/orchestration-protocol.md
+++ b/skills/review-code-change/references/orchestration-protocol.md
@@ -11,6 +11,11 @@ Read applicable repository instructions and named specifications, then capture
 the complete diff, exact candidate identity, representative nearby code and
 tests, validation evidence, and worktree state.
 
+Write the captured diff to a file outside the candidate worktree and record its
+location as `candidate.diff.path`. Dispatch every lens with the packet and let
+it read the diff from that path; do not inline the complete diff into any lens
+invocation.
+
 Run the shared packet validator — the bundled dependency-free copy at
 [references/review-suite/validate.py](review-suite/validate.py), or the
 canonical `review-suite/scripts/validate.py` inside the source monorepo. Do not

--- a/skills/review-code-change/references/orchestration-protocol.md
+++ b/skills/review-code-change/references/orchestration-protocol.md
@@ -11,10 +11,8 @@ Read applicable repository instructions and named specifications, then capture
 the complete diff, exact candidate identity, representative nearby code and
 tests, validation evidence, and worktree state.
 
-Write the captured diff to a file outside the candidate worktree and record its
-location as `candidate.diff.path`. Dispatch every lens with the packet and let
-it read the diff from that path; do not inline the complete diff into any lens
-invocation.
+Dispatch every lens with the packet and let it read the diff from
+`candidate.diff.path`; do not inline the complete diff into any lens invocation.
 
 Run the shared packet validator — the bundled dependency-free copy at
 [references/review-suite/validate.py](review-suite/validate.py), or the

--- a/skills/review-code-change/references/review-suite/CONTRACT.md
+++ b/skills/review-code-change/references/review-suite/CONTRACT.md
@@ -55,7 +55,7 @@ Required packet sections are:
 
 1. `repository`: repository identity and base branch.
 2. `candidate`: the captured head, the comparison base or merge base, and the
-   complete candidate diff.
+   complete candidate diff in one of the two forms below.
 3. `change_contract`: observable goal, non-empty acceptance criteria, explicit
    non-goals, and behavior or invariants to preserve.
 4. `sources`: applicable repository instructions, named design or contract
@@ -72,8 +72,32 @@ on it. Optional `base_drift` records why evidence was retained or reset after
 the base advanced.
 
 Do not infer missing intent. Missing repository identity, goal, acceptance
-criteria, candidate identity, a complete diff, or required validation evidence
-prevents a trustworthy review and must yield a `blocked` result.
+criteria, candidate identity, a complete diff in either form below, or required
+validation evidence prevents a trustworthy review and must yield a `blocked`
+result.
+
+### The candidate diff: inline or referenced by path
+
+`candidate.diff` carries the complete diff in exactly one of two forms:
+
+- **inline** — `content` holds the unified diff itself; and
+- **referenced** — `path` holds the location of a file whose content is that
+  diff.
+
+The forms are mutually exclusive: a diff object carrying both or neither is
+malformed. Both assert `complete: true` and mean the same thing to a lens — the
+reviewed candidate is the whole diff, never a summary of it.
+
+A packet builder that writes the diff to a file writes it **outside the
+candidate worktree**. Evidence written inside the worktree registers as a
+candidate mutation and fails the before/after integrity check that proves the
+review was read-only, so keeping the evidence elsewhere is what keeps that check
+trivially satisfied rather than something the builder must exempt itself from.
+
+A referenced file that is absent or empty is missing review evidence, exactly as
+an absent inline `content` is: `scripts/validate.py` fails closed on it and the
+review yields `blocked`. Never read an unreadable reference as a candidate whose
+diff is merely smaller.
 
 ## Finding semantics
 

--- a/skills/review-code-change/references/review-suite/CONTRACT.md
+++ b/skills/review-code-change/references/review-suite/CONTRACT.md
@@ -89,10 +89,16 @@ malformed. Both assert `complete: true` and mean the same thing to a lens — th
 reviewed candidate is the whole diff, never a summary of it.
 
 A packet builder that writes the diff to a file writes it **outside the
-candidate worktree**. Evidence written inside the worktree registers as a
-candidate mutation and fails the before/after integrity check that proves the
-review was read-only, so keeping the evidence elsewhere is what keeps that check
-trivially satisfied rather than something the builder must exempt itself from.
+candidate worktree**, and records an **absolute** path. Evidence written inside
+the worktree registers as a candidate mutation and fails the before/after
+integrity check that proves the review was read-only, so keeping the evidence
+elsewhere is what keeps that check trivially satisfied rather than something the
+builder must exempt itself from. A relative path is rejected because the builder
+and every lens revalidate the same packet from their own working directories: a
+relative reference either reports evidence absent that exists, or resolves to a
+different file of the same name and binds a lens to a diff that is not the
+candidate's — a substitution no candidate-identity check can catch, because
+those compare SHAs and never the diff's provenance.
 
 A referenced file that is absent or empty is missing review evidence, exactly as
 an absent inline `content` is: `scripts/validate.py` fails closed on it and the

--- a/skills/review-code-change/references/review-suite/review-packet.schema.json
+++ b/skills/review-code-change/references/review-suite/review-packet.schema.json
@@ -36,14 +36,28 @@
           "pattern": "^[0-9a-f]{40}$"
         },
         "diff": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["format", "complete", "content"],
-          "properties": {
-            "format": {"enum": ["unified_diff"]},
-            "complete": {"const": true},
-            "content": {"type": "string", "minLength": 1}
-          }
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["format", "complete", "content"],
+              "properties": {
+                "format": {"enum": ["unified_diff"]},
+                "complete": {"const": true},
+                "content": {"type": "string", "minLength": 1}
+              }
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["format", "complete", "path"],
+              "properties": {
+                "format": {"enum": ["unified_diff"]},
+                "complete": {"const": true},
+                "path": {"type": "string", "minLength": 1}
+              }
+            }
+          ]
         }
       }
     },

--- a/skills/review-code-change/references/review-suite/validate.py
+++ b/skills/review-code-change/references/review-suite/validate.py
@@ -67,6 +67,10 @@ BLOCKABLE_PACKET_ERROR_PATTERNS = (
         r"(missing|empty)$"
     ),
     re.compile(
+        r"^\$\.candidate\.diff\.path: referenced diff evidence file must be an "
+        r"absolute path$"
+    ),
+    re.compile(
         r"^\$\.change_contract: missing required property "
         r"'(goal|acceptance_criteria|non_goals|preserved_behaviors)'$"
     ),
@@ -207,12 +211,26 @@ def _check_diff_evidence_path(packet: dict[str, Any]) -> list[str]:
     inline `content` reports — and not a candidate with a smaller diff. The
     emptiness bar mirrors the inline form's `minLength: 1` exactly so neither
     form is stricter than the other.
+
+    The reference must be absolute. A relative path resolves against whatever
+    working directory happens to be current, and the builder and each lens
+    revalidate the same packet from different directories, so a relative
+    reference either reports absent evidence that exists or — worse — resolves
+    to a different file of the same name and binds a lens to a diff that is not
+    the candidate's. Candidate-identity checks compare SHAs and cannot detect
+    that substitution. This mirrors why `_schema_file` above resolves its own
+    schemas `__file__`-relative rather than from the current directory.
     """
     diff = packet.get("candidate", {}).get("diff")
     location = diff.get("path") if isinstance(diff, dict) else None
     if not location:
         return []
     evidence = Path(location)
+    if not evidence.is_absolute():
+        return [
+            "$.candidate.diff.path: referenced diff evidence file must be an "
+            "absolute path"
+        ]
     if not evidence.is_file():
         return ["$.candidate.diff.path: referenced diff evidence file is missing"]
     if evidence.stat().st_size == 0:

--- a/skills/review-code-change/references/review-suite/validate.py
+++ b/skills/review-code-change/references/review-suite/validate.py
@@ -58,10 +58,14 @@ BLOCKABLE_PACKET_ERROR_PATTERNS = (
     ),
     re.compile(
         r"^\$\.candidate\.diff: missing required property "
-        r"'(format|complete|content)'$"
+        r"'(format|complete|content|path)'$"
     ),
     re.compile(r"^\$\.candidate\.diff\.complete: expected constant True$"),
-    re.compile(r"^\$\.candidate\.diff\.content: string is too short$"),
+    re.compile(r"^\$\.candidate\.diff\.(content|path): string is too short$"),
+    re.compile(
+        r"^\$\.candidate\.diff\.path: referenced diff evidence file is "
+        r"(missing|empty)$"
+    ),
     re.compile(
         r"^\$\.change_contract: missing required property "
         r"'(goal|acceptance_criteria|non_goals|preserved_behaviors)'$"
@@ -105,6 +109,18 @@ def validate_schema(value: Any, schema: dict[str, Any], at: str = "$") -> list[s
     expected_type = schema.get("type")
     if expected_type and not _is_type(value, expected_type):
         return [f"{at}: expected {expected_type}"]
+
+    if branches := schema.get("oneOf"):
+        # Every `oneOf` in this repository's schemas has branches made mutually
+        # exclusive by `additionalProperties: false`, so no value can satisfy
+        # two of them and a match by any branch is the match. On failure,
+        # report the closest branch's own errors instead of a generic
+        # "no form matched": the caller needs the actionable message for the
+        # form it was evidently aiming at, and BLOCKABLE_PACKET_ERROR_PATTERNS
+        # is written against those exact messages.
+        attempts = [validate_schema(value, branch, at) for branch in branches]
+        if all(attempts):
+            errors.extend(min(attempts, key=len))
 
     if "const" in schema:
         const = schema["const"]
@@ -150,6 +166,8 @@ def validate_packet(packet: dict[str, Any]) -> list[str]:
     if errors:
         return errors
 
+    errors.extend(_check_diff_evidence_path(packet))
+
     for index, validation in enumerate(packet.get("validation", [])):
         status = validation.get("status")
         if status in {"passed", "failed"} and not validation.get("result"):
@@ -178,6 +196,28 @@ def validate_packet(packet: dict[str, Any]) -> list[str]:
                 + ", ".join(active)
             )
     return errors
+
+
+def _check_diff_evidence_path(packet: dict[str, Any]) -> list[str]:
+    """Fail closed when a path-form candidate diff references no readable file.
+
+    The path form exists so lens dispatch carries a reference instead of the
+    complete diff, which means the file is the evidence. An absent or empty
+    file is therefore missing review evidence — the same condition an absent
+    inline `content` reports — and not a candidate with a smaller diff. The
+    emptiness bar mirrors the inline form's `minLength: 1` exactly so neither
+    form is stricter than the other.
+    """
+    diff = packet.get("candidate", {}).get("diff")
+    location = diff.get("path") if isinstance(diff, dict) else None
+    if not location:
+        return []
+    evidence = Path(location)
+    if not evidence.is_file():
+        return ["$.candidate.diff.path: referenced diff evidence file is missing"]
+    if evidence.stat().st_size == 0:
+        return ["$.candidate.diff.path: referenced diff evidence file is empty"]
+    return []
 
 
 def validate_result(result: dict[str, Any]) -> list[str]:

--- a/skills/review-code-change/scripts/tests/test_orchestration_contract.py
+++ b/skills/review-code-change/scripts/tests/test_orchestration_contract.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import re
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -21,6 +23,11 @@ SPEC.loader.exec_module(VALIDATOR)
 
 def load(path: Path):
     return json.loads(path.read_text())
+
+
+def compact(value: str) -> str:
+    """Collapse wrapping and Markdown emphasis so phrases survive reflow."""
+    return re.sub(r"\s+", " ", value.replace("*", "")).strip()
 
 
 class OrchestrationContractTests(unittest.TestCase):
@@ -72,6 +79,38 @@ class OrchestrationContractTests(unittest.TestCase):
         ):
             self.assertTrue((bundle / name).is_file(), name)
 
+    def test_lens_dispatch_references_the_diff_by_path(self):
+        for name, source in (("skill", self.skill), ("protocol", self.protocol)):
+            with self.subTest(source=name):
+                text = compact(source)
+                self.assertIn("candidate.diff.path", text)
+                self.assertIn("outside the candidate worktree", text)
+        self.assertIn(
+            "Do not paste the complete diff into a lens invocation",
+            compact(self.skill),
+        )
+        self.assertIn(
+            "do not inline the complete diff into any lens invocation",
+            compact(self.protocol),
+        )
+
+    def test_bundled_validator_accepts_a_path_referenced_candidate_diff(self):
+        packet = load(REVIEW_SUITE / "fixtures" / "clean-change" / "packet.json")
+        with tempfile.TemporaryDirectory() as directory:
+            evidence = Path(directory) / "candidate.diff"
+            evidence.write_text(packet["candidate"]["diff"]["content"])
+            packet["candidate"]["diff"] = {
+                "format": "unified_diff",
+                "complete": True,
+                "path": str(evidence),
+            }
+            self.assertEqual([], VALIDATOR.validate_packet(packet))
+
+            evidence.unlink()
+            errors = VALIDATOR.validate_packet(packet)
+            self.assertTrue(errors)
+            self.assertTrue(all(map(VALIDATOR.is_blockable_packet_error, errors)))
+
     def test_forward_evaluations_cover_every_case_and_conform(self):
         self.assertEqual(set(self.cases), set(self.results))
         for case_id, record in self.results.items():
@@ -121,6 +160,7 @@ class OrchestrationContractTests(unittest.TestCase):
             ),
             "missing-dependency": ([], "blocked"),
             "missing-evidence": ([], "blocked"),
+            "missing-diff-evidence-file": ([], "blocked"),
             "deferred-only-clean": (
                 ["solution_simplicity", "correctness", "code_simplicity"],
                 "clean",

--- a/skills/review-code-change/scripts/tests/test_orchestration_contract.py
+++ b/skills/review-code-change/scripts/tests/test_orchestration_contract.py
@@ -3,13 +3,10 @@ from __future__ import annotations
 import importlib.util
 import json
 import re
-import tempfile
 import unittest
 from pathlib import Path
 
 SKILL_ROOT = Path(__file__).resolve().parents[2]
-REPOSITORY_ROOT = SKILL_ROOT.parents[1]
-REVIEW_SUITE = REPOSITORY_ROOT / "review-suite"
 # Import the skill's own bundled validator so these tests exercise the
 # installed layout, not only the canonical monorepo copy.
 SPEC = importlib.util.spec_from_file_location(
@@ -26,8 +23,7 @@ def load(path: Path):
 
 
 def compact(value: str) -> str:
-    """Collapse wrapping and Markdown emphasis so phrases survive reflow."""
-    return re.sub(r"\s+", " ", value.replace("*", "")).strip()
+    return re.sub(r"\s+", " ", value).strip()
 
 
 class OrchestrationContractTests(unittest.TestCase):
@@ -80,36 +76,19 @@ class OrchestrationContractTests(unittest.TestCase):
             self.assertTrue((bundle / name).is_file(), name)
 
     def test_lens_dispatch_references_the_diff_by_path(self):
-        for name, source in (("skill", self.skill), ("protocol", self.protocol)):
-            with self.subTest(source=name):
-                text = compact(source)
-                self.assertIn("candidate.diff.path", text)
-                self.assertIn("outside the candidate worktree", text)
-        self.assertIn(
-            "Do not paste the complete diff into a lens invocation",
-            compact(self.skill),
-        )
-        self.assertIn(
-            "do not inline the complete diff into any lens invocation",
-            compact(self.protocol),
-        )
+        # The shared contract owns the write-it-outside-the-worktree rule; this
+        # skill states the builder obligation once and the protocol states only
+        # the dispatch clause it owns.
+        skill = compact(self.skill)
+        self.assertIn("outside the candidate worktree", skill)
+        self.assertIn("absolute location as the packet's `candidate.diff.path`", skill)
+        self.assertIn("Do not paste the complete diff into a lens invocation", skill)
 
-    def test_bundled_validator_accepts_a_path_referenced_candidate_diff(self):
-        packet = load(REVIEW_SUITE / "fixtures" / "clean-change" / "packet.json")
-        with tempfile.TemporaryDirectory() as directory:
-            evidence = Path(directory) / "candidate.diff"
-            evidence.write_text(packet["candidate"]["diff"]["content"])
-            packet["candidate"]["diff"] = {
-                "format": "unified_diff",
-                "complete": True,
-                "path": str(evidence),
-            }
-            self.assertEqual([], VALIDATOR.validate_packet(packet))
-
-            evidence.unlink()
-            errors = VALIDATOR.validate_packet(packet)
-            self.assertTrue(errors)
-            self.assertTrue(all(map(VALIDATOR.is_blockable_packet_error, errors)))
+        protocol = compact(self.protocol)
+        self.assertIn("read the diff from `candidate.diff.path`", protocol)
+        self.assertIn(
+            "do not inline the complete diff into any lens invocation", protocol
+        )
 
     def test_forward_evaluations_cover_every_case_and_conform(self):
         self.assertEqual(set(self.cases), set(self.results))

--- a/skills/review-code-simplicity/references/review-suite/CONTRACT.md
+++ b/skills/review-code-simplicity/references/review-suite/CONTRACT.md
@@ -55,7 +55,7 @@ Required packet sections are:
 
 1. `repository`: repository identity and base branch.
 2. `candidate`: the captured head, the comparison base or merge base, and the
-   complete candidate diff.
+   complete candidate diff in one of the two forms below.
 3. `change_contract`: observable goal, non-empty acceptance criteria, explicit
    non-goals, and behavior or invariants to preserve.
 4. `sources`: applicable repository instructions, named design or contract
@@ -72,8 +72,32 @@ on it. Optional `base_drift` records why evidence was retained or reset after
 the base advanced.
 
 Do not infer missing intent. Missing repository identity, goal, acceptance
-criteria, candidate identity, a complete diff, or required validation evidence
-prevents a trustworthy review and must yield a `blocked` result.
+criteria, candidate identity, a complete diff in either form below, or required
+validation evidence prevents a trustworthy review and must yield a `blocked`
+result.
+
+### The candidate diff: inline or referenced by path
+
+`candidate.diff` carries the complete diff in exactly one of two forms:
+
+- **inline** — `content` holds the unified diff itself; and
+- **referenced** — `path` holds the location of a file whose content is that
+  diff.
+
+The forms are mutually exclusive: a diff object carrying both or neither is
+malformed. Both assert `complete: true` and mean the same thing to a lens — the
+reviewed candidate is the whole diff, never a summary of it.
+
+A packet builder that writes the diff to a file writes it **outside the
+candidate worktree**. Evidence written inside the worktree registers as a
+candidate mutation and fails the before/after integrity check that proves the
+review was read-only, so keeping the evidence elsewhere is what keeps that check
+trivially satisfied rather than something the builder must exempt itself from.
+
+A referenced file that is absent or empty is missing review evidence, exactly as
+an absent inline `content` is: `scripts/validate.py` fails closed on it and the
+review yields `blocked`. Never read an unreadable reference as a candidate whose
+diff is merely smaller.
 
 ## Finding semantics
 

--- a/skills/review-code-simplicity/references/review-suite/CONTRACT.md
+++ b/skills/review-code-simplicity/references/review-suite/CONTRACT.md
@@ -89,10 +89,16 @@ malformed. Both assert `complete: true` and mean the same thing to a lens — th
 reviewed candidate is the whole diff, never a summary of it.
 
 A packet builder that writes the diff to a file writes it **outside the
-candidate worktree**. Evidence written inside the worktree registers as a
-candidate mutation and fails the before/after integrity check that proves the
-review was read-only, so keeping the evidence elsewhere is what keeps that check
-trivially satisfied rather than something the builder must exempt itself from.
+candidate worktree**, and records an **absolute** path. Evidence written inside
+the worktree registers as a candidate mutation and fails the before/after
+integrity check that proves the review was read-only, so keeping the evidence
+elsewhere is what keeps that check trivially satisfied rather than something the
+builder must exempt itself from. A relative path is rejected because the builder
+and every lens revalidate the same packet from their own working directories: a
+relative reference either reports evidence absent that exists, or resolves to a
+different file of the same name and binds a lens to a diff that is not the
+candidate's — a substitution no candidate-identity check can catch, because
+those compare SHAs and never the diff's provenance.
 
 A referenced file that is absent or empty is missing review evidence, exactly as
 an absent inline `content` is: `scripts/validate.py` fails closed on it and the

--- a/skills/review-code-simplicity/references/review-suite/review-packet.schema.json
+++ b/skills/review-code-simplicity/references/review-suite/review-packet.schema.json
@@ -36,14 +36,28 @@
           "pattern": "^[0-9a-f]{40}$"
         },
         "diff": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["format", "complete", "content"],
-          "properties": {
-            "format": {"enum": ["unified_diff"]},
-            "complete": {"const": true},
-            "content": {"type": "string", "minLength": 1}
-          }
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["format", "complete", "content"],
+              "properties": {
+                "format": {"enum": ["unified_diff"]},
+                "complete": {"const": true},
+                "content": {"type": "string", "minLength": 1}
+              }
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["format", "complete", "path"],
+              "properties": {
+                "format": {"enum": ["unified_diff"]},
+                "complete": {"const": true},
+                "path": {"type": "string", "minLength": 1}
+              }
+            }
+          ]
         }
       }
     },

--- a/skills/review-code-simplicity/references/review-suite/validate.py
+++ b/skills/review-code-simplicity/references/review-suite/validate.py
@@ -67,6 +67,10 @@ BLOCKABLE_PACKET_ERROR_PATTERNS = (
         r"(missing|empty)$"
     ),
     re.compile(
+        r"^\$\.candidate\.diff\.path: referenced diff evidence file must be an "
+        r"absolute path$"
+    ),
+    re.compile(
         r"^\$\.change_contract: missing required property "
         r"'(goal|acceptance_criteria|non_goals|preserved_behaviors)'$"
     ),
@@ -207,12 +211,26 @@ def _check_diff_evidence_path(packet: dict[str, Any]) -> list[str]:
     inline `content` reports — and not a candidate with a smaller diff. The
     emptiness bar mirrors the inline form's `minLength: 1` exactly so neither
     form is stricter than the other.
+
+    The reference must be absolute. A relative path resolves against whatever
+    working directory happens to be current, and the builder and each lens
+    revalidate the same packet from different directories, so a relative
+    reference either reports absent evidence that exists or — worse — resolves
+    to a different file of the same name and binds a lens to a diff that is not
+    the candidate's. Candidate-identity checks compare SHAs and cannot detect
+    that substitution. This mirrors why `_schema_file` above resolves its own
+    schemas `__file__`-relative rather than from the current directory.
     """
     diff = packet.get("candidate", {}).get("diff")
     location = diff.get("path") if isinstance(diff, dict) else None
     if not location:
         return []
     evidence = Path(location)
+    if not evidence.is_absolute():
+        return [
+            "$.candidate.diff.path: referenced diff evidence file must be an "
+            "absolute path"
+        ]
     if not evidence.is_file():
         return ["$.candidate.diff.path: referenced diff evidence file is missing"]
     if evidence.stat().st_size == 0:

--- a/skills/review-code-simplicity/references/review-suite/validate.py
+++ b/skills/review-code-simplicity/references/review-suite/validate.py
@@ -58,10 +58,14 @@ BLOCKABLE_PACKET_ERROR_PATTERNS = (
     ),
     re.compile(
         r"^\$\.candidate\.diff: missing required property "
-        r"'(format|complete|content)'$"
+        r"'(format|complete|content|path)'$"
     ),
     re.compile(r"^\$\.candidate\.diff\.complete: expected constant True$"),
-    re.compile(r"^\$\.candidate\.diff\.content: string is too short$"),
+    re.compile(r"^\$\.candidate\.diff\.(content|path): string is too short$"),
+    re.compile(
+        r"^\$\.candidate\.diff\.path: referenced diff evidence file is "
+        r"(missing|empty)$"
+    ),
     re.compile(
         r"^\$\.change_contract: missing required property "
         r"'(goal|acceptance_criteria|non_goals|preserved_behaviors)'$"
@@ -105,6 +109,18 @@ def validate_schema(value: Any, schema: dict[str, Any], at: str = "$") -> list[s
     expected_type = schema.get("type")
     if expected_type and not _is_type(value, expected_type):
         return [f"{at}: expected {expected_type}"]
+
+    if branches := schema.get("oneOf"):
+        # Every `oneOf` in this repository's schemas has branches made mutually
+        # exclusive by `additionalProperties: false`, so no value can satisfy
+        # two of them and a match by any branch is the match. On failure,
+        # report the closest branch's own errors instead of a generic
+        # "no form matched": the caller needs the actionable message for the
+        # form it was evidently aiming at, and BLOCKABLE_PACKET_ERROR_PATTERNS
+        # is written against those exact messages.
+        attempts = [validate_schema(value, branch, at) for branch in branches]
+        if all(attempts):
+            errors.extend(min(attempts, key=len))
 
     if "const" in schema:
         const = schema["const"]
@@ -150,6 +166,8 @@ def validate_packet(packet: dict[str, Any]) -> list[str]:
     if errors:
         return errors
 
+    errors.extend(_check_diff_evidence_path(packet))
+
     for index, validation in enumerate(packet.get("validation", [])):
         status = validation.get("status")
         if status in {"passed", "failed"} and not validation.get("result"):
@@ -178,6 +196,28 @@ def validate_packet(packet: dict[str, Any]) -> list[str]:
                 + ", ".join(active)
             )
     return errors
+
+
+def _check_diff_evidence_path(packet: dict[str, Any]) -> list[str]:
+    """Fail closed when a path-form candidate diff references no readable file.
+
+    The path form exists so lens dispatch carries a reference instead of the
+    complete diff, which means the file is the evidence. An absent or empty
+    file is therefore missing review evidence — the same condition an absent
+    inline `content` reports — and not a candidate with a smaller diff. The
+    emptiness bar mirrors the inline form's `minLength: 1` exactly so neither
+    form is stricter than the other.
+    """
+    diff = packet.get("candidate", {}).get("diff")
+    location = diff.get("path") if isinstance(diff, dict) else None
+    if not location:
+        return []
+    evidence = Path(location)
+    if not evidence.is_file():
+        return ["$.candidate.diff.path: referenced diff evidence file is missing"]
+    if evidence.stat().st_size == 0:
+        return ["$.candidate.diff.path: referenced diff evidence file is empty"]
+    return []
 
 
 def validate_result(result: dict[str, Any]) -> list[str]:

--- a/skills/review-correctness/references/review-suite/CONTRACT.md
+++ b/skills/review-correctness/references/review-suite/CONTRACT.md
@@ -55,7 +55,7 @@ Required packet sections are:
 
 1. `repository`: repository identity and base branch.
 2. `candidate`: the captured head, the comparison base or merge base, and the
-   complete candidate diff.
+   complete candidate diff in one of the two forms below.
 3. `change_contract`: observable goal, non-empty acceptance criteria, explicit
    non-goals, and behavior or invariants to preserve.
 4. `sources`: applicable repository instructions, named design or contract
@@ -72,8 +72,32 @@ on it. Optional `base_drift` records why evidence was retained or reset after
 the base advanced.
 
 Do not infer missing intent. Missing repository identity, goal, acceptance
-criteria, candidate identity, a complete diff, or required validation evidence
-prevents a trustworthy review and must yield a `blocked` result.
+criteria, candidate identity, a complete diff in either form below, or required
+validation evidence prevents a trustworthy review and must yield a `blocked`
+result.
+
+### The candidate diff: inline or referenced by path
+
+`candidate.diff` carries the complete diff in exactly one of two forms:
+
+- **inline** — `content` holds the unified diff itself; and
+- **referenced** — `path` holds the location of a file whose content is that
+  diff.
+
+The forms are mutually exclusive: a diff object carrying both or neither is
+malformed. Both assert `complete: true` and mean the same thing to a lens — the
+reviewed candidate is the whole diff, never a summary of it.
+
+A packet builder that writes the diff to a file writes it **outside the
+candidate worktree**. Evidence written inside the worktree registers as a
+candidate mutation and fails the before/after integrity check that proves the
+review was read-only, so keeping the evidence elsewhere is what keeps that check
+trivially satisfied rather than something the builder must exempt itself from.
+
+A referenced file that is absent or empty is missing review evidence, exactly as
+an absent inline `content` is: `scripts/validate.py` fails closed on it and the
+review yields `blocked`. Never read an unreadable reference as a candidate whose
+diff is merely smaller.
 
 ## Finding semantics
 

--- a/skills/review-correctness/references/review-suite/CONTRACT.md
+++ b/skills/review-correctness/references/review-suite/CONTRACT.md
@@ -89,10 +89,16 @@ malformed. Both assert `complete: true` and mean the same thing to a lens — th
 reviewed candidate is the whole diff, never a summary of it.
 
 A packet builder that writes the diff to a file writes it **outside the
-candidate worktree**. Evidence written inside the worktree registers as a
-candidate mutation and fails the before/after integrity check that proves the
-review was read-only, so keeping the evidence elsewhere is what keeps that check
-trivially satisfied rather than something the builder must exempt itself from.
+candidate worktree**, and records an **absolute** path. Evidence written inside
+the worktree registers as a candidate mutation and fails the before/after
+integrity check that proves the review was read-only, so keeping the evidence
+elsewhere is what keeps that check trivially satisfied rather than something the
+builder must exempt itself from. A relative path is rejected because the builder
+and every lens revalidate the same packet from their own working directories: a
+relative reference either reports evidence absent that exists, or resolves to a
+different file of the same name and binds a lens to a diff that is not the
+candidate's — a substitution no candidate-identity check can catch, because
+those compare SHAs and never the diff's provenance.
 
 A referenced file that is absent or empty is missing review evidence, exactly as
 an absent inline `content` is: `scripts/validate.py` fails closed on it and the

--- a/skills/review-correctness/references/review-suite/review-packet.schema.json
+++ b/skills/review-correctness/references/review-suite/review-packet.schema.json
@@ -36,14 +36,28 @@
           "pattern": "^[0-9a-f]{40}$"
         },
         "diff": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["format", "complete", "content"],
-          "properties": {
-            "format": {"enum": ["unified_diff"]},
-            "complete": {"const": true},
-            "content": {"type": "string", "minLength": 1}
-          }
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["format", "complete", "content"],
+              "properties": {
+                "format": {"enum": ["unified_diff"]},
+                "complete": {"const": true},
+                "content": {"type": "string", "minLength": 1}
+              }
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["format", "complete", "path"],
+              "properties": {
+                "format": {"enum": ["unified_diff"]},
+                "complete": {"const": true},
+                "path": {"type": "string", "minLength": 1}
+              }
+            }
+          ]
         }
       }
     },

--- a/skills/review-correctness/references/review-suite/validate.py
+++ b/skills/review-correctness/references/review-suite/validate.py
@@ -67,6 +67,10 @@ BLOCKABLE_PACKET_ERROR_PATTERNS = (
         r"(missing|empty)$"
     ),
     re.compile(
+        r"^\$\.candidate\.diff\.path: referenced diff evidence file must be an "
+        r"absolute path$"
+    ),
+    re.compile(
         r"^\$\.change_contract: missing required property "
         r"'(goal|acceptance_criteria|non_goals|preserved_behaviors)'$"
     ),
@@ -207,12 +211,26 @@ def _check_diff_evidence_path(packet: dict[str, Any]) -> list[str]:
     inline `content` reports — and not a candidate with a smaller diff. The
     emptiness bar mirrors the inline form's `minLength: 1` exactly so neither
     form is stricter than the other.
+
+    The reference must be absolute. A relative path resolves against whatever
+    working directory happens to be current, and the builder and each lens
+    revalidate the same packet from different directories, so a relative
+    reference either reports absent evidence that exists or — worse — resolves
+    to a different file of the same name and binds a lens to a diff that is not
+    the candidate's. Candidate-identity checks compare SHAs and cannot detect
+    that substitution. This mirrors why `_schema_file` above resolves its own
+    schemas `__file__`-relative rather than from the current directory.
     """
     diff = packet.get("candidate", {}).get("diff")
     location = diff.get("path") if isinstance(diff, dict) else None
     if not location:
         return []
     evidence = Path(location)
+    if not evidence.is_absolute():
+        return [
+            "$.candidate.diff.path: referenced diff evidence file must be an "
+            "absolute path"
+        ]
     if not evidence.is_file():
         return ["$.candidate.diff.path: referenced diff evidence file is missing"]
     if evidence.stat().st_size == 0:

--- a/skills/review-correctness/references/review-suite/validate.py
+++ b/skills/review-correctness/references/review-suite/validate.py
@@ -58,10 +58,14 @@ BLOCKABLE_PACKET_ERROR_PATTERNS = (
     ),
     re.compile(
         r"^\$\.candidate\.diff: missing required property "
-        r"'(format|complete|content)'$"
+        r"'(format|complete|content|path)'$"
     ),
     re.compile(r"^\$\.candidate\.diff\.complete: expected constant True$"),
-    re.compile(r"^\$\.candidate\.diff\.content: string is too short$"),
+    re.compile(r"^\$\.candidate\.diff\.(content|path): string is too short$"),
+    re.compile(
+        r"^\$\.candidate\.diff\.path: referenced diff evidence file is "
+        r"(missing|empty)$"
+    ),
     re.compile(
         r"^\$\.change_contract: missing required property "
         r"'(goal|acceptance_criteria|non_goals|preserved_behaviors)'$"
@@ -105,6 +109,18 @@ def validate_schema(value: Any, schema: dict[str, Any], at: str = "$") -> list[s
     expected_type = schema.get("type")
     if expected_type and not _is_type(value, expected_type):
         return [f"{at}: expected {expected_type}"]
+
+    if branches := schema.get("oneOf"):
+        # Every `oneOf` in this repository's schemas has branches made mutually
+        # exclusive by `additionalProperties: false`, so no value can satisfy
+        # two of them and a match by any branch is the match. On failure,
+        # report the closest branch's own errors instead of a generic
+        # "no form matched": the caller needs the actionable message for the
+        # form it was evidently aiming at, and BLOCKABLE_PACKET_ERROR_PATTERNS
+        # is written against those exact messages.
+        attempts = [validate_schema(value, branch, at) for branch in branches]
+        if all(attempts):
+            errors.extend(min(attempts, key=len))
 
     if "const" in schema:
         const = schema["const"]
@@ -150,6 +166,8 @@ def validate_packet(packet: dict[str, Any]) -> list[str]:
     if errors:
         return errors
 
+    errors.extend(_check_diff_evidence_path(packet))
+
     for index, validation in enumerate(packet.get("validation", [])):
         status = validation.get("status")
         if status in {"passed", "failed"} and not validation.get("result"):
@@ -178,6 +196,28 @@ def validate_packet(packet: dict[str, Any]) -> list[str]:
                 + ", ".join(active)
             )
     return errors
+
+
+def _check_diff_evidence_path(packet: dict[str, Any]) -> list[str]:
+    """Fail closed when a path-form candidate diff references no readable file.
+
+    The path form exists so lens dispatch carries a reference instead of the
+    complete diff, which means the file is the evidence. An absent or empty
+    file is therefore missing review evidence — the same condition an absent
+    inline `content` reports — and not a candidate with a smaller diff. The
+    emptiness bar mirrors the inline form's `minLength: 1` exactly so neither
+    form is stricter than the other.
+    """
+    diff = packet.get("candidate", {}).get("diff")
+    location = diff.get("path") if isinstance(diff, dict) else None
+    if not location:
+        return []
+    evidence = Path(location)
+    if not evidence.is_file():
+        return ["$.candidate.diff.path: referenced diff evidence file is missing"]
+    if evidence.stat().st_size == 0:
+        return ["$.candidate.diff.path: referenced diff evidence file is empty"]
+    return []
 
 
 def validate_result(result: dict[str, Any]) -> list[str]:

--- a/skills/review-fix-loop/references/review-suite/CONTRACT.md
+++ b/skills/review-fix-loop/references/review-suite/CONTRACT.md
@@ -55,7 +55,7 @@ Required packet sections are:
 
 1. `repository`: repository identity and base branch.
 2. `candidate`: the captured head, the comparison base or merge base, and the
-   complete candidate diff.
+   complete candidate diff in one of the two forms below.
 3. `change_contract`: observable goal, non-empty acceptance criteria, explicit
    non-goals, and behavior or invariants to preserve.
 4. `sources`: applicable repository instructions, named design or contract
@@ -72,8 +72,32 @@ on it. Optional `base_drift` records why evidence was retained or reset after
 the base advanced.
 
 Do not infer missing intent. Missing repository identity, goal, acceptance
-criteria, candidate identity, a complete diff, or required validation evidence
-prevents a trustworthy review and must yield a `blocked` result.
+criteria, candidate identity, a complete diff in either form below, or required
+validation evidence prevents a trustworthy review and must yield a `blocked`
+result.
+
+### The candidate diff: inline or referenced by path
+
+`candidate.diff` carries the complete diff in exactly one of two forms:
+
+- **inline** — `content` holds the unified diff itself; and
+- **referenced** — `path` holds the location of a file whose content is that
+  diff.
+
+The forms are mutually exclusive: a diff object carrying both or neither is
+malformed. Both assert `complete: true` and mean the same thing to a lens — the
+reviewed candidate is the whole diff, never a summary of it.
+
+A packet builder that writes the diff to a file writes it **outside the
+candidate worktree**. Evidence written inside the worktree registers as a
+candidate mutation and fails the before/after integrity check that proves the
+review was read-only, so keeping the evidence elsewhere is what keeps that check
+trivially satisfied rather than something the builder must exempt itself from.
+
+A referenced file that is absent or empty is missing review evidence, exactly as
+an absent inline `content` is: `scripts/validate.py` fails closed on it and the
+review yields `blocked`. Never read an unreadable reference as a candidate whose
+diff is merely smaller.
 
 ## Finding semantics
 

--- a/skills/review-fix-loop/references/review-suite/CONTRACT.md
+++ b/skills/review-fix-loop/references/review-suite/CONTRACT.md
@@ -89,10 +89,16 @@ malformed. Both assert `complete: true` and mean the same thing to a lens — th
 reviewed candidate is the whole diff, never a summary of it.
 
 A packet builder that writes the diff to a file writes it **outside the
-candidate worktree**. Evidence written inside the worktree registers as a
-candidate mutation and fails the before/after integrity check that proves the
-review was read-only, so keeping the evidence elsewhere is what keeps that check
-trivially satisfied rather than something the builder must exempt itself from.
+candidate worktree**, and records an **absolute** path. Evidence written inside
+the worktree registers as a candidate mutation and fails the before/after
+integrity check that proves the review was read-only, so keeping the evidence
+elsewhere is what keeps that check trivially satisfied rather than something the
+builder must exempt itself from. A relative path is rejected because the builder
+and every lens revalidate the same packet from their own working directories: a
+relative reference either reports evidence absent that exists, or resolves to a
+different file of the same name and binds a lens to a diff that is not the
+candidate's — a substitution no candidate-identity check can catch, because
+those compare SHAs and never the diff's provenance.
 
 A referenced file that is absent or empty is missing review evidence, exactly as
 an absent inline `content` is: `scripts/validate.py` fails closed on it and the

--- a/skills/review-fix-loop/references/review-suite/review-packet.schema.json
+++ b/skills/review-fix-loop/references/review-suite/review-packet.schema.json
@@ -36,14 +36,28 @@
           "pattern": "^[0-9a-f]{40}$"
         },
         "diff": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["format", "complete", "content"],
-          "properties": {
-            "format": {"enum": ["unified_diff"]},
-            "complete": {"const": true},
-            "content": {"type": "string", "minLength": 1}
-          }
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["format", "complete", "content"],
+              "properties": {
+                "format": {"enum": ["unified_diff"]},
+                "complete": {"const": true},
+                "content": {"type": "string", "minLength": 1}
+              }
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["format", "complete", "path"],
+              "properties": {
+                "format": {"enum": ["unified_diff"]},
+                "complete": {"const": true},
+                "path": {"type": "string", "minLength": 1}
+              }
+            }
+          ]
         }
       }
     },

--- a/skills/review-fix-loop/references/review-suite/validate.py
+++ b/skills/review-fix-loop/references/review-suite/validate.py
@@ -67,6 +67,10 @@ BLOCKABLE_PACKET_ERROR_PATTERNS = (
         r"(missing|empty)$"
     ),
     re.compile(
+        r"^\$\.candidate\.diff\.path: referenced diff evidence file must be an "
+        r"absolute path$"
+    ),
+    re.compile(
         r"^\$\.change_contract: missing required property "
         r"'(goal|acceptance_criteria|non_goals|preserved_behaviors)'$"
     ),
@@ -207,12 +211,26 @@ def _check_diff_evidence_path(packet: dict[str, Any]) -> list[str]:
     inline `content` reports — and not a candidate with a smaller diff. The
     emptiness bar mirrors the inline form's `minLength: 1` exactly so neither
     form is stricter than the other.
+
+    The reference must be absolute. A relative path resolves against whatever
+    working directory happens to be current, and the builder and each lens
+    revalidate the same packet from different directories, so a relative
+    reference either reports absent evidence that exists or — worse — resolves
+    to a different file of the same name and binds a lens to a diff that is not
+    the candidate's. Candidate-identity checks compare SHAs and cannot detect
+    that substitution. This mirrors why `_schema_file` above resolves its own
+    schemas `__file__`-relative rather than from the current directory.
     """
     diff = packet.get("candidate", {}).get("diff")
     location = diff.get("path") if isinstance(diff, dict) else None
     if not location:
         return []
     evidence = Path(location)
+    if not evidence.is_absolute():
+        return [
+            "$.candidate.diff.path: referenced diff evidence file must be an "
+            "absolute path"
+        ]
     if not evidence.is_file():
         return ["$.candidate.diff.path: referenced diff evidence file is missing"]
     if evidence.stat().st_size == 0:

--- a/skills/review-fix-loop/references/review-suite/validate.py
+++ b/skills/review-fix-loop/references/review-suite/validate.py
@@ -58,10 +58,14 @@ BLOCKABLE_PACKET_ERROR_PATTERNS = (
     ),
     re.compile(
         r"^\$\.candidate\.diff: missing required property "
-        r"'(format|complete|content)'$"
+        r"'(format|complete|content|path)'$"
     ),
     re.compile(r"^\$\.candidate\.diff\.complete: expected constant True$"),
-    re.compile(r"^\$\.candidate\.diff\.content: string is too short$"),
+    re.compile(r"^\$\.candidate\.diff\.(content|path): string is too short$"),
+    re.compile(
+        r"^\$\.candidate\.diff\.path: referenced diff evidence file is "
+        r"(missing|empty)$"
+    ),
     re.compile(
         r"^\$\.change_contract: missing required property "
         r"'(goal|acceptance_criteria|non_goals|preserved_behaviors)'$"
@@ -105,6 +109,18 @@ def validate_schema(value: Any, schema: dict[str, Any], at: str = "$") -> list[s
     expected_type = schema.get("type")
     if expected_type and not _is_type(value, expected_type):
         return [f"{at}: expected {expected_type}"]
+
+    if branches := schema.get("oneOf"):
+        # Every `oneOf` in this repository's schemas has branches made mutually
+        # exclusive by `additionalProperties: false`, so no value can satisfy
+        # two of them and a match by any branch is the match. On failure,
+        # report the closest branch's own errors instead of a generic
+        # "no form matched": the caller needs the actionable message for the
+        # form it was evidently aiming at, and BLOCKABLE_PACKET_ERROR_PATTERNS
+        # is written against those exact messages.
+        attempts = [validate_schema(value, branch, at) for branch in branches]
+        if all(attempts):
+            errors.extend(min(attempts, key=len))
 
     if "const" in schema:
         const = schema["const"]
@@ -150,6 +166,8 @@ def validate_packet(packet: dict[str, Any]) -> list[str]:
     if errors:
         return errors
 
+    errors.extend(_check_diff_evidence_path(packet))
+
     for index, validation in enumerate(packet.get("validation", [])):
         status = validation.get("status")
         if status in {"passed", "failed"} and not validation.get("result"):
@@ -178,6 +196,28 @@ def validate_packet(packet: dict[str, Any]) -> list[str]:
                 + ", ".join(active)
             )
     return errors
+
+
+def _check_diff_evidence_path(packet: dict[str, Any]) -> list[str]:
+    """Fail closed when a path-form candidate diff references no readable file.
+
+    The path form exists so lens dispatch carries a reference instead of the
+    complete diff, which means the file is the evidence. An absent or empty
+    file is therefore missing review evidence — the same condition an absent
+    inline `content` reports — and not a candidate with a smaller diff. The
+    emptiness bar mirrors the inline form's `minLength: 1` exactly so neither
+    form is stricter than the other.
+    """
+    diff = packet.get("candidate", {}).get("diff")
+    location = diff.get("path") if isinstance(diff, dict) else None
+    if not location:
+        return []
+    evidence = Path(location)
+    if not evidence.is_file():
+        return ["$.candidate.diff.path: referenced diff evidence file is missing"]
+    if evidence.stat().st_size == 0:
+        return ["$.candidate.diff.path: referenced diff evidence file is empty"]
+    return []
 
 
 def validate_result(result: dict[str, Any]) -> list[str]:

--- a/skills/review-solution-simplicity/references/review-suite/CONTRACT.md
+++ b/skills/review-solution-simplicity/references/review-suite/CONTRACT.md
@@ -55,7 +55,7 @@ Required packet sections are:
 
 1. `repository`: repository identity and base branch.
 2. `candidate`: the captured head, the comparison base or merge base, and the
-   complete candidate diff.
+   complete candidate diff in one of the two forms below.
 3. `change_contract`: observable goal, non-empty acceptance criteria, explicit
    non-goals, and behavior or invariants to preserve.
 4. `sources`: applicable repository instructions, named design or contract
@@ -72,8 +72,32 @@ on it. Optional `base_drift` records why evidence was retained or reset after
 the base advanced.
 
 Do not infer missing intent. Missing repository identity, goal, acceptance
-criteria, candidate identity, a complete diff, or required validation evidence
-prevents a trustworthy review and must yield a `blocked` result.
+criteria, candidate identity, a complete diff in either form below, or required
+validation evidence prevents a trustworthy review and must yield a `blocked`
+result.
+
+### The candidate diff: inline or referenced by path
+
+`candidate.diff` carries the complete diff in exactly one of two forms:
+
+- **inline** — `content` holds the unified diff itself; and
+- **referenced** — `path` holds the location of a file whose content is that
+  diff.
+
+The forms are mutually exclusive: a diff object carrying both or neither is
+malformed. Both assert `complete: true` and mean the same thing to a lens — the
+reviewed candidate is the whole diff, never a summary of it.
+
+A packet builder that writes the diff to a file writes it **outside the
+candidate worktree**. Evidence written inside the worktree registers as a
+candidate mutation and fails the before/after integrity check that proves the
+review was read-only, so keeping the evidence elsewhere is what keeps that check
+trivially satisfied rather than something the builder must exempt itself from.
+
+A referenced file that is absent or empty is missing review evidence, exactly as
+an absent inline `content` is: `scripts/validate.py` fails closed on it and the
+review yields `blocked`. Never read an unreadable reference as a candidate whose
+diff is merely smaller.
 
 ## Finding semantics
 

--- a/skills/review-solution-simplicity/references/review-suite/CONTRACT.md
+++ b/skills/review-solution-simplicity/references/review-suite/CONTRACT.md
@@ -89,10 +89,16 @@ malformed. Both assert `complete: true` and mean the same thing to a lens — th
 reviewed candidate is the whole diff, never a summary of it.
 
 A packet builder that writes the diff to a file writes it **outside the
-candidate worktree**. Evidence written inside the worktree registers as a
-candidate mutation and fails the before/after integrity check that proves the
-review was read-only, so keeping the evidence elsewhere is what keeps that check
-trivially satisfied rather than something the builder must exempt itself from.
+candidate worktree**, and records an **absolute** path. Evidence written inside
+the worktree registers as a candidate mutation and fails the before/after
+integrity check that proves the review was read-only, so keeping the evidence
+elsewhere is what keeps that check trivially satisfied rather than something the
+builder must exempt itself from. A relative path is rejected because the builder
+and every lens revalidate the same packet from their own working directories: a
+relative reference either reports evidence absent that exists, or resolves to a
+different file of the same name and binds a lens to a diff that is not the
+candidate's — a substitution no candidate-identity check can catch, because
+those compare SHAs and never the diff's provenance.
 
 A referenced file that is absent or empty is missing review evidence, exactly as
 an absent inline `content` is: `scripts/validate.py` fails closed on it and the

--- a/skills/review-solution-simplicity/references/review-suite/review-packet.schema.json
+++ b/skills/review-solution-simplicity/references/review-suite/review-packet.schema.json
@@ -36,14 +36,28 @@
           "pattern": "^[0-9a-f]{40}$"
         },
         "diff": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["format", "complete", "content"],
-          "properties": {
-            "format": {"enum": ["unified_diff"]},
-            "complete": {"const": true},
-            "content": {"type": "string", "minLength": 1}
-          }
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["format", "complete", "content"],
+              "properties": {
+                "format": {"enum": ["unified_diff"]},
+                "complete": {"const": true},
+                "content": {"type": "string", "minLength": 1}
+              }
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["format", "complete", "path"],
+              "properties": {
+                "format": {"enum": ["unified_diff"]},
+                "complete": {"const": true},
+                "path": {"type": "string", "minLength": 1}
+              }
+            }
+          ]
         }
       }
     },

--- a/skills/review-solution-simplicity/references/review-suite/validate.py
+++ b/skills/review-solution-simplicity/references/review-suite/validate.py
@@ -67,6 +67,10 @@ BLOCKABLE_PACKET_ERROR_PATTERNS = (
         r"(missing|empty)$"
     ),
     re.compile(
+        r"^\$\.candidate\.diff\.path: referenced diff evidence file must be an "
+        r"absolute path$"
+    ),
+    re.compile(
         r"^\$\.change_contract: missing required property "
         r"'(goal|acceptance_criteria|non_goals|preserved_behaviors)'$"
     ),
@@ -207,12 +211,26 @@ def _check_diff_evidence_path(packet: dict[str, Any]) -> list[str]:
     inline `content` reports — and not a candidate with a smaller diff. The
     emptiness bar mirrors the inline form's `minLength: 1` exactly so neither
     form is stricter than the other.
+
+    The reference must be absolute. A relative path resolves against whatever
+    working directory happens to be current, and the builder and each lens
+    revalidate the same packet from different directories, so a relative
+    reference either reports absent evidence that exists or — worse — resolves
+    to a different file of the same name and binds a lens to a diff that is not
+    the candidate's. Candidate-identity checks compare SHAs and cannot detect
+    that substitution. This mirrors why `_schema_file` above resolves its own
+    schemas `__file__`-relative rather than from the current directory.
     """
     diff = packet.get("candidate", {}).get("diff")
     location = diff.get("path") if isinstance(diff, dict) else None
     if not location:
         return []
     evidence = Path(location)
+    if not evidence.is_absolute():
+        return [
+            "$.candidate.diff.path: referenced diff evidence file must be an "
+            "absolute path"
+        ]
     if not evidence.is_file():
         return ["$.candidate.diff.path: referenced diff evidence file is missing"]
     if evidence.stat().st_size == 0:

--- a/skills/review-solution-simplicity/references/review-suite/validate.py
+++ b/skills/review-solution-simplicity/references/review-suite/validate.py
@@ -58,10 +58,14 @@ BLOCKABLE_PACKET_ERROR_PATTERNS = (
     ),
     re.compile(
         r"^\$\.candidate\.diff: missing required property "
-        r"'(format|complete|content)'$"
+        r"'(format|complete|content|path)'$"
     ),
     re.compile(r"^\$\.candidate\.diff\.complete: expected constant True$"),
-    re.compile(r"^\$\.candidate\.diff\.content: string is too short$"),
+    re.compile(r"^\$\.candidate\.diff\.(content|path): string is too short$"),
+    re.compile(
+        r"^\$\.candidate\.diff\.path: referenced diff evidence file is "
+        r"(missing|empty)$"
+    ),
     re.compile(
         r"^\$\.change_contract: missing required property "
         r"'(goal|acceptance_criteria|non_goals|preserved_behaviors)'$"
@@ -105,6 +109,18 @@ def validate_schema(value: Any, schema: dict[str, Any], at: str = "$") -> list[s
     expected_type = schema.get("type")
     if expected_type and not _is_type(value, expected_type):
         return [f"{at}: expected {expected_type}"]
+
+    if branches := schema.get("oneOf"):
+        # Every `oneOf` in this repository's schemas has branches made mutually
+        # exclusive by `additionalProperties: false`, so no value can satisfy
+        # two of them and a match by any branch is the match. On failure,
+        # report the closest branch's own errors instead of a generic
+        # "no form matched": the caller needs the actionable message for the
+        # form it was evidently aiming at, and BLOCKABLE_PACKET_ERROR_PATTERNS
+        # is written against those exact messages.
+        attempts = [validate_schema(value, branch, at) for branch in branches]
+        if all(attempts):
+            errors.extend(min(attempts, key=len))
 
     if "const" in schema:
         const = schema["const"]
@@ -150,6 +166,8 @@ def validate_packet(packet: dict[str, Any]) -> list[str]:
     if errors:
         return errors
 
+    errors.extend(_check_diff_evidence_path(packet))
+
     for index, validation in enumerate(packet.get("validation", [])):
         status = validation.get("status")
         if status in {"passed", "failed"} and not validation.get("result"):
@@ -178,6 +196,28 @@ def validate_packet(packet: dict[str, Any]) -> list[str]:
                 + ", ".join(active)
             )
     return errors
+
+
+def _check_diff_evidence_path(packet: dict[str, Any]) -> list[str]:
+    """Fail closed when a path-form candidate diff references no readable file.
+
+    The path form exists so lens dispatch carries a reference instead of the
+    complete diff, which means the file is the evidence. An absent or empty
+    file is therefore missing review evidence — the same condition an absent
+    inline `content` reports — and not a candidate with a smaller diff. The
+    emptiness bar mirrors the inline form's `minLength: 1` exactly so neither
+    form is stricter than the other.
+    """
+    diff = packet.get("candidate", {}).get("diff")
+    location = diff.get("path") if isinstance(diff, dict) else None
+    if not location:
+        return []
+    evidence = Path(location)
+    if not evidence.is_file():
+        return ["$.candidate.diff.path: referenced diff evidence file is missing"]
+    if evidence.stat().st_size == 0:
+        return ["$.candidate.diff.path: referenced diff evidence file is empty"]
+    return []
 
 
 def validate_result(result: dict[str, Any]) -> list[str]:


### PR DESCRIPTION
## Outcome

Review-packet diff evidence and epic child dispatch are delivered as files instead of inlined context — the reviewer and the dispatched worker read artifacts they can open for themselves, rather than being handed a copy in the prompt.

Ported with attribution from superpowers' `subagent-driven-development` fresh-context construction, already recorded as that skill's secondary entry in the named-peer registry.

## What changed

**Review packet.** `candidate.diff` becomes a schema `oneOf`: the existing inline unified-diff string, or an evidence-path object naming a file whose content is that diff. The packet builder writes the complete diff **outside** the candidate worktree and records an absolute path, so the existing before/after read-only integrity check stays trivially satisfied by construction rather than needing an exemption.

`validate.py` gains generic `oneOf` support — reporting the closest branch's own errors rather than a generic no-form-matched message, so every existing blockable-error pattern keeps matching — and fails closed when a referenced diff file is absent, empty, or named by a relative path, classifying all three as missing review evidence so the review yields `blocked`.

**Dispatch prose.** Lens dispatch in `review-code-change` and the caller-side invocation prose in `implement-ticket`'s `references/review-and-merge-gates.md` hand the path; no inlined complete diff remains in either. The rule itself is stated once, in `review-suite/CONTRACT.md`, and referenced from the seam.

**Epic dispatch.** `implement-epic` gains file-based child-dispatch artifacts under `.implement-epic/` — a brief file as the single source of a child's requirements and a per-dispatch report the executing context appends to — plus the no-pasted-history rule. The directory sits at the coordinator's working root outside every candidate worktree and the paths are absolute, because the executing context owns a different worktree.

**Delegated execution is deliberately out of the mandate.** The coordinator is contractually opaque and this repository cannot bind its prompt format, so `implement-ticket`'s delegated-worker paragraph carries the rule as recommend-only prose that never returns `blocked` for its absence. `references/delegated-execution/CONTRACT.md` is unchanged.

## Acceptance criteria

- [x] Lens dispatch and the review-and-merge-gates invocation prose reference the diff by path; no inlined complete diff remains in either.
- [x] The schema `oneOf` validates both forms; fail-closed on missing file; existing fixtures pass unmodified; bundled-contract drift tests (including `review-fix-loop`'s copy) pass; orchestration evals updated and green.
- [x] The integrity check still passes trivially — no writes inside the candidate worktree.
- [x] Brief/report conventions and the no-pasted-history rule appear in `implement-epic`'s dispatch prose; the recommend-only rule appears in `implement-ticket`'s delegated-worker paragraph.

## Non-goals honored

Finding/result schemas, verdict semantics, and lens rubrics are unchanged. The delegated-execution contract and its result schema are unchanged. Fixtures under `review-suite/fixtures/` and the eval strata stay inline and pass unmodified.

## Validation

`just format`, `just lint`, `just test` all pass at head `54b6e37`. All 12 suites green, including `review-suite` 335 and the bundled-contract drift tests. The twelve behavioral tests this change adds were each observed failing at base `73f1aa8` and passing at head.

## Review

Three full review cycles with the repository-owned suite; the final aggregate is `clean` across all three lenses, freshly executed against `54b6e37`.

Two findings from earlier cycles were real defects in this change and are fixed here:

1. `candidate.diff.path` originally resolved relative to the current working directory. Because the reference is now the sole binding between a lens and the diff it reviews, a packet could validate clean in the builder's directory *and* clean in a sibling directory holding an unrelated file of the same name — binding a lens to a diff that is not the candidate's, a substitution no candidate-identity check can catch since those compare SHAs and never provenance. Hence the absolute-path requirement.
2. The epic dispatch prose had the same cross-context hazard applied asymmetrically, and because the prompt deliberately does not restate the brief, an unresolvable path would dispatch a worker with no requirements at all while the prompt still looked complete.

One deferred finding is preserved without expanding this PR: `skills/implement-epic/.gitignore` follows `AGENTS.md` and the `skills/ready-ticket` precedent, but a skill-local ignore cannot cover a dot directory created at a target repository's root. That gap predates this change and equally affects `carve-changesets` and `ready-ticket`; it is a repository-wide convention question.

Fixes #130
