### PR TITLE
feat(implement-ticket): route not-ready blocked results to ready-ticket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ summary: Chronological history of repository and skill changes.
   orchestration eval case proving the fail-closed path, and twelve behavioral
   tests bound to the ticket's acceptance criteria, each observed failing at base
   `73f1aa8` and passing at head (`8f3f0adb7607ff1e4a880b224c8eff475c28fbb2`)
+
 - feat(skills): add the ready-ticket skill for peer-aware ticket authoring
   (issue #124, epic #118, the epic's first seam leaf) — add
   `skills/ready-ticket`, which turns a vague idea or an unready GitHub or Linear

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,31 @@ summary: Chronological history of repository and skill changes.
 
 # Changelog
 
-## 2026-08-04 — Authored `ready-ticket`, the first peer-aware seam skill, at the pipeline's upstream edge, then moved review-packet diff evidence and epic child dispatch onto files instead of inlined context
+## 2026-08-04 — Authored `ready-ticket`, the first peer-aware seam skill, at the pipeline's upstream edge and wired `implement-ticket`'s not-ready dead end into it as a recommendation edge, then moved review-packet diff evidence and epic child dispatch onto files instead of inlined context
+
+- feat(implement-ticket): route not-ready blocked results to ready-ticket (issue
+  #125, epic #118) — give `implement-ticket`'s not-ready `blocked` result a
+  sanctioned next step instead of a dead end. A ticket that fails the body-level
+  readiness conditions now returns `blocked` naming repository-owned
+  `ready-ticket` and carrying the stable marker
+  `implement-ticket:requires-ready-ticket:<tracker>:<ticket-id>`, in the same
+  form as the existing `requires-epic` marker, so contract tests can assert its
+  exact shape and a caller can detect a routing loop. The edge is a
+  **recommendation, not a dispatch**: `implement-ticket` never invokes
+  `ready-ticket`, never runs its elicitation, and never authors a body itself —
+  the caller decides — which is what keeps the authority boundary and the
+  readiness bar unchanged. It is one-way by construction, because `ready-ticket`
+  terminates in a ticket body and never invokes `implement-ticket`, so no cycle
+  can form; the incoming-marker check returns a routing-cycle `blocked` rather
+  than recommending again. Only body readiness carries the marker: an unresolved
+  native dependency, a missing prerequisite outcome, an absent authority, or a
+  competing canonical candidate keeps its own blocked reason, because
+  `ready-ticket` cannot repair any of those. Both dependency-documentation
+  surfaces — the README chain and `implement-ticket`'s own dependency prose —
+  now render the recommendation as a dashed `┈▷` edge annotated "recommendation
+  only, never invoked", with solid edges reserved for invocation. Also corrects
+  the README's plugin-installation count from nine skills to ten, stale since
+  `ready-ticket` landed earlier today
 
 - feat(review-suite,skills): deliver review-packet and epic-dispatch context via
   files instead of inlined context (issue #130, epic #119, the epic's only
@@ -57,8 +81,7 @@ summary: Chronological history of repository and skill changes.
   that skill's secondary registry entry. Adds a `missing-diff-evidence-file`
   orchestration eval case proving the fail-closed path, and twelve behavioral
   tests bound to the ticket's acceptance criteria, each observed failing at base
-  `73f1aa8` and passing at head
-
+  `73f1aa8` and passing at head (`8f3f0adb7607ff1e4a880b224c8eff475c28fbb2`)
 - feat(skills): add the ready-ticket skill for peer-aware ticket authoring
   (issue #124, epic #118, the epic's first seam leaf) — add
   `skills/ready-ticket`, which turns a vague idea or an unready GitHub or Linear

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,10 @@ summary: Chronological history of repository and skill changes.
   `ready-ticket` cannot repair any of those. Both dependency-documentation
   surfaces — the README chain and `implement-ticket`'s own dependency prose —
   now render the recommendation as a dashed `┈▷` edge annotated "recommendation
-  only, never invoked", with solid edges reserved for invocation. Also corrects
-  the README's plugin-installation count from nine skills to ten, stale since
-  `ready-ticket` landed earlier today
+  only, never invoked", with solid edges reserved for invocation and the diagram
+  legend pointing at the owning section rather than restating its rules. Also
+  corrects the README's plugin-installation count from nine skills to ten, stale
+  since `ready-ticket` landed earlier today
 
 - feat(review-suite,skills): deliver review-packet and epic-dispatch context via
   files instead of inlined context (issue #130, epic #119, the epic's only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,15 @@ summary: Chronological history of repository and skill changes.
   form as the existing `requires-epic` marker, so contract tests can assert its
   exact shape and a caller can detect a routing loop. The edge is a
   **recommendation, not a dispatch**: `implement-ticket` never invokes
-  `ready-ticket`, never runs its elicitation, and never authors a body itself —
-  the caller decides — which is what keeps the authority boundary and the
-  readiness bar unchanged. It is one-way by construction, because `ready-ticket`
-  terminates in a ticket body and never invokes `implement-ticket`, so no cycle
-  can form; the incoming-marker check returns a routing-cycle `blocked` rather
-  than recommending again. Only body readiness carries the marker: an unresolved
+  `ready-ticket` and never runs its elicitation — the caller decides. The
+  readiness bar itself is untouched, and so is the gate's existing remediation:
+  when ticket editing is authorized and the gap is not a product, data,
+  authorization, migration, destructive, or architecture decision, the skill
+  still repairs the body in place and continues, and only the other branch emits
+  the marker. It is one-way by construction, because `ready-ticket` terminates
+  in a ticket body and never invokes `implement-ticket`, so no cycle can form;
+  the incoming-marker check returns a routing-cycle `blocked` rather than
+  recommending again. Only body readiness carries the marker: an unresolved
   native dependency, a missing prerequisite outcome, an absent authority, or a
   competing canonical candidate keeps its own blocked reason, because
   `ready-ticket` cannot repair any of those. Both dependency-documentation

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A personal monorepo for agent skills and supporting scripts.
 
 ## Installation
 
-Install the plugin when you need any composed workflow. It packages all nine
+Install the plugin when you need any composed workflow. It packages all ten
 skills together so stable-name dependencies such as `implement-ticket`,
 `review-code-change`, and `babysit-pr` are available in the same fresh session.
 
@@ -111,16 +111,26 @@ implement-epic
     ├── review-code-change          # initial candidate review
     ├── babysit-pr                  # ordinary single-PR lifecycle
     │   └── review-code-change      # after a head-changing fix
-    └── carve-changesets            # authority-gated oversized path
-        ├── review-code-change      # each exact changeset
-        └── babysit-pr              # each changeset PR lifecycle
-            └── review-code-change  # after a head-changing fix
+    ├── carve-changesets            # authority-gated oversized path
+    │   ├── review-code-change      # each exact changeset
+    │   └── babysit-pr              # each changeset PR lifecycle
+    │       └── review-code-change  # after a head-changing fix
+    ┊
+    ┈▷ ready-ticket                 # recommendation only, never invoked
 
 carve-changesets
 ├── review-code-change              # direct per-changeset review
 └── babysit-pr                      # each published PR lifecycle
     └── review-code-change          # after a head-changing fix
 ```
+
+Solid edges are invocation. The single dashed edge is a recommendation:
+`implement-ticket` names `ready-ticket` in a not-ready `blocked` result,
+carrying the marker
+`implement-ticket:requires-ready-ticket:<tracker>:<ticket-id>`, and the caller
+decides whether to run it. Nothing invokes `ready-ticket` automatically, and
+`ready-ticket` never invokes `implement-ticket`, so the recommendation cannot
+close a cycle.
 
 Compatible runtimes may provide named subagents or equivalent isolated
 implementation and review contexts. Files under each skill's `agents/` directory

--- a/skills/implement-ticket/SKILL.md
+++ b/skills/implement-ticket/SKILL.md
@@ -345,10 +345,10 @@ destructive, or architecture decision — is not a dead end. Two checkable facts
 decide the branch: whether ticket editing is authorized, and whether closing the
 gap would decide something this skill may not decide.
 
-- **Ticket editing is authorized and the gap is not a product, data,
-  authorization, migration, destructive, or architecture decision.** The
-  preceding paragraph governs unchanged: make the ticket implementation-ready,
-  re-read it, and continue. Do not return `blocked` and do not emit the marker.
+- **Ticket editing is authorized and the gap is not one of those decisions.**
+  The preceding paragraph governs unchanged: make the ticket
+  implementation-ready, re-read it, and continue. Do not return `blocked` and do
+  not emit the marker.
 - **Otherwise** — ticket editing is unauthorized, or the gap is one of those
   decisions this skill may not make for the requester. Return `blocked` and name
   repository-owned `ready-ticket` as the remediation path, including the stable

--- a/skills/implement-ticket/SKILL.md
+++ b/skills/implement-ticket/SKILL.md
@@ -241,11 +241,18 @@ implement-epic
     ├── review-code-change          # initial candidate review
     ├── babysit-pr                  # ordinary single-PR lifecycle
     │   └── review-code-change      # after a head-changing fix
-    └── carve-changesets            # authority-gated oversized path
-        ├── review-code-change      # each exact changeset
-        └── babysit-pr              # each changeset PR lifecycle
-            └── review-code-change  # after a head-changing fix
+    ├── carve-changesets            # authority-gated oversized path
+    │   ├── review-code-change      # each exact changeset
+    │   └── babysit-pr              # each changeset PR lifecycle
+    │       └── review-code-change  # after a head-changing fix
+    ┊
+    ┈▷ ready-ticket                 # recommendation only, never invoked
 ```
+
+Solid edges are invocation. The dashed edge to `ready-ticket` is a
+recommendation this skill names in a not-ready `blocked` result and never calls;
+it is one-way, because `ready-ticket` terminates in a ticket body and never
+invokes `implement-ticket`.
 
 `babysit-pr` and `carve-changesets` must never invoke `implement-ticket`.
 `carve-changesets` must never invoke `implement-epic`. Do not re-enter this
@@ -328,6 +335,30 @@ available post-merge verification and tracker authority.
 When ticket editing is authorized, make an unclear ticket implementation-ready
 and re-read it. Otherwise stop with the missing decision rather than
 improvising.
+
+### Route a not-ready ticket to `ready-ticket`
+
+A ticket that fails the body-level conditions above — a missing observable goal,
+absent or unusable acceptance criteria, no non-goals or preserved behavior, no
+required verification, or an unresolved product, data, authorization, migration,
+destructive, or architecture decision — is not a dead end. Return `blocked` and
+name repository-owned `ready-ticket` as the remediation path, including the
+stable marker `implement-ticket:requires-ready-ticket:<tracker>:<ticket-id>`.
+
+This is a recommendation, not a dispatch. Never invoke `ready-ticket`, run its
+elicitation, or author the ticket body from inside this skill; the caller
+decides whether to run it. Report which body-level conditions failed so the
+caller hands `ready-ticket` a concrete gap rather than the whole ticket.
+
+The edge is one-way by construction: `ready-ticket` terminates in a ticket body
+and must never invoke `implement-ticket`, so the recommendation cannot form a
+cycle. If the incoming handoff already carries this same marker, return
+`blocked` with a routing-cycle reason instead of recommending it again.
+
+A blocker other than body readiness — an unresolved native dependency, a missing
+prerequisite outcome, an absent authority, or a competing canonical candidate —
+keeps its own `blocked` reason and does not carry this marker. `ready-ticket`
+cannot repair any of those.
 
 ## Execute one ticket
 

--- a/skills/implement-ticket/SKILL.md
+++ b/skills/implement-ticket/SKILL.md
@@ -341,14 +341,23 @@ improvising.
 A ticket that fails the body-level conditions above — a missing observable goal,
 absent or unusable acceptance criteria, no non-goals or preserved behavior, no
 required verification, or an unresolved product, data, authorization, migration,
-destructive, or architecture decision — is not a dead end. Return `blocked` and
-name repository-owned `ready-ticket` as the remediation path, including the
-stable marker `implement-ticket:requires-ready-ticket:<tracker>:<ticket-id>`.
+destructive, or architecture decision — is not a dead end. Two checkable facts
+decide the branch: whether ticket editing is authorized, and whether closing the
+gap would decide something this skill may not decide.
 
-This is a recommendation, not a dispatch. Never invoke `ready-ticket`, run its
-elicitation, or author the ticket body from inside this skill; the caller
-decides whether to run it. Report which body-level conditions failed so the
-caller hands `ready-ticket` a concrete gap rather than the whole ticket.
+- **Ticket editing is authorized and the gap is not a product, data,
+  authorization, migration, destructive, or architecture decision.** The
+  preceding paragraph governs unchanged: make the ticket implementation-ready,
+  re-read it, and continue. Do not return `blocked` and do not emit the marker.
+- **Otherwise** — ticket editing is unauthorized, or the gap is one of those
+  decisions this skill may not make for the requester. Return `blocked` and name
+  repository-owned `ready-ticket` as the remediation path, including the stable
+  marker `implement-ticket:requires-ready-ticket:<tracker>:<ticket-id>`.
+
+This is a recommendation, not a dispatch. Never invoke `ready-ticket` or run its
+elicitation from inside this skill; the caller decides whether to run it. Report
+which body-level conditions failed so the caller hands `ready-ticket` a concrete
+gap rather than the whole ticket.
 
 The edge is one-way by construction: `ready-ticket` terminates in a ticket body
 and must never invoke `implement-ticket`, so the recommendation cannot form a

--- a/skills/implement-ticket/SKILL.md
+++ b/skills/implement-ticket/SKILL.md
@@ -336,12 +336,11 @@ improvising.
 
 ### Route a not-ready ticket to `ready-ticket`
 
-A ticket that fails the body-level conditions above — a missing observable goal,
-absent or unusable acceptance criteria, no non-goals or preserved behavior, no
-required verification, or an unresolved product, data, authorization, migration,
-destructive, or architecture decision — is not a dead end. Two checkable facts
-decide the branch: whether ticket editing is authorized, and whether closing the
-gap would decide something this skill may not decide.
+A ticket that fails the body-level conditions above — including an unresolved
+product, data, authorization, migration, destructive, or architecture decision —
+is not a dead end. Two checkable facts decide the branch: whether ticket editing
+is authorized, and whether closing the gap would decide something this skill may
+not decide.
 
 - **Ticket editing is authorized and the gap is not one of those decisions.**
   The preceding paragraph governs unchanged: make the ticket

--- a/skills/implement-ticket/SKILL.md
+++ b/skills/implement-ticket/SKILL.md
@@ -249,10 +249,8 @@ implement-epic
     ┈▷ ready-ticket                 # recommendation only, never invoked
 ```
 
-Solid edges are invocation. The dashed edge to `ready-ticket` is a
-recommendation this skill names in a not-ready `blocked` result and never calls;
-it is one-way, because `ready-ticket` terminates in a ticket body and never
-invokes `implement-ticket`.
+Solid edges are invocation. The dashed edge is a recommendation, governed by
+[Route a not-ready ticket to `ready-ticket`](#route-a-not-ready-ticket-to-ready-ticket).
 
 `babysit-pr` and `carve-changesets` must never invoke `implement-ticket`.
 `carve-changesets` must never invoke `implement-epic`. Do not re-enter this

--- a/skills/implement-ticket/scripts/tests/test_implement_ticket_contract.py
+++ b/skills/implement-ticket/scripts/tests/test_implement_ticket_contract.py
@@ -142,6 +142,15 @@ class ImplementTicketContractTests(unittest.TestCase):
         )
         self.assertIn("`ready-ticket` cannot repair any of those", self.skill_compact)
 
+    def test_each_recommendation_edge_rule_has_exactly_one_owner(self):
+        """One owner per rule, so a later narrowing cannot strand a stale copy."""
+        self.assertEqual(1, self.skill_compact.count("Never invoke `ready-ticket`"))
+        self.assertEqual(1, self.skill_compact.count("terminates in a ticket body"))
+        # The diagram legend points at the owning section instead of restating it.
+        self.assertIn(
+            "The dashed edge is a recommendation, governed by", self.skill_compact
+        )
+
     def test_dependency_surfaces_annotate_the_recommendation_edge(self):
         readme = compact(read(REPOSITORY_ROOT / "README.md"))
         for surface in (self.skill_compact, readme):

--- a/skills/implement-ticket/scripts/tests/test_implement_ticket_contract.py
+++ b/skills/implement-ticket/scripts/tests/test_implement_ticket_contract.py
@@ -98,6 +98,44 @@ class ImplementTicketContractTests(unittest.TestCase):
         self.assertIn("routing cycle detected", self.all_contract)
         self.assertIn("implement-epic", self.skill_compact)
 
+    def test_not_ready_routing_marker_and_cycle_guard_are_stable(self):
+        self.assertIn(
+            "implement-ticket:requires-ready-ticket:<tracker>:<ticket-id>",
+            self.all_contract,
+        )
+        self.assertIn("ready-ticket", self.skill_compact)
+        self.assertIn(
+            "routing-cycle reason instead of recommending it", self.skill_compact
+        )
+
+    def test_ready_ticket_is_recommended_and_never_invoked(self):
+        """The new edge is a recommendation, so no cycle and no implicit dispatch."""
+        for required in (
+            "This is a recommendation, not a dispatch",
+            "Never invoke `ready-ticket`, run its elicitation, or author the ticket "
+            "body from inside this skill",
+            "the caller decides whether to run it",
+            "`ready-ticket` terminates in a ticket body and must never invoke "
+            "`implement-ticket`",
+        ):
+            self.assertIn(required, self.skill_compact)
+
+    def test_only_body_readiness_carries_the_ready_ticket_marker(self):
+        self.assertIn(
+            "keeps its own `blocked` reason and does not carry this marker",
+            self.skill_compact,
+        )
+        self.assertIn("`ready-ticket` cannot repair any of those", self.skill_compact)
+
+    def test_dependency_surfaces_annotate_the_recommendation_edge(self):
+        readme = compact(read(REPOSITORY_ROOT / "README.md"))
+        for surface in (self.skill_compact, readme):
+            self.assertIn("┈▷ ready-ticket", surface)
+            self.assertIn("recommendation only, never invoked", surface)
+        self.assertIn("Solid edges are invocation", self.skill_compact)
+        self.assertIn("Solid edges are invocation", readme)
+        self.assertIn("cannot close a cycle", readme)
+
     def test_dependency_names_are_repository_owned_and_acyclic(self):
         self.assertIn("review-code-change", self.skill_compact)
         self.assertIn("babysit-pr", self.skill_compact)

--- a/skills/implement-ticket/scripts/tests/test_implement_ticket_contract.py
+++ b/skills/implement-ticket/scripts/tests/test_implement_ticket_contract.py
@@ -112,13 +112,28 @@ class ImplementTicketContractTests(unittest.TestCase):
         """The new edge is a recommendation, so no cycle and no implicit dispatch."""
         for required in (
             "This is a recommendation, not a dispatch",
-            "Never invoke `ready-ticket`, run its elicitation, or author the ticket "
-            "body from inside this skill",
+            "Never invoke `ready-ticket` or run its elicitation from inside this skill",
             "the caller decides whether to run it",
             "`ready-ticket` terminates in a ticket body and must never invoke "
             "`implement-ticket`",
         ):
             self.assertIn(required, self.skill_compact)
+
+    def test_authorized_body_repair_survives_the_new_routing_branch(self):
+        """Routing must not silently narrow the pre-existing readiness remediation."""
+        self.assertIn(
+            "When ticket editing is authorized, make an unclear ticket "
+            "implementation-ready and re-read it",
+            self.skill_compact,
+        )
+        for required in (
+            "Two checkable facts decide the branch",
+            "The preceding paragraph governs unchanged",
+            "Do not return `blocked` and do not emit the marker",
+        ):
+            self.assertIn(required, self.skill_compact)
+        # The prohibition must not reach the authorized repair the gate already allows.
+        self.assertNotIn("or author the ticket body from inside", self.skill_compact)
 
     def test_only_body_readiness_carries_the_ready_ticket_marker(self):
         self.assertIn(


### PR DESCRIPTION
## Summary

`implement-ticket` refuses an unready ticket and, until now, said nothing about what to do next — a dead end at the pipeline's upstream edge. [#124](https://github.com/shaug/agent-scripts/issues/124) landed `ready-ticket`; this connects the two.

A ticket that fails the body-level readiness conditions now returns `blocked` naming repository-owned `ready-ticket` and carrying the stable marker `implement-ticket:requires-ready-ticket:<tracker>:<ticket-id>`, in the same form as the existing `requires-epic` marker.

## The edge is a recommendation, not a dispatch

`implement-ticket` never invokes `ready-ticket` and never runs its elicitation — the caller decides. That is what keeps the authority boundary intact.

It is one-way by construction: `ready-ticket` terminates in a ticket body and never invokes `implement-ticket`, so no cycle can form. The incoming-marker check returns a routing-cycle `blocked` rather than recommending again. Verified against `skills/ready-ticket/SKILL.md` at head, whose only mention of `implement-ticket` is definitional.

## The readiness bar is unchanged

Two checkable facts decide the branch:

- **Ticket editing is authorized and the gap is not one of the decision classes** → the gate's pre-existing behavior governs unchanged: repair the body in place, re-read, continue. No `blocked`, no marker.
- **Otherwise** — editing unauthorized, or the gap is a product, data, authorization, migration, destructive, or architecture decision → `blocked` with the marker.

Only body readiness carries the marker. A native dependency, a missing prerequisite outcome, an absent authority, or a competing canonical candidate keeps its own blocked reason, because `ready-ticket` cannot repair any of those.

## Dependency surfaces

Both the README chain and `implement-ticket`'s own dependency prose render the recommendation as a dashed `┈▷` edge annotated "recommendation only, never invoked", with solid edges reserved for invocation. A contract test holds the two copies in agreement.

Also corrects the README's plugin-installation count from nine skills to ten, stale since `ready-ticket` landed.

## Validation

`just format`, `just lint`, `just test` all exit 0 at head — ten skills valid, plugin packaging validated, 12 suites, 96 `implement-ticket` tests. The six new assertions fail at base and pass at head.

## Review

`review-code-change` ran five cycles. Four findings were raised and all four applied, each pinned by a test red at the head that carried it:

1. **Blocking** — the first draft's unqualified "never author the ticket body" contradicted the gate's existing authorized-repair branch, making that path indeterminate. Fixed with the two-branch predicate above.
2. The six decision classes appeared three times → back-reference.
3. The edge's two rules were stated twice, in different modality → the diagram legend now points at the owning section.
4. The routing subsection re-enumerated the readiness conditions the gate owns, and the copy had already drifted (it dropped "enough detail to classify each evidence item as pre-merge or post-merge") → deleted the restatement.

Final cycle after rebasing onto #143: solution simplicity, correctness, and code simplicity all **clean**.

Two findings are recorded as deliberately deferred rather than silently dropped: no forward-eval pair for the new branch (the eval-backed norm #135 is explicitly not in force), and the new contract assertions bind prose rather than the module's declared stable-identifier surface. Both belong with #135.

Fixes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)
