### PR TITLE
feat(scripts): detect drift between installed skill copies and this repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,22 @@ summary: Chronological history of repository and skill changes.
 
 # Changelog
 
-## 2026-08-05 — Fixed the intermittent claude_executor real-model parsing failure blocking implement-ticket eval evidence, added scoped per-finding re-review and escalated final-cycle execution to implement-ticket's fix loop, then made installed-distribution drift detectable so a stale skill snapshot can no longer run an out-of-date review rubric in silence, then closed the blind spots an adversarial review found in that very check
+## 2026-08-05 — Fixed the intermittent claude_executor real-model parsing failure blocking implement-ticket eval evidence, added scoped per-finding re-review and escalated final-cycle execution to implement-ticket's fix loop, then made installed-distribution drift detectable and drove that check through five adversarial review rounds until it no longer had the silent successes it exists to catch
+
+- test(scripts): pin the install-directory identity guard where CI can see it
+  (fifth adversarial review round) — the regression test for the previous commit
+  reproduces its defect through case-folding, which only exists on a
+  case-insensitive filesystem. CI runs `ubuntu-latest` on ext4, so that test
+  skipped itself there, and no other test distinguished the two implementations:
+  the nearest one uses a directory that is *path-equal* to a canonical location,
+  which passes under path comparison too. Reverting the guard to path equality
+  would therefore have gone green in CI and restored the destructive
+  "re-install, then delete what you just installed" advice that four review
+  rounds converged on removing. A stray directory that is a symlink to the
+  canonical directory is path-unequal and inode-identical on every filesystem,
+  so it pins the same guard without a platform gate; the case-folding test stays
+  as documentation of the real-world trigger. Observed failing at base and
+  passing at head, with no skip on either platform.
 
 - fix(scripts): compare install directories by filesystem identity, not by path
   (fourth adversarial review round) — the guard round three added to keep the
@@ -23,6 +38,7 @@ summary: Chronological history of repository and skill changes.
   fence — that behavior is already correct and the test passes at base, but a
   mutation run showed nothing asserted it, so prose after the fence could have
   started renaming copies without the suite noticing.
+  (3f446f61b0f0260f3d8165a8f727a5fe7db07fdf)
 
 - fix(scripts): stop the drift check from recommending a destructive removal,
   and simplify (third adversarial review round) — the check emits exactly one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,39 @@ summary: Chronological history of repository and skill changes.
 
 # Changelog
 
-## 2026-08-05 — Fixed the intermittent claude_executor real-model parsing failure blocking implement-ticket eval evidence, then added scoped per-finding re-review and escalated final-cycle execution to implement-ticket's fix loop
+## 2026-08-05 — Fixed the intermittent claude_executor real-model parsing failure blocking implement-ticket eval evidence, added scoped per-finding re-review and escalated final-cycle execution to implement-ticket's fix loop, then made installed-distribution drift detectable so a stale skill snapshot can no longer run an out-of-date review rubric in silence
+
+- feat(scripts): detect drift between installed skill copies and this repository
+  — add `scripts/check_installed_skills.py` and the `just check-installed`
+  recipe, which compare an installed skills directory (`~/.agents/skills` by
+  default, overridable with `--skills-root` or `$AGENTS_SKILLS_DIR`) against the
+  working tree, name every differing, absent, and leftover file per skill, and
+  exit non-zero on drift. A skill is distributed by copying its folder out of
+  this repository, so an installed copy is a snapshot that never learns about
+  later commits, and `just sync-contracts` does not reach it: that recipe
+  refreshes only the bundles inside this repository. The resulting failure is
+  silent in the worst place. A stale review skill still runs, validates its own
+  result against the stale schema it bundles, and returns a verdict, because the
+  snapshot is internally consistent — old prose, old schema, and old validator
+  all agree with each other, so no check confined to the snapshot can detect the
+  problem. Detection therefore has to compare against a source of truth outside
+  it. Observed in the field before this change: an installed distribution pinned
+  at `schema_version` 1.0 accepted an aggregate `clean` review result carrying
+  no `lens_executions` evidence at all, which the canonical 1.4 contract
+  rejects, while its `review-correctness/SKILL.md` was missing the entire
+  required consumer/impact traversal pass. Runtime byproducts are excluded from
+  the comparison — `__pycache__`, `*.pyc`, `.DS_Store`, and the skill-local
+  record-keeping directories `AGENTS.md` prescribes — because they are written
+  after installation rather than distributed. A repository skill that is simply
+  not installed is named but does not fail the check: declining to install a
+  skill is a choice, not staleness in the ones that are installed. Deliberately
+  kept out of `lint` and `check`, whose gates must stay reproducible in
+  continuous integration where no installed distribution exists; the command
+  exits zero with a note when the directory is absent. Not a skill-prose change,
+  so the eval-evidence norm's recorded-run requirement does not apply. Nine
+  behavioral tests bound to the criteria above assert at the command's public
+  surface — its exit status and its printed report — and were each observed
+  failing at base `1001595` and passing at head.
 
 - fix(implement-ticket): retry `claude_executor.py`'s real-model call on
   malformed JSON instead of aborting the whole forward-eval run (issue #154) —
@@ -31,6 +63,7 @@ summary: Chronological history of repository and skill changes.
   retry-then-succeed, exhausting all attempts, and no retry on a CLI exit
   failure. Not a skill-prose change, so the eval-evidence norm's recorded-run
   requirement does not apply; the diagnostic evidence above is the record.
+  (1001595a0c06c604bd1e02ea9b6c73bba881d0ed)
 
 - feat(implement-ticket): add scoped per-finding re-review and escalated
   final-cycle execution to the fix loop (issue #132, epic #119) — the fix loop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ summary: Chronological history of repository and skill changes.
 
 ## 2026-08-05 — Fixed the intermittent claude_executor real-model parsing failure blocking implement-ticket eval evidence, added scoped per-finding re-review and escalated final-cycle execution to implement-ticket's fix loop, then made installed-distribution drift detectable so a stale skill snapshot can no longer run an out-of-date review rubric in silence, then closed the blind spots an adversarial review found in that very check
 
+- fix(scripts): stop the drift check from recommending a destructive removal,
+  and simplify (third adversarial review round) — the check emits exactly one
+  destructive instruction, the "remove this stray directory" line round two
+  added for a copy sitting under a name a re-install can never overwrite. Round
+  two also made one directory matchable as two skills, once by its declared name
+  and once by its own, and the removal list did not account for that: an
+  installed `beta/` whose frontmatter reads `alpha` was reported as a stray copy
+  of `alpha` and named for deletion, so an operator following the printed
+  remediation in order would `skills update` a correct `beta` into place and
+  then be told to delete it. Removal advice now excludes any directory that is
+  some skill's canonical install location, and the skills root is resolved so a
+  printed target is never a bare relative path. Two further correctness fixes:
+  the untrustworthy-source banner was appended *after* the per-skill blocks it
+  disclaims, so fabricated `missing`/`extra` entries computed from a source that
+  could not be enumerated were printed above the warning about them — those
+  blocks are now suppressed entirely rather than captioned; and a duplicated
+  `name:` key resolved first-wins where a YAML loader resolves last-wins, which
+  let a runtime and this check disagree about what a document declares. The
+  realpath guard that keeps a symlink cycle terminating was dropping files
+  rather than only pruning descent, so a second link to one directory
+  contributed nothing and its content went unreported; files are recorded before
+  the guard applies. Alongside these, local simplifications that preserve
+  behavior: the copy map is built as a dict of sets, stating its dedupe rule
+  once instead of three times; `render` ends in a single exit; `argparse`'s own
+  `sys.argv` fallback replaces a hand-written conditional; the exit mapping
+  moves into a named `exit_code` so the contract is assertable rather than
+  reachable only through `main`; and the frontmatter subtests use a named
+  fixture helper instead of calling `setUp` by hand. Three further behavioral
+  tests plus one strengthened, each observed failing at base `45b1f6d` and
+  passing at head, with no other test moving.
+
 - fix(scripts): make the drift check's copy matching independent of frontmatter
   spelling (second adversarial review round) — round one closed the headline
   blind spot by matching an installed copy on the name its `SKILL.md` declares,
@@ -34,7 +65,7 @@ summary: Chronological history of repository and skill changes.
   not drift, so it joins the misconfiguration code the comment already called
   it. Five further behavioral tests, including the frontmatter input space whose
   absence let the blocking defect through, each observed failing at base
-  `4b18269` and passing at head.
+  `4b18269` and passing at head. (45b1f6d651f9748081ac4f7a502c5448e2ae3d69)
 
 - fix(scripts): close the drift check's own silent-success paths (adversarial
   review of `3c18034`) — a check whose purpose is detecting a silent failure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ summary: Chronological history of repository and skill changes.
 
 ## 2026-08-05 — Fixed the intermittent claude_executor real-model parsing failure blocking implement-ticket eval evidence, added scoped per-finding re-review and escalated final-cycle execution to implement-ticket's fix loop, then made installed-distribution drift detectable so a stale skill snapshot can no longer run an out-of-date review rubric in silence, then closed the blind spots an adversarial review found in that very check
 
+- fix(scripts): make the drift check's copy matching independent of frontmatter
+  spelling (second adversarial review round) — round one closed the headline
+  blind spot by matching an installed copy on the name its `SKILL.md` declares,
+  and a second review round showed that fix worked for exactly one spelling of
+  the field. The parser took the value as an opaque token, so
+  `name: "review-correctness"` yielded `'"review-correctness"'` — truthy, so the
+  directory-name fallback never ran, and not a known skill, so the copy was
+  dropped: a stale rubric on disk, "Installed skills match this repository",
+  exit 0, and the skill additionally asserted to be *not installed*. Not
+  hypothetical — `gh-fix-ci` in the live distribution already writes
+  `name: "gh-fix-ci"`, and every skill in this repository already quotes its
+  `description:` scalar. The structural fix is to stop treating the two matches
+  as alternatives: a directory now matches on its declared name **or** its own
+  name, so a frontmatter this check reads wrongly can no longer hide a copy that
+  the plain directory name would have found. The parser is hardened alongside it
+  (quoted values, inline comments, a BOM) and now reads only unindented keys, so
+  a `name:` inside a block scalar is no longer mistaken for the document's own.
+  Two further findings: a read failure in **this repository's** own `skills/`
+  tree was being merged into the installed copy's drift, which reported a
+  faithful copy as stale and printed remediation that would have overwritten its
+  good files with a truncated source — source-side failures now invalidate the
+  run instead of contributing to it; and a copy under a stray directory name was
+  told to re-install, which writes `<root>/<skill>` and therefore can never
+  clear it, so that case now prints the directory to remove. The exit contract
+  stops contradicting itself: nothing-to-compare is the operator's environment,
+  not drift, so it joins the misconfiguration code the comment already called
+  it. Five further behavioral tests, including the frontmatter input space whose
+  absence let the blocking defect through, each observed failing at base
+  `4b18269` and passing at head.
+
 - fix(scripts): close the drift check's own silent-success paths (adversarial
   review of `3c18034`) — a check whose purpose is detecting a silent failure
   must not have silent failures of its own, and the first cut had four. **A
@@ -44,6 +74,7 @@ summary: Chronological history of repository and skill changes.
   cover the fixed paths, including the byte-comparison path a same-length edit
   exercises and `--skills-root` precedence over the environment, each observed
   failing at base `3c18034` and passing at head.
+  (4b182690ef0cd67c77f390b892606174fccd61c3)
 
 - feat(scripts): detect drift between installed skill copies and this repository
   — add `scripts/check_installed_skills.py` and the `just check-installed`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ summary: Chronological history of repository and skill changes.
 
 ## 2026-08-05 — Fixed the intermittent claude_executor real-model parsing failure blocking implement-ticket eval evidence, added scoped per-finding re-review and escalated final-cycle execution to implement-ticket's fix loop, then made installed-distribution drift detectable so a stale skill snapshot can no longer run an out-of-date review rubric in silence, then closed the blind spots an adversarial review found in that very check
 
+- fix(scripts): compare install directories by filesystem identity, not by path
+  (fourth adversarial review round) — the guard round three added to keep the
+  removal advice off a skill's canonical install directory compared `Path`
+  objects, and the default skills root lives on macOS's case-insensitive APFS.
+  There `<root>/Review-Correctness` and `<root>/review-correctness` are one
+  directory with one inode and two unequal paths, so the guard passed and the
+  report said "re-install, then delete the directory you just installed into" —
+  the exact destructive advice that guard exists to prevent, reproduced
+  end-to-end with `ls -di` confirming a single inode. Identity is now decided by
+  `Path.samefile`, which case-folding cannot defeat and `Path.resolve` would not
+  have caught, since resolution preserves case. Adds a regression test observed
+  failing at base `7d752a1` and passing at head, which skips itself on a
+  case-sensitive filesystem rather than asserting a platform it cannot create,
+  and one coverage test pinning that frontmatter parsing stops at the closing
+  fence — that behavior is already correct and the test passes at base, but a
+  mutation run showed nothing asserted it, so prose after the fence could have
+  started renaming copies without the suite noticing.
+
 - fix(scripts): stop the drift check from recommending a destructive removal,
   and simplify (third adversarial review round) — the check emits exactly one
   destructive instruction, the "remove this stray directory" line round two
@@ -36,6 +54,7 @@ summary: Chronological history of repository and skill changes.
   fixture helper instead of calling `setUp` by hand. Three further behavioral
   tests plus one strengthened, each observed failing at base `45b1f6d` and
   passing at head, with no other test moving.
+  (7d752a1e34afd4a1844d77ddc20b40ff22a4200e)
 
 - fix(scripts): make the drift check's copy matching independent of frontmatter
   spelling (second adversarial review round) — round one closed the headline

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,46 @@ summary: Chronological history of repository and skill changes.
 
 # Changelog
 
-## 2026-08-05 — Fixed the intermittent claude_executor real-model parsing failure blocking implement-ticket eval evidence, added scoped per-finding re-review and escalated final-cycle execution to implement-ticket's fix loop, then made installed-distribution drift detectable so a stale skill snapshot can no longer run an out-of-date review rubric in silence
+## 2026-08-05 — Fixed the intermittent claude_executor real-model parsing failure blocking implement-ticket eval evidence, added scoped per-finding re-review and escalated final-cycle execution to implement-ticket's fix loop, then made installed-distribution drift detectable so a stale skill snapshot can no longer run an out-of-date review rubric in silence, then closed the blind spots an adversarial review found in that very check
+
+- fix(scripts): close the drift check's own silent-success paths (adversarial
+  review of `3c18034`) — a check whose purpose is detecting a silent failure
+  must not have silent failures of its own, and the first cut had four. **A
+  stale copy under any other directory name was invisible.** The comparison loop
+  was source-driven — for each repository skill, look for a directory of that
+  name — so `review-correctness-old/`, whose `SKILL.md` still declares
+  `name: review-correctness` and which a runtime therefore still loads as that
+  skill, was never compared and never named; the command printed "Installed
+  skills match this repository" and exited 0 with a live stale rubric on disk.
+  Installed directories are now enumerated and matched by their **declared**
+  name, with the directory name itself reported as drift, because re-installing
+  will not replace a copy sitting under a different name. A directory named for
+  a repository skill is matched even when its `SKILL.md` is absent, so a gutted
+  install is reported rather than counted absent. **Comparing nothing rendered
+  as a match**: a skills root holding no copy of anything this repository ships
+  returned the same affirmative sentence and exit 0, which is the misconfigured
+  path case and now reports what it found and exits non-zero. **An explicitly
+  named root that did not exist exited 0**, so one typo in `--skills-root` or a
+  stale `$AGENTS_SKILLS_DIR` bought a check that could never fail; naming a root
+  is now an assertion that it exists, and only the built-in default may be
+  absent — that is the continuous-integration case and the only one that still
+  exits zero with a note. **A directory that could not be read was skipped
+  silently** by `os.walk`, so an unreadable subtree on both sides read as in
+  sync; walk errors are now collected and reported. Two robustness defects
+  alongside them: a dangling symlink where a distributed file belongs raised
+  `FileNotFoundError` out of `filecmp` and aborted every skill sorting after it,
+  and a symlinked interior directory reported its entire byte-identical contents
+  as `missing`. Both are fixed, the latter by following links with a realpath
+  cycle guard. Finally, `evals/results/` is excluded: `just eval-record` appends
+  a summary there on every recorded run, so those receipts re-dirtied every
+  installed copy without changing what any installed skill does — on the live
+  distribution they were three of the eight skills' only reported drift, and a
+  check that is never green is a check operators stop reading. The
+  `.<skill-name>` record-keeping exclusion is now anchored to the skill root
+  rather than matching that name at any depth. Twelve further behavioral tests
+  cover the fixed paths, including the byte-comparison path a same-length edit
+  exercises and `--skills-root` precedence over the environment, each observed
+  failing at base `3c18034` and passing at head.
 
 - feat(scripts): detect drift between installed skill copies and this repository
   — add `scripts/check_installed_skills.py` and the `just check-installed`
@@ -37,6 +76,7 @@ summary: Chronological history of repository and skill changes.
   behavioral tests bound to the criteria above assert at the command's public
   surface — its exit status and its printed report — and were each observed
   failing at base `1001595` and passing at head.
+  (3c18034f16bcfd9b03b90043b6a68750363e043c)
 
 - fix(implement-ticket): retry `claude_executor.py`'s real-model call on
   malformed JSON instead of aborting the whole forward-eval run (issue #154) —

--- a/README.md
+++ b/README.md
@@ -169,13 +169,15 @@ integration case, and it is the one case that exits zero with a note. A root
 named explicitly through `--skills-root` or `$AGENTS_SKILLS_DIR` is an assertion
 that it exists, so a typo is an error rather than a check that can never fail.
 
-An installed copy is matched by the name its `SKILL.md` declares rather than by
+An installed copy is matched by the name its `SKILL.md` declares as well as by
 its directory name, since the declared name is what a runtime loads: a stale
 copy left under `review-correctness-old` is still a live review skill, and is
-reported as drift rather than passed over as an unrelated directory. Runtime
-byproducts and the eval summaries `just eval-record` appends are excluded,
-because neither changes what an installed skill does. The comparison is against
-the working tree, so update the checkout first if it may be behind.
+reported as drift rather than passed over as an unrelated directory. Either
+match is enough, so a frontmatter this check reads wrongly cannot hide a copy
+the plain directory name would have found. Runtime byproducts and the eval
+summaries `just eval-record` appends are excluded, because neither changes what
+an installed skill does. The comparison is against the working tree, so update
+the checkout first if it may be behind.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,23 @@ files and refresh the copies with:
 just sync-contracts
 ```
 
+That recipe refreshes only the copies bundled inside this repository. Skills
+installed elsewhere — under `~/.agents/skills`, a plugin directory, or any other
+distribution — are snapshots taken at install time, and they keep running the
+prose and contracts they shipped with until they are re-installed. The failure
+is silent by construction: a stale review skill validates its own result against
+the stale schema it bundles, so every part of the snapshot agrees with every
+other part and a weakened review still reports a verdict. Compare an installed
+distribution against this repository with:
+
+```bash
+just check-installed
+```
+
+It exits non-zero when an installed copy has drifted, names the differing files,
+and is skipped when no installed distribution is present. The comparison is
+against the working tree, so update the checkout first if it may be behind.
+
 ## Quick Start
 
 Run the core checks:

--- a/README.md
+++ b/README.md
@@ -160,9 +160,22 @@ distribution against this repository with:
 just check-installed
 ```
 
-It exits non-zero when an installed copy has drifted, names the differing files,
-and is skipped when no installed distribution is present. The comparison is
-against the working tree, so update the checkout first if it may be behind.
+It exits non-zero when an installed copy has drifted and names the differing
+files. Because the failure it detects is a silent success, it refuses to succeed
+silently itself: comparing nothing, being pointed at a directory that does not
+exist, and failing to read part of a tree are all reported rather than passed
+over. Only the built-in default location may be absent — that is the continuous
+integration case, and it is the one case that exits zero with a note. A root
+named explicitly through `--skills-root` or `$AGENTS_SKILLS_DIR` is an assertion
+that it exists, so a typo is an error rather than a check that can never fail.
+
+An installed copy is matched by the name its `SKILL.md` declares rather than by
+its directory name, since the declared name is what a runtime loads: a stale
+copy left under `review-correctness-old` is still a live review skill, and is
+reported as drift rather than passed over as an unrelated directory. Runtime
+byproducts and the eval summaries `just eval-record` appends are excluded,
+because neither changes what an installed skill does. The comparison is against
+the working tree, so update the checkout first if it may be behind.
 
 ## Quick Start
 

--- a/justfile
+++ b/justfile
@@ -43,7 +43,9 @@ sync-contracts:
 # re-installed. Deliberately excluded from `lint` and `check`: the installed
 # path is machine-specific and absent in continuous integration.
 #
-# Override the location with --skills-root or $AGENTS_SKILLS_DIR.
+# Exit 0 in sync, 1 drifted (or nothing comparable found), 2 misconfigured.
+# Override the location with --skills-root or $AGENTS_SKILLS_DIR; only the
+# built-in default may be absent, since naming a root asserts that it exists.
 check-installed *args:
   python3 scripts/check_installed_skills.py {{args}}
 

--- a/justfile
+++ b/justfile
@@ -43,7 +43,9 @@ sync-contracts:
 # re-installed. Deliberately excluded from `lint` and `check`: the installed
 # path is machine-specific and absent in continuous integration.
 #
-# Exit 0 in sync, 1 drifted (or nothing comparable found), 2 misconfigured.
+# Exit 0 in sync, 1 an installed copy drifted, 2 the operator's environment is
+# wrong: no such root, nothing there to compare, or this repository's own
+# skills tree could not be read.
 # Override the location with --skills-root or $AGENTS_SKILLS_DIR; only the
 # built-in default may be absent, since naming a root asserts that it exists.
 check-installed *args:

--- a/justfile
+++ b/justfile
@@ -36,6 +36,17 @@ sync-contracts:
     echo "Synced $scripts_dest/review_gate.py and $tests_dest/test_review_gate.py"; \
   done
 
+# Compare the separately installed skill copies under ~/.agents/skills against
+# this repository's working tree. `sync-contracts` above only refreshes the
+# copies bundled *inside* this repository; an installed snapshot is a distinct
+# distribution that keeps running stale prose and stale contracts until it is
+# re-installed. Deliberately excluded from `lint` and `check`: the installed
+# path is machine-specific and absent in continuous integration.
+#
+# Override the location with --skills-root or $AGENTS_SKILLS_DIR.
+check-installed *args:
+  python3 scripts/check_installed_skills.py {{args}}
+
 test: test-plugins
   @found=0; \
   for tests in {{skills_dir}}/*/scripts/tests; do \

--- a/scripts/check_installed_skills.py
+++ b/scripts/check_installed_skills.py
@@ -108,11 +108,28 @@ class Report:
     # Where re-installing writes: `<root>/<skill>` for every skill this
     # repository ships. Removal advice must never name one of these.
     canonical_directories: set[Path] = field(default_factory=set)
+
     # Parts of this repository's own `skills/` tree that could not be read. A
     # comparison against a source that could not be enumerated says nothing
     # about the installed copy, so this invalidates the run rather than
     # contributing to it.
     unreadable_sources: list[str] = field(default_factory=list)
+
+    def is_canonical(self, directory: Path) -> bool:
+        """Whether `directory` is where re-installing some skill would write.
+
+        Compared by filesystem identity, not by path equality: the default
+        skills root lives on a case-insensitive filesystem, where
+        `Review-Correctness` and `review-correctness` are unequal paths naming
+        one directory. Getting that wrong turns the single destructive line this
+        command prints into "delete what you just installed".
+        """
+        if directory in self.canonical_directories:
+            return True
+        return any(
+            _same_directory(directory, canonical)
+            for canonical in self.canonical_directories
+        )
 
     @property
     def drifted(self) -> list[SkillComparison]:
@@ -125,6 +142,14 @@ class Report:
         # far more often than it is a deliberate empty install. `main` reports
         # that case as misconfiguration rather than as drift.
         return bool(self.compared) and not self.drifted and not self.unreadable_sources
+
+
+def _same_directory(one: Path, other: Path) -> bool:
+    """Whether two paths name the same directory on disk."""
+    try:
+        return one.samefile(other)
+    except OSError:
+        return False
 
 
 def _ignored_file(name: str) -> bool:
@@ -350,8 +375,7 @@ def render(report: Report) -> str:
             {
                 str(comparison.directory)
                 for comparison in report.drifted
-                if comparison.misnamed
-                and comparison.directory not in report.canonical_directories
+                if comparison.misnamed and not report.is_canonical(comparison.directory)
             }
         )
         if stray:

--- a/scripts/check_installed_skills.py
+++ b/scripts/check_installed_skills.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Compare installed skill copies against this repository's `skills/` tree.
+
+Skills are distributed by copying a skill folder out of this repository into an
+agent's skills directory, so an installed copy is a snapshot that never learns
+about later commits. That drift is silent in the worst possible place: a stale
+review skill still runs, still validates its own result against the stale
+contract it shipped with, and still reports a verdict. Nothing inside the
+installed snapshot can detect the problem, because the snapshot is internally
+consistent — old prose, old schema, and old validator all agree with each other.
+Detection has to compare the snapshot against a source of truth outside it,
+which is what this check does.
+
+The comparison is against the working tree, not against `origin/main`: a
+checkout that is itself behind the remote will report "in sync" while both
+copies are stale. Update the checkout first when that matters.
+"""
+
+from __future__ import annotations
+
+import argparse
+import filecmp
+import os
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+DEFAULT_SKILLS_ROOT = "~/.agents/skills"
+SKILLS_ROOT_ENV = "AGENTS_SKILLS_DIR"
+
+# Record-keeping directories a skill writes at runtime, per AGENTS.md, plus
+# interpreter and filesystem byproducts. None of these are distributed, so a
+# difference in them is not drift.
+IGNORED_DIRECTORY_NAMES = frozenset({"__pycache__", ".skill-state"})
+IGNORED_FILE_NAMES = frozenset({".DS_Store"})
+IGNORED_FILE_SUFFIXES = frozenset({".pyc", ".pyo"})
+
+
+@dataclass
+class SkillComparison:
+    """One skill's installed copy measured against its repository source."""
+
+    name: str
+    differing: list[str] = field(default_factory=list)
+    missing: list[str] = field(default_factory=list)
+    extra: list[str] = field(default_factory=list)
+
+    @property
+    def is_drifted(self) -> bool:
+        return bool(self.differing or self.missing or self.extra)
+
+
+@dataclass
+class Report:
+    """The complete result of one comparison run."""
+
+    skills_root: Path
+    compared: list[SkillComparison] = field(default_factory=list)
+    not_installed: list[str] = field(default_factory=list)
+
+    @property
+    def drifted(self) -> list[SkillComparison]:
+        return [comparison for comparison in self.compared if comparison.is_drifted]
+
+
+def _ignored_directory(name: str, skill: str) -> bool:
+    return name in IGNORED_DIRECTORY_NAMES or name == f".{skill}"
+
+
+def _ignored_file(name: str) -> bool:
+    return name in IGNORED_FILE_NAMES or Path(name).suffix in IGNORED_FILE_SUFFIXES
+
+
+def _relative_files(root: Path, skill: str) -> set[str]:
+    """Every distributed file under `root`, as POSIX paths relative to it."""
+    found: set[str] = set()
+    for directory, subdirectories, filenames in os.walk(root):
+        subdirectories[:] = [
+            name for name in subdirectories if not _ignored_directory(name, skill)
+        ]
+        for filename in filenames:
+            if _ignored_file(filename):
+                continue
+            path = Path(directory, filename)
+            found.add(path.relative_to(root).as_posix())
+    return found
+
+
+def _repository_skills(repository_root: Path) -> list[str]:
+    return sorted(
+        path.parent.name
+        for path in (repository_root / "skills").glob("*/SKILL.md")
+        if path.is_file()
+    )
+
+
+def compare(repository_root: Path, skills_root: Path) -> Report:
+    """Compare every repository skill that is installed under `skills_root`."""
+    report = Report(skills_root=skills_root)
+    for skill in _repository_skills(repository_root):
+        installed = skills_root / skill
+        if not installed.is_dir():
+            report.not_installed.append(skill)
+            continue
+
+        source = repository_root / "skills" / skill
+        source_files = _relative_files(source, skill)
+        installed_files = _relative_files(installed, skill)
+        comparison = SkillComparison(
+            name=skill,
+            missing=sorted(source_files - installed_files),
+            extra=sorted(installed_files - source_files),
+        )
+        comparison.differing = sorted(
+            relative
+            for relative in source_files & installed_files
+            if not filecmp.cmp(source / relative, installed / relative, shallow=False)
+        )
+        report.compared.append(comparison)
+    return report
+
+
+def render(report: Report) -> str:
+    """Render a report as the operator-facing text the command prints."""
+    lines = [
+        f"Comparing installed skills in {report.skills_root} against this repository"
+    ]
+    for comparison in report.compared:
+        if not comparison.is_drifted:
+            lines.append(f"  ok     {comparison.name}")
+            continue
+        lines.append(f"  drift  {comparison.name}")
+        for label, paths in (
+            ("differs", comparison.differing),
+            ("missing", comparison.missing),
+            ("extra", comparison.extra),
+        ):
+            lines.extend(f"           {label}: {path}" for path in paths)
+
+    if report.not_installed:
+        lines.append(f"  not installed: {', '.join(report.not_installed)}")
+
+    drifted = report.drifted
+    if not drifted:
+        lines.append("")
+        lines.append("Installed skills match this repository.")
+        return "\n".join(lines)
+
+    names = [comparison.name for comparison in drifted]
+    lines.append("")
+    lines.append(f"Installed skills are stale: {', '.join(names)}")
+    lines.append("Re-install them from this repository, for example:")
+    lines.append(f"  skills update -g -y {' '.join(names)}")
+    return "\n".join(lines)
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Compare installed skill copies against this repository."
+    )
+    parser.add_argument(
+        "--skills-root",
+        help=(
+            "Installed skills directory "
+            f"(default: ${SKILLS_ROOT_ENV} or {DEFAULT_SKILLS_ROOT})"
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def _resolve_skills_root(argument: str | None) -> Path:
+    raw = argument or os.environ.get(SKILLS_ROOT_ENV) or DEFAULT_SKILLS_ROOT
+    return Path(raw).expanduser()
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    skills_root = _resolve_skills_root(args.skills_root)
+    if not skills_root.is_dir():
+        print(f"No installed skills directory at {skills_root}; nothing to compare")
+        return 0
+
+    repository_root = Path(__file__).resolve().parents[1]
+    report = compare(repository_root, skills_root)
+    print(render(report))
+    return 1 if report.drifted else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_installed_skills.py
+++ b/scripts/check_installed_skills.py
@@ -16,13 +16,23 @@ own silent successes as failures too. Comparing nothing, being pointed at a
 directory that does not exist, and failing to read part of a tree are all
 reported and exit non-zero rather than passing quietly.
 
-An installed copy is matched by the name its `SKILL.md` declares, not by its
-directory name, because that declared name is what an agent runtime loads. A
+An installed copy is matched by the name its `SKILL.md` declares *and* by its
+directory name, because the declared name is what an agent runtime loads and a
 stale copy left behind under a different directory name is still a live skill.
+Either match is enough: reading a declared name means parsing frontmatter, and a
+parse this check gets wrong must not be able to hide a copy that the plain
+directory name would have found.
 
 The comparison is against the working tree, not against `origin/main`: a
 checkout that is itself behind the remote will report "in sync" while both
 copies are stale. Update the checkout first when that matters.
+
+On why this is not `diff -rq` in a shell loop, which would cover most of it in a
+few lines: the declared-name matching above cannot be expressed that way without
+reading frontmatter anyway, and the exclusions here are anchored to a skill root
+rather than matched as bare names at any depth. Those two are the whole reason
+this is a Python module. The recursive comparison itself is the cheap part and
+carries no cleverness worth defending.
 """
 
 from __future__ import annotations
@@ -55,7 +65,10 @@ IGNORED_FILE_SUFFIXES = frozenset({".pyc"})
 IGNORED_SKILL_RELATIVE_DIRECTORIES = frozenset({".skill-state", "evals/results"})
 
 FRONTMATTER_FENCE = "---"
-NAME_FIELD = re.compile(r"name:\s*(\S+)")
+# Matched only against a line with no leading whitespace, so a `name:` appearing
+# inside an indented block scalar — a description, most plausibly — is not read
+# as the document's own name. The value runs to an unquoted `#` comment.
+NAME_FIELD = re.compile(r"name:\s*(?P<value>[^#]*?)\s*(?:#.*)?$")
 
 
 @dataclass
@@ -92,6 +105,11 @@ class Report:
     skills_root: Path
     compared: list[SkillComparison] = field(default_factory=list)
     not_installed: list[str] = field(default_factory=list)
+    # Parts of this repository's own `skills/` tree that could not be read. A
+    # comparison against a source that could not be enumerated says nothing
+    # about the installed copy, so this invalidates the run rather than
+    # contributing to it.
+    unreadable_sources: list[str] = field(default_factory=list)
 
     @property
     def drifted(self) -> list[SkillComparison]:
@@ -101,8 +119,9 @@ class Report:
     def is_clean(self) -> bool:
         # Comparing nothing is never a match: it means the skills root holds no
         # copy of anything this repository ships, which is a misconfigured path
-        # far more often than it is a deliberate empty install.
-        return bool(self.compared) and not self.drifted
+        # far more often than it is a deliberate empty install. `main` reports
+        # that case as misconfiguration rather than as drift.
+        return bool(self.compared) and not self.drifted and not self.unreadable_sources
 
 
 def _ignored_file(name: str) -> bool:
@@ -151,21 +170,27 @@ def _distributed_files(root: Path, skill: str) -> tuple[set[str], list[str]]:
 
 
 def _declared_name(skill_document: Path) -> str | None:
-    """The `name:` a `SKILL.md` declares in its frontmatter, if it has one."""
+    """The `name:` a `SKILL.md` declares in its frontmatter, if it has one.
+
+    Best effort by design. This is one of two ways a copy is matched, never the
+    only one, so an unparsed or oddly written frontmatter costs nothing that the
+    directory name does not already recover.
+    """
     try:
-        lines = skill_document.read_text(
-            encoding="utf-8", errors="replace"
-        ).splitlines()
+        text = skill_document.read_text(encoding="utf-8-sig", errors="replace")
     except OSError:
         return None
+    lines = text.splitlines()
     if not lines or lines[0].strip() != FRONTMATTER_FENCE:
         return None
     for line in lines[1:]:
         if line.strip() == FRONTMATTER_FENCE:
             return None
-        match = NAME_FIELD.fullmatch(line.strip())
+        if line[:1].isspace():  # inside a nested mapping or a block scalar
+            continue
+        match = NAME_FIELD.fullmatch(line)
         if match:
-            return match.group(1)
+            return match.group("value").strip("\"'") or None
     return None
 
 
@@ -180,17 +205,20 @@ def _repository_skills(repository_root: Path) -> list[str]:
 def _installed_copies(skills_root: Path, skills: list[str]) -> dict[str, list[Path]]:
     """Map each repository skill to every installed directory providing it.
 
-    A directory is matched by the name its `SKILL.md` declares, so a copy
-    renamed on disk is still found. A directory named for a repository skill is
-    matched too, even with an absent or unreadable `SKILL.md`, so a gutted
-    install is reported rather than mistaken for an absent one.
+    A directory matches on either the name its `SKILL.md` declares or its own
+    name, so a copy renamed on disk is found by the first and a copy whose
+    frontmatter this check cannot parse is still found by the second. A
+    directory named for a repository skill is matched even with an absent
+    `SKILL.md`, so a gutted install is reported rather than mistaken for an
+    absent one.
     """
     known = set(skills)
     copies: dict[str, list[Path]] = {}
     for document in sorted(skills_root.glob("*/SKILL.md")):
-        declared = _declared_name(document) or document.parent.name
-        if declared in known:
-            copies.setdefault(declared, []).append(document.parent)
+        directory = document.parent
+        for candidate in {_declared_name(document), directory.name}:
+            if candidate in known and directory not in copies.get(candidate, []):
+                copies.setdefault(candidate, []).append(directory)
     for skill in skills:
         directory = skills_root / skill
         if directory.is_dir() and directory not in copies.get(skill, []):
@@ -212,6 +240,7 @@ def compare(repository_root: Path, skills_root: Path) -> Report:
 
         source = repository_root / "skills" / skill
         source_files, source_unreadable = _distributed_files(source, skill)
+        report.unreadable_sources.extend(source_unreadable)
         for directory in sorted(directories):
             installed_files, installed_unreadable = _distributed_files(directory, skill)
             comparison = SkillComparison(
@@ -219,7 +248,7 @@ def compare(repository_root: Path, skills_root: Path) -> Report:
                 directory=directory,
                 missing=sorted(source_files - installed_files),
                 extra=sorted(installed_files - source_files),
-                unreadable=sorted(source_unreadable + installed_unreadable),
+                unreadable=sorted(installed_unreadable),
             )
             comparison.differing = sorted(
                 relative
@@ -270,6 +299,18 @@ def render(report: Report) -> str:
         lines.append(f"  not installed: {', '.join(report.not_installed)}")
 
     lines.append("")
+    if report.unreadable_sources:
+        # Said before anything else and without remediation: re-installing from
+        # a source that could not be read would overwrite good installed files
+        # with a truncated copy of this repository.
+        lines.append(
+            "This repository's own skills tree could not be read in full, so no "
+            "comparison here is trustworthy:"
+        )
+        lines.extend(
+            f"  unreadable: {path}" for path in sorted(report.unreadable_sources)
+        )
+        return "\n".join(lines)
     if not report.compared:
         lines.append(
             f"No skill from this repository is installed in {report.skills_root}, "
@@ -284,6 +325,21 @@ def render(report: Report) -> str:
     lines.append(f"Installed skills are stale: {', '.join(names)}")
     lines.append("Re-install them from this repository, for example:")
     lines.append(f"  skills update -g -y {' '.join(names)}")
+
+    # Re-installing writes `<root>/<skill>`, so it can never clear a copy that
+    # is sitting somewhere else. Those have to be removed by name.
+    stray = sorted(
+        {
+            str(comparison.directory)
+            for comparison in report.drifted
+            if comparison.misnamed
+        }
+    )
+    if stray:
+        lines.append(
+            "Re-installing cannot clear a copy under another directory name. Remove:"
+        )
+        lines.extend(f"  {path}" for path in stray)
     return "\n".join(lines)
 
 
@@ -318,6 +374,11 @@ def main(argv: list[str] | None = None) -> int:
     repository_root = Path(__file__).resolve().parents[1]
     report = compare(repository_root, skills_root)
     print(render(report))
+    if report.unreadable_sources or not report.compared:
+        # Neither is a statement about the installed copies: one means this
+        # repository could not be read, the other that the root holds nothing
+        # to compare. Both are the operator's environment, not drift.
+        return EXIT_MISCONFIGURED
     return EXIT_IN_SYNC if report.is_clean else EXIT_DRIFTED
 
 

--- a/scripts/check_installed_skills.py
+++ b/scripts/check_installed_skills.py
@@ -11,6 +11,15 @@ consistent — old prose, old schema, and old validator all agree with each othe
 Detection has to compare the snapshot against a source of truth outside it,
 which is what this check does.
 
+Because the failure being detected is a silent success, this command treats its
+own silent successes as failures too. Comparing nothing, being pointed at a
+directory that does not exist, and failing to read part of a tree are all
+reported and exit non-zero rather than passing quietly.
+
+An installed copy is matched by the name its `SKILL.md` declares, not by its
+directory name, because that declared name is what an agent runtime loads. A
+stale copy left behind under a different directory name is still a live skill.
+
 The comparison is against the working tree, not against `origin/main`: a
 checkout that is itself behind the remote will report "in sync" while both
 copies are stale. Update the checkout first when that matters.
@@ -21,6 +30,7 @@ from __future__ import annotations
 import argparse
 import filecmp
 import os
+import re
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -28,26 +38,51 @@ from pathlib import Path
 DEFAULT_SKILLS_ROOT = "~/.agents/skills"
 SKILLS_ROOT_ENV = "AGENTS_SKILLS_DIR"
 
-# Record-keeping directories a skill writes at runtime, per AGENTS.md, plus
-# interpreter and filesystem byproducts. None of these are distributed, so a
-# difference in them is not drift.
-IGNORED_DIRECTORY_NAMES = frozenset({"__pycache__", ".skill-state"})
+EXIT_IN_SYNC = 0
+EXIT_DRIFTED = 1
+EXIT_MISCONFIGURED = 2
+
+# Interpreter and filesystem byproducts, which appear at any depth.
+IGNORED_DIRECTORY_NAMES = frozenset({"__pycache__"})
 IGNORED_FILE_NAMES = frozenset({".DS_Store"})
-IGNORED_FILE_SUFFIXES = frozenset({".pyc", ".pyo"})
+IGNORED_FILE_SUFFIXES = frozenset({".pyc"})
+
+# Paths relative to a skill root that are not part of what gets distributed:
+# the record-keeping directory `AGENTS.md` prescribes, and the eval summaries
+# `just eval-record` appends, which are committed evidence for repository
+# readers and grow after every recorded run without changing what an installed
+# skill does. Each skill's own `.<skill-name>` directory is added per skill.
+IGNORED_SKILL_RELATIVE_DIRECTORIES = frozenset({".skill-state", "evals/results"})
+
+FRONTMATTER_FENCE = "---"
+NAME_FIELD = re.compile(r"name:\s*(\S+)")
 
 
 @dataclass
 class SkillComparison:
-    """One skill's installed copy measured against its repository source."""
+    """One installed copy of a skill measured against its repository source."""
 
     name: str
+    directory: Path
     differing: list[str] = field(default_factory=list)
     missing: list[str] = field(default_factory=list)
     extra: list[str] = field(default_factory=list)
+    unreadable: list[str] = field(default_factory=list)
+
+    @property
+    def misnamed(self) -> bool:
+        """The copy declares this skill from a differently named directory."""
+        return self.directory.name != self.name
 
     @property
     def is_drifted(self) -> bool:
-        return bool(self.differing or self.missing or self.extra)
+        return bool(
+            self.differing
+            or self.missing
+            or self.extra
+            or self.unreadable
+            or self.misnamed
+        )
 
 
 @dataclass
@@ -62,28 +97,76 @@ class Report:
     def drifted(self) -> list[SkillComparison]:
         return [comparison for comparison in self.compared if comparison.is_drifted]
 
-
-def _ignored_directory(name: str, skill: str) -> bool:
-    return name in IGNORED_DIRECTORY_NAMES or name == f".{skill}"
+    @property
+    def is_clean(self) -> bool:
+        # Comparing nothing is never a match: it means the skills root holds no
+        # copy of anything this repository ships, which is a misconfigured path
+        # far more often than it is a deliberate empty install.
+        return bool(self.compared) and not self.drifted
 
 
 def _ignored_file(name: str) -> bool:
     return name in IGNORED_FILE_NAMES or Path(name).suffix in IGNORED_FILE_SUFFIXES
 
 
-def _relative_files(root: Path, skill: str) -> set[str]:
-    """Every distributed file under `root`, as POSIX paths relative to it."""
+def _distributed_files(root: Path, skill: str) -> tuple[set[str], list[str]]:
+    """Every distributed file under `root`, plus any subtree that cannot be read.
+
+    Returns POSIX paths relative to `root`. Symlinked directories are followed
+    so a copy assembled out of links compares by content, with a realpath guard
+    so a cycle terminates instead of walking forever.
+    """
+    ignored_relative = {Path(entry) for entry in IGNORED_SKILL_RELATIVE_DIRECTORIES}
+    ignored_relative.add(Path(f".{skill}"))
+
     found: set[str] = set()
-    for directory, subdirectories, filenames in os.walk(root):
+    unreadable: list[str] = []
+    visited: set[str] = set()
+
+    def record_unreadable(error: OSError) -> None:
+        unreadable.append(str(error.filename or root))
+
+    for directory, subdirectories, filenames in os.walk(
+        root, followlinks=True, onerror=record_unreadable
+    ):
+        real = os.path.realpath(directory)
+        if real in visited:
+            subdirectories[:] = []
+            continue
+        visited.add(real)
+
+        relative_directory = Path(directory).relative_to(root)
         subdirectories[:] = [
-            name for name in subdirectories if not _ignored_directory(name, skill)
+            name
+            for name in subdirectories
+            if name not in IGNORED_DIRECTORY_NAMES
+            and relative_directory / name not in ignored_relative
         ]
         for filename in filenames:
             if _ignored_file(filename):
                 continue
-            path = Path(directory, filename)
-            found.add(path.relative_to(root).as_posix())
-    return found
+            found.add((relative_directory / filename).as_posix())
+
+    return found, unreadable
+
+
+def _declared_name(skill_document: Path) -> str | None:
+    """The `name:` a `SKILL.md` declares in its frontmatter, if it has one."""
+    try:
+        lines = skill_document.read_text(
+            encoding="utf-8", errors="replace"
+        ).splitlines()
+    except OSError:
+        return None
+    if not lines or lines[0].strip() != FRONTMATTER_FENCE:
+        return None
+    for line in lines[1:]:
+        if line.strip() == FRONTMATTER_FENCE:
+            return None
+        match = NAME_FIELD.fullmatch(line.strip())
+        if match:
+            return match.group(1)
+    return None
 
 
 def _repository_skills(repository_root: Path) -> list[str]:
@@ -94,30 +177,70 @@ def _repository_skills(repository_root: Path) -> list[str]:
     )
 
 
+def _installed_copies(skills_root: Path, skills: list[str]) -> dict[str, list[Path]]:
+    """Map each repository skill to every installed directory providing it.
+
+    A directory is matched by the name its `SKILL.md` declares, so a copy
+    renamed on disk is still found. A directory named for a repository skill is
+    matched too, even with an absent or unreadable `SKILL.md`, so a gutted
+    install is reported rather than mistaken for an absent one.
+    """
+    known = set(skills)
+    copies: dict[str, list[Path]] = {}
+    for document in sorted(skills_root.glob("*/SKILL.md")):
+        declared = _declared_name(document) or document.parent.name
+        if declared in known:
+            copies.setdefault(declared, []).append(document.parent)
+    for skill in skills:
+        directory = skills_root / skill
+        if directory.is_dir() and directory not in copies.get(skill, []):
+            copies.setdefault(skill, []).append(directory)
+    return copies
+
+
 def compare(repository_root: Path, skills_root: Path) -> Report:
-    """Compare every repository skill that is installed under `skills_root`."""
+    """Compare every repository skill installed under `skills_root`."""
     report = Report(skills_root=skills_root)
-    for skill in _repository_skills(repository_root):
-        installed = skills_root / skill
-        if not installed.is_dir():
+    skills = _repository_skills(repository_root)
+    installed = _installed_copies(skills_root, skills)
+
+    for skill in skills:
+        directories = installed.get(skill)
+        if not directories:
             report.not_installed.append(skill)
             continue
 
         source = repository_root / "skills" / skill
-        source_files = _relative_files(source, skill)
-        installed_files = _relative_files(installed, skill)
-        comparison = SkillComparison(
-            name=skill,
-            missing=sorted(source_files - installed_files),
-            extra=sorted(installed_files - source_files),
-        )
-        comparison.differing = sorted(
-            relative
-            for relative in source_files & installed_files
-            if not filecmp.cmp(source / relative, installed / relative, shallow=False)
-        )
-        report.compared.append(comparison)
+        source_files, source_unreadable = _distributed_files(source, skill)
+        for directory in sorted(directories):
+            installed_files, installed_unreadable = _distributed_files(directory, skill)
+            comparison = SkillComparison(
+                name=skill,
+                directory=directory,
+                missing=sorted(source_files - installed_files),
+                extra=sorted(installed_files - source_files),
+                unreadable=sorted(source_unreadable + installed_unreadable),
+            )
+            comparison.differing = sorted(
+                relative
+                for relative in source_files & installed_files
+                if not _same_content(source / relative, directory / relative)
+            )
+            report.compared.append(comparison)
     return report
+
+
+def _same_content(source: Path, installed: Path) -> bool:
+    """Whether two distributed files are byte-identical.
+
+    A file that cannot be read at all — a dangling symlink most often — counts
+    as different rather than raising, so one broken entry is reported as drift
+    instead of aborting every remaining skill's comparison.
+    """
+    try:
+        return filecmp.cmp(source, installed, shallow=False)
+    except OSError:
+        return False
 
 
 def render(report: Report) -> str:
@@ -130,24 +253,34 @@ def render(report: Report) -> str:
             lines.append(f"  ok     {comparison.name}")
             continue
         lines.append(f"  drift  {comparison.name}")
+        if comparison.misnamed:
+            lines.append(
+                f"           installed in directory {comparison.directory.name}, "
+                f"which declares skill {comparison.name}"
+            )
         for label, paths in (
             ("differs", comparison.differing),
             ("missing", comparison.missing),
             ("extra", comparison.extra),
+            ("unreadable", comparison.unreadable),
         ):
             lines.extend(f"           {label}: {path}" for path in paths)
 
     if report.not_installed:
         lines.append(f"  not installed: {', '.join(report.not_installed)}")
 
-    drifted = report.drifted
-    if not drifted:
-        lines.append("")
+    lines.append("")
+    if not report.compared:
+        lines.append(
+            f"No skill from this repository is installed in {report.skills_root}, "
+            "so nothing was compared."
+        )
+        return "\n".join(lines)
+    if report.is_clean:
         lines.append("Installed skills match this repository.")
         return "\n".join(lines)
 
-    names = [comparison.name for comparison in drifted]
-    lines.append("")
+    names = sorted({comparison.name for comparison in report.drifted})
     lines.append(f"Installed skills are stale: {', '.join(names)}")
     lines.append("Re-install them from this repository, for example:")
     lines.append(f"  skills update -g -y {' '.join(names)}")
@@ -168,22 +301,24 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def _resolve_skills_root(argument: str | None) -> Path:
-    raw = argument or os.environ.get(SKILLS_ROOT_ENV) or DEFAULT_SKILLS_ROOT
-    return Path(raw).expanduser()
-
-
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(sys.argv[1:] if argv is None else argv)
-    skills_root = _resolve_skills_root(args.skills_root)
+    supplied = args.skills_root or os.environ.get(SKILLS_ROOT_ENV)
+    skills_root = Path(supplied or DEFAULT_SKILLS_ROOT).expanduser()
+
     if not skills_root.is_dir():
+        if supplied:
+            # Naming a root is an assertion that it exists. Skipping quietly
+            # would turn a typo into a check that can never fail.
+            print(f"error: {skills_root} is not a directory", file=sys.stderr)
+            return EXIT_MISCONFIGURED
         print(f"No installed skills directory at {skills_root}; nothing to compare")
-        return 0
+        return EXIT_IN_SYNC
 
     repository_root = Path(__file__).resolve().parents[1]
     report = compare(repository_root, skills_root)
     print(render(report))
-    return 1 if report.drifted else 0
+    return EXIT_IN_SYNC if report.is_clean else EXIT_DRIFTED
 
 
 if __name__ == "__main__":

--- a/scripts/check_installed_skills.py
+++ b/scripts/check_installed_skills.py
@@ -68,7 +68,7 @@ FRONTMATTER_FENCE = "---"
 # Matched only against a line with no leading whitespace, so a `name:` appearing
 # inside an indented block scalar — a description, most plausibly — is not read
 # as the document's own name. The value runs to an unquoted `#` comment.
-NAME_FIELD = re.compile(r"name:\s*(?P<value>[^#]*?)\s*(?:#.*)?$")
+NAME_FIELD = re.compile(r"name:\s*(?P<value>[^#]*?)\s*(?:#.*)?")
 
 
 @dataclass
@@ -105,6 +105,9 @@ class Report:
     skills_root: Path
     compared: list[SkillComparison] = field(default_factory=list)
     not_installed: list[str] = field(default_factory=list)
+    # Where re-installing writes: `<root>/<skill>` for every skill this
+    # repository ships. Removal advice must never name one of these.
+    canonical_directories: set[Path] = field(default_factory=set)
     # Parts of this repository's own `skills/` tree that could not be read. A
     # comparison against a source that could not be enumerated says nothing
     # about the installed copy, so this invalidates the run rather than
@@ -148,23 +151,26 @@ def _distributed_files(root: Path, skill: str) -> tuple[set[str], list[str]]:
     for directory, subdirectories, filenames in os.walk(
         root, followlinks=True, onerror=record_unreadable
     ):
+        relative_directory = Path(directory).relative_to(root)
+        for filename in filenames:
+            if not _ignored_file(filename):
+                found.add((relative_directory / filename).as_posix())
+
+        # Descend once per real directory. Recording this level's files first
+        # means a second path reaching the same place still contributes what it
+        # exposes — two links to one directory are content at both paths — while
+        # a cycle stops here instead of walking forever.
         real = os.path.realpath(directory)
         if real in visited:
             subdirectories[:] = []
             continue
         visited.add(real)
-
-        relative_directory = Path(directory).relative_to(root)
         subdirectories[:] = [
             name
             for name in subdirectories
             if name not in IGNORED_DIRECTORY_NAMES
             and relative_directory / name not in ignored_relative
         ]
-        for filename in filenames:
-            if _ignored_file(filename):
-                continue
-            found.add((relative_directory / filename).as_posix())
 
     return found, unreadable
 
@@ -183,15 +189,18 @@ def _declared_name(skill_document: Path) -> str | None:
     lines = text.splitlines()
     if not lines or lines[0].strip() != FRONTMATTER_FENCE:
         return None
+    declared: str | None = None
     for line in lines[1:]:
         if line.strip() == FRONTMATTER_FENCE:
-            return None
+            break
         if line[:1].isspace():  # inside a nested mapping or a block scalar
             continue
         match = NAME_FIELD.fullmatch(line)
         if match:
-            return match.group("value").strip("\"'") or None
-    return None
+            # Last wins, as a YAML loader resolves a duplicate mapping key, so
+            # this check and the runtime agree on what the document declares.
+            declared = match.group("value").strip("\"'") or None
+    return declared
 
 
 def _repository_skills(repository_root: Path) -> list[str]:
@@ -202,7 +211,7 @@ def _repository_skills(repository_root: Path) -> list[str]:
     )
 
 
-def _installed_copies(skills_root: Path, skills: list[str]) -> dict[str, list[Path]]:
+def _installed_copies(skills_root: Path, skills: list[str]) -> dict[str, set[Path]]:
     """Map each repository skill to every installed directory providing it.
 
     A directory matches on either the name its `SKILL.md` declares or its own
@@ -213,23 +222,25 @@ def _installed_copies(skills_root: Path, skills: list[str]) -> dict[str, list[Pa
     absent one.
     """
     known = set(skills)
-    copies: dict[str, list[Path]] = {}
-    for document in sorted(skills_root.glob("*/SKILL.md")):
+    copies: dict[str, set[Path]] = {skill: set() for skill in skills}
+    for document in skills_root.glob("*/SKILL.md"):
         directory = document.parent
-        for candidate in {_declared_name(document), directory.name}:
-            if candidate in known and directory not in copies.get(candidate, []):
-                copies.setdefault(candidate, []).append(directory)
+        for candidate in {_declared_name(document), directory.name} & known:
+            copies[candidate].add(directory)
     for skill in skills:
         directory = skills_root / skill
-        if directory.is_dir() and directory not in copies.get(skill, []):
-            copies.setdefault(skill, []).append(directory)
+        if directory.is_dir():
+            copies[skill].add(directory)
     return copies
 
 
 def compare(repository_root: Path, skills_root: Path) -> Report:
     """Compare every repository skill installed under `skills_root`."""
-    report = Report(skills_root=skills_root)
     skills = _repository_skills(repository_root)
+    report = Report(
+        skills_root=skills_root,
+        canonical_directories={skills_root / skill for skill in skills},
+    )
     installed = _installed_copies(skills_root, skills)
 
     for skill in skills:
@@ -277,6 +288,24 @@ def render(report: Report) -> str:
     lines = [
         f"Comparing installed skills in {report.skills_root} against this repository"
     ]
+
+    if report.unreadable_sources:
+        # Said instead of the per-skill blocks, not above them. Those blocks are
+        # computed from a source that could not be enumerated, so they invent
+        # `missing` and `extra` entries; printing them under a caveat still
+        # invites an operator to act on a file that is not actually stray.
+        lines.append("")
+        lines.append(
+            "This repository's own skills tree could not be read in full, so no "
+            "comparison is trustworthy. Nothing is reported and no remediation "
+            "is suggested; re-installing from a source this incomplete would "
+            "overwrite good installed files."
+        )
+        lines.extend(
+            f"  unreadable: {path}" for path in sorted(report.unreadable_sources)
+        )
+        return "\n".join(lines)
+
     for comparison in report.compared:
         if not comparison.is_drifted:
             lines.append(f"  ok     {comparison.name}")
@@ -299,51 +328,55 @@ def render(report: Report) -> str:
         lines.append(f"  not installed: {', '.join(report.not_installed)}")
 
     lines.append("")
-    if report.unreadable_sources:
-        # Said before anything else and without remediation: re-installing from
-        # a source that could not be read would overwrite good installed files
-        # with a truncated copy of this repository.
-        lines.append(
-            "This repository's own skills tree could not be read in full, so no "
-            "comparison here is trustworthy:"
-        )
-        lines.extend(
-            f"  unreadable: {path}" for path in sorted(report.unreadable_sources)
-        )
-        return "\n".join(lines)
     if not report.compared:
         lines.append(
             f"No skill from this repository is installed in {report.skills_root}, "
             "so nothing was compared."
         )
-        return "\n".join(lines)
-    if report.is_clean:
+    elif report.is_clean:
         lines.append("Installed skills match this repository.")
-        return "\n".join(lines)
+    else:
+        names = sorted({comparison.name for comparison in report.drifted})
+        lines.append(f"Installed skills are stale: {', '.join(names)}")
+        lines.append("Re-install them from this repository, for example:")
+        lines.append(f"  skills update -g -y {' '.join(names)}")
 
-    names = sorted({comparison.name for comparison in report.drifted})
-    lines.append(f"Installed skills are stale: {', '.join(names)}")
-    lines.append("Re-install them from this repository, for example:")
-    lines.append(f"  skills update -g -y {' '.join(names)}")
-
-    # Re-installing writes `<root>/<skill>`, so it can never clear a copy that
-    # is sitting somewhere else. Those have to be removed by name.
-    stray = sorted(
-        {
-            str(comparison.directory)
-            for comparison in report.drifted
-            if comparison.misnamed
-        }
-    )
-    if stray:
-        lines.append(
-            "Re-installing cannot clear a copy under another directory name. Remove:"
+        # Re-installing writes `<root>/<skill>`, so it can never clear a copy
+        # sitting somewhere else. Those have to be removed by name — but a
+        # directory that is some other skill's canonical location is where a
+        # re-install lands, and telling an operator to delete it would uninstall
+        # that skill one line after installing it.
+        stray = sorted(
+            {
+                str(comparison.directory)
+                for comparison in report.drifted
+                if comparison.misnamed
+                and comparison.directory not in report.canonical_directories
+            }
         )
-        lines.extend(f"  {path}" for path in stray)
+        if stray:
+            lines.append(
+                "Re-installing cannot clear a copy under another directory name. "
+                "Remove:"
+            )
+            lines.extend(f"  {path}" for path in stray)
     return "\n".join(lines)
 
 
-def _parse_args(argv: list[str]) -> argparse.Namespace:
+def exit_code(report: Report) -> int:
+    """The status a completed comparison reports.
+
+    Neither an unreadable source nor an empty comparison set is a statement
+    about the installed copies: one means this repository could not be read, the
+    other that the root holds nothing to compare. Both are the operator's
+    environment, not drift.
+    """
+    if report.unreadable_sources or not report.compared:
+        return EXIT_MISCONFIGURED
+    return EXIT_IN_SYNC if report.is_clean else EXIT_DRIFTED
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Compare installed skill copies against this repository."
     )
@@ -358,9 +391,13 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
 
 
 def main(argv: list[str] | None = None) -> int:
-    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    args = _parse_args(argv)
     supplied = args.skills_root or os.environ.get(SKILLS_ROOT_ENV)
     skills_root = Path(supplied or DEFAULT_SKILLS_ROOT).expanduser()
+    if skills_root.is_dir():
+        # Resolved so a removal target printed below is an absolute path
+        # rather than something relative to the caller's directory.
+        skills_root = skills_root.resolve()
 
     if not skills_root.is_dir():
         if supplied:
@@ -374,12 +411,7 @@ def main(argv: list[str] | None = None) -> int:
     repository_root = Path(__file__).resolve().parents[1]
     report = compare(repository_root, skills_root)
     print(render(report))
-    if report.unreadable_sources or not report.compared:
-        # Neither is a statement about the installed copies: one means this
-        # repository could not be read, the other that the root holds nothing
-        # to compare. Both are the operator's environment, not drift.
-        return EXIT_MISCONFIGURED
-    return EXIT_IN_SYNC if report.is_clean else EXIT_DRIFTED
+    return exit_code(report)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_check_installed_skills.py
+++ b/scripts/tests/test_check_installed_skills.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import json
+import shutil
+import sys
+import tempfile
+import unittest
+import unittest.mock
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location(
+    "check_installed_skills", REPOSITORY_ROOT / "scripts" / "check_installed_skills.py"
+)
+assert SPEC is not None and SPEC.loader is not None
+check_installed_skills = importlib.util.module_from_spec(SPEC)
+# Registered before execution so the module's dataclasses can resolve their own
+# module namespace during class creation.
+sys.modules[SPEC.name] = check_installed_skills
+SPEC.loader.exec_module(check_installed_skills)
+
+DISTRIBUTION_EXCLUSIONS = shutil.ignore_patterns(
+    "__pycache__", "*.pyc", ".skill-state", ".DS_Store"
+)
+
+
+class CheckInstalledSkillsTests(unittest.TestCase):
+    """The command's observable contract: what it prints and what it exits."""
+
+    def setUp(self) -> None:
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        self.skills_root = Path(directory.name)
+
+    def install(self, *skills: str) -> None:
+        """Copy repository skills into the fixture as a distribution would."""
+        sources = (
+            [REPOSITORY_ROOT / "skills" / skill for skill in skills]
+            if skills
+            else sorted(
+                path.parent
+                for path in (REPOSITORY_ROOT / "skills").glob("*/SKILL.md")
+                if path.is_file()
+            )
+        )
+        for source in sources:
+            shutil.copytree(
+                source, self.skills_root / source.name, ignore=DISTRIBUTION_EXCLUSIONS
+            )
+
+    def run_check(self, *extra_argv: str) -> tuple[int, str]:
+        stream = io.StringIO()
+        with contextlib.redirect_stdout(stream):
+            status = check_installed_skills.main(
+                ["--skills-root", str(self.skills_root), *extra_argv]
+            )
+        return status, stream.getvalue()
+
+    def test_faithful_install_reports_no_drift(self) -> None:
+        self.install()
+
+        status, output = self.run_check()
+
+        self.assertEqual(status, 0)
+        self.assertIn("Installed skills match this repository.", output)
+        self.assertNotIn("drift", output)
+
+    def test_stale_bundled_review_contract_is_reported(self) -> None:
+        """A stale bundled contract is the drift that silently weakens review."""
+        self.install()
+        bundled = (
+            self.skills_root
+            / "review-correctness"
+            / "references"
+            / "review-suite"
+            / "review-result.schema.json"
+        )
+        schema = json.loads(bundled.read_text(encoding="utf-8"))
+        schema["properties"]["schema_version"] = {"const": "1.0"}
+        schema["properties"].pop("lens_executions", None)
+        bundled.write_text(json.dumps(schema), encoding="utf-8")
+
+        status, output = self.run_check()
+
+        self.assertEqual(status, 1)
+        self.assertIn("drift  review-correctness", output)
+        self.assertIn(
+            "differs: references/review-suite/review-result.schema.json", output
+        )
+        self.assertIn("Installed skills are stale: review-correctness", output)
+
+    def test_stale_skill_prose_is_reported(self) -> None:
+        """A dropped required section is drift even when every file is present."""
+        self.install()
+        skill_document = self.skills_root / "review-correctness" / "SKILL.md"
+        body = skill_document.read_text(encoding="utf-8")
+        skill_document.write_text(
+            body.replace("## Perform the required traversal pass", ""), encoding="utf-8"
+        )
+
+        status, output = self.run_check()
+
+        self.assertEqual(status, 1)
+        self.assertIn("differs: SKILL.md", output)
+
+    def test_absent_bundled_directory_is_reported(self) -> None:
+        self.install()
+        shutil.rmtree(
+            self.skills_root / "review-code-change" / "references" / "review-suite"
+        )
+
+        status, output = self.run_check()
+
+        self.assertEqual(status, 1)
+        self.assertIn("missing: references/review-suite/validate.py", output)
+
+    def test_file_only_in_the_installed_copy_is_reported(self) -> None:
+        self.install()
+        (self.skills_root / "review-correctness" / "leftover.md").write_text(
+            "from an older release\n", encoding="utf-8"
+        )
+
+        status, output = self.run_check()
+
+        self.assertEqual(status, 1)
+        self.assertIn("extra: leftover.md", output)
+
+    def test_runtime_byproducts_are_not_drift(self) -> None:
+        """Caches and skill-local state are written at runtime, not distributed."""
+        self.install()
+        installed = self.skills_root / "review-correctness"
+        (installed / "scripts" / "__pycache__").mkdir(parents=True, exist_ok=True)
+        (installed / "scripts" / "__pycache__" / "helper.cpython-313.pyc").write_bytes(
+            b"\x00"
+        )
+        (installed / ".skill-state").mkdir(exist_ok=True)
+        (installed / ".skill-state" / "run.json").write_text("{}", encoding="utf-8")
+        (installed / ".review-correctness").mkdir(exist_ok=True)
+        (installed / ".review-correctness" / "notes.md").write_text(
+            "scratch\n", encoding="utf-8"
+        )
+        (installed / ".DS_Store").write_bytes(b"\x00")
+
+        status, output = self.run_check()
+
+        self.assertEqual(status, 0)
+        self.assertIn("Installed skills match this repository.", output)
+
+    def test_uninstalled_skill_is_named_without_failing(self) -> None:
+        """Choosing not to install a skill is not drift in the ones installed."""
+        self.install("review-correctness")
+
+        status, output = self.run_check()
+
+        self.assertEqual(status, 0)
+        self.assertIn("ok     review-correctness", output)
+        self.assertIn("not installed: ", output)
+        self.assertIn("babysit-pr", output.split("not installed: ")[1])
+
+    def test_absent_skills_root_is_skipped(self) -> None:
+        """Continuous integration has no installed distribution to compare."""
+        self.skills_root = self.skills_root / "nonexistent"
+
+        status, output = self.run_check()
+
+        self.assertEqual(status, 0)
+        self.assertIn("nothing to compare", output)
+
+    def test_skills_root_comes_from_the_environment_when_unset(self) -> None:
+        self.install()
+        with unittest.mock.patch.dict(
+            "os.environ",
+            {check_installed_skills.SKILLS_ROOT_ENV: str(self.skills_root)},
+        ):
+            stream = io.StringIO()
+            with contextlib.redirect_stdout(stream):
+                status = check_installed_skills.main([])
+
+        self.assertEqual(status, 0)
+        self.assertIn(str(self.skills_root), stream.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_check_installed_skills.py
+++ b/scripts/tests/test_check_installed_skills.py
@@ -205,6 +205,23 @@ class CheckInstalledSkillsTests(unittest.TestCase):
         self.assertIn("drift  alpha", output)
         self.assertNotIn(str(installed_root / "beta"), output.split("Remove:")[-1])
 
+    def test_removal_advice_compares_directories_by_identity_not_by_path(self) -> None:
+        """The guard has to hold wherever one directory has two unequal paths.
+
+        A symlink to the canonical directory is that case on every filesystem,
+        so this pins the guard where continuous integration runs. The
+        case-folding test below is the same defect's real-world trigger, but it
+        can only run where the filesystem folds case.
+        """
+        self.install(A_SKILL)
+        stray = self.skills_root / f"{A_SKILL}-old"
+        stray.symlink_to(self.skills_root / A_SKILL, target_is_directory=True)
+
+        status, output = self.run_check()
+
+        self.assertEqual(status, 1)
+        self.assertNotIn("Remove:", output)
+
     def test_removal_advice_survives_a_case_insensitive_filesystem(self) -> None:
         """The default skills root lives on one, where two names are one directory."""
         installed = self.install(A_SKILL, as_directory=A_SKILL.title())

--- a/scripts/tests/test_check_installed_skills.py
+++ b/scripts/tests/test_check_installed_skills.py
@@ -158,6 +158,77 @@ class CheckInstalledSkillsTests(unittest.TestCase):
         self.assertEqual(status, 1)
         self.assertIn(f"installed in directory {A_SKILL}-backup", output)
 
+    def test_a_stray_copy_is_told_to_be_removed_not_re_installed(self) -> None:
+        """Re-installing writes `<root>/<skill>`, so it never clears a stray copy."""
+        stray = self.install(A_SKILL, as_directory=f"{A_SKILL}-backup")
+
+        status, output = self.run_check()
+
+        self.assertEqual(status, 1)
+        self.assertIn(
+            "Re-installing cannot clear a copy under another directory", output
+        )
+        self.assertIn(str(stray), output)
+
+    def test_renamed_copy_is_found_whatever_its_frontmatter_looks_like(self) -> None:
+        """Matching must not hinge on one spelling of the declared name.
+
+        A copy under another directory name is found by what its `SKILL.md`
+        declares, so every frontmatter shape a real skill might carry has to
+        reach the same verdict as the plain unquoted one.
+        """
+        for index, declaration in enumerate(
+            (
+                f"name: {A_SKILL}",
+                f'name: "{A_SKILL}"',
+                f"name: '{A_SKILL}'",
+                f"name: {A_SKILL}  # canonical",
+                f"name:    {A_SKILL}",
+            )
+        ):
+            with self.subTest(declaration=declaration):
+                self.setUp()
+                installed = self.install(A_SKILL, as_directory=f"{A_SKILL}-old{index}")
+                document = installed / "SKILL.md"
+                body = document.read_text(encoding="utf-8").splitlines()
+                body[1] = declaration
+                document.write_text(
+                    "\n".join(body) + "\nSTALE RUBRIC\n", encoding="utf-8"
+                )
+
+                status, output = self.run_check()
+
+                self.assertEqual(status, 1)
+                self.assertIn(f"drift  {A_SKILL}", output)
+                self.assertNotIn(A_SKILL, self.not_installed_line(output))
+
+    def test_unparsable_frontmatter_still_matches_on_the_directory_name(self) -> None:
+        """A frontmatter this check cannot read must not hide an installed copy."""
+        installed = self.install(A_SKILL)
+        document = installed / "SKILL.md"
+        document.write_text("no frontmatter at all\n", encoding="utf-8")
+
+        status, output = self.run_check()
+
+        self.assertEqual(status, 1)
+        self.assertIn("differs: SKILL.md", output)
+        self.assertNotIn(A_SKILL, self.not_installed_line(output))
+
+    def test_a_name_inside_a_block_scalar_is_not_the_declared_name(self) -> None:
+        """An indented `name:` belongs to the value it sits in, not the document."""
+        stray = self.skills_root / "unrelated"
+        stray.mkdir()
+        (stray / "SKILL.md").write_text(
+            f"---\nname: unrelated\ndescription: |\n  name: {A_SKILL}\n---\n",
+            encoding="utf-8",
+        )
+        self.install(A_SKILL)
+
+        status, output = self.run_check()
+
+        self.assertEqual(status, 0)
+        self.assertIn(f"ok     {A_SKILL}", output)
+
     def test_gutted_install_is_reported_rather_than_called_absent(self) -> None:
         installed = self.install(A_SKILL)
         (installed / "SKILL.md").unlink()
@@ -178,9 +249,39 @@ class CheckInstalledSkillsTests(unittest.TestCase):
 
         status, output = self.run_check()
 
-        self.assertEqual(status, 1)
+        self.assertEqual(status, 2)
         self.assertIn("nothing was compared", output)
         self.assertNotIn("Installed skills match this repository.", output)
+
+    def test_unreadable_repository_source_invalidates_the_run(self) -> None:
+        """A source that cannot be enumerated says nothing about a copy of it.
+
+        Reporting it as installed-copy drift would print remediation that
+        overwrites good installed files with a truncated source.
+        """
+        repository = self.skills_root / "repository"
+        source = repository / "skills" / "demo"
+        (source / "references").mkdir(parents=True)
+        (source / "SKILL.md").write_text("---\nname: demo\n---\n", encoding="utf-8")
+        (source / "references" / "rubric.md").write_text("rubric\n", encoding="utf-8")
+
+        installed_root = self.skills_root / "installed"
+        shutil.copytree(source, installed_root / "demo")
+
+        blocked = source / "references"
+        original_mode = blocked.stat().st_mode
+        blocked.chmod(0o000)
+        self.addCleanup(blocked.chmod, original_mode)
+        if os.access(blocked, os.R_OK):  # pragma: no cover - root ignores the mode
+            self.skipTest("filesystem does not enforce directory permissions")
+
+        report = check_installed_skills.compare(repository, installed_root)
+        output = check_installed_skills.render(report)
+
+        self.assertIn("could not be read in full", output)
+        self.assertIn(f"unreadable: {blocked}", output)
+        self.assertNotIn("skills update", output)
+        self.assertFalse(report.is_clean)
 
     def test_named_skills_root_that_does_not_exist_is_an_error(self) -> None:
         self.skills_root = self.skills_root / "typo"

--- a/scripts/tests/test_check_installed_skills.py
+++ b/scripts/tests/test_check_installed_skills.py
@@ -34,9 +34,21 @@ class CheckInstalledSkillsTests(unittest.TestCase):
     """The command's observable contract: what it prints and what it exits."""
 
     def setUp(self) -> None:
+        self.fresh_skills_root()
+
+    def fresh_skills_root(self) -> None:
+        """Allocate an empty installed-skills directory for one scenario."""
         directory = tempfile.TemporaryDirectory()
         self.addCleanup(directory.cleanup)
         self.skills_root = Path(directory.name)
+
+    def write_skill(self, directory: Path, declared: str, body: str = "") -> Path:
+        """A minimal skill folder, for cases the real `skills/` cannot express."""
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / "SKILL.md").write_text(
+            f"---\nname: {declared}\n---\n{body}", encoding="utf-8"
+        )
+        return directory
 
     def install(self, *skills: str, as_directory: str | None = None) -> Path:
         """Copy repository skills into the fixture as a distribution would."""
@@ -170,6 +182,61 @@ class CheckInstalledSkillsTests(unittest.TestCase):
         )
         self.assertIn(str(stray), output)
 
+    def test_removal_advice_never_names_another_skills_install_directory(self) -> None:
+        """The one destructive instruction must not undo a re-install.
+
+        A directory matches on its declared name as well as its own, so one
+        directory can be attributed to two skills. If it is where a re-install
+        writes some other skill, telling the operator to delete it uninstalls
+        that skill one line after installing it.
+        """
+        repository = self.skills_root / "repository"
+        self.write_skill(repository / "skills" / "alpha", "alpha")
+        self.write_skill(repository / "skills" / "beta", "beta")
+
+        installed_root = self.skills_root / "installed"
+        # `<root>/beta` is where re-installing `beta` lands, and it declares
+        # `alpha`, so it is matched as a stray copy of `alpha` as well.
+        self.write_skill(installed_root / "beta", "alpha")
+
+        report = check_installed_skills.compare(repository, installed_root)
+        output = check_installed_skills.render(report)
+
+        self.assertIn("drift  alpha", output)
+        self.assertNotIn(str(installed_root / "beta"), output.split("Remove:")[-1])
+
+    def test_a_duplicated_name_key_resolves_the_way_a_loader_resolves_it(self) -> None:
+        """Last wins, so this check and the runtime agree on what is declared."""
+        repository = self.skills_root / "repository"
+        self.write_skill(repository / "skills" / "alpha", "alpha")
+
+        installed_root = self.skills_root / "installed"
+        stray = installed_root / "zzz"
+        stray.mkdir(parents=True)
+        (stray / "SKILL.md").write_text(
+            "---\nname: something-else\nname: alpha\n---\n", encoding="utf-8"
+        )
+
+        report = check_installed_skills.compare(repository, installed_root)
+
+        self.assertEqual([comparison.name for comparison in report.compared], ["alpha"])
+        self.assertEqual(report.not_installed, [])
+
+    def test_a_second_link_to_one_directory_still_contributes_its_content(self) -> None:
+        """Descending once per real directory must not drop what a path exposes."""
+        installed = self.install(A_SKILL)
+        shared = self.skills_root / "shared"
+        shared.mkdir()
+        (shared / "leftover.md").write_text("from an older release\n", "utf-8")
+        (installed / "one").symlink_to(shared, target_is_directory=True)
+        (installed / "two").symlink_to(shared, target_is_directory=True)
+
+        status, output = self.run_check()
+
+        self.assertEqual(status, 1)
+        self.assertIn("extra: one/leftover.md", output)
+        self.assertIn("extra: two/leftover.md", output)
+
     def test_renamed_copy_is_found_whatever_its_frontmatter_looks_like(self) -> None:
         """Matching must not hinge on one spelling of the declared name.
 
@@ -177,20 +244,21 @@ class CheckInstalledSkillsTests(unittest.TestCase):
         declares, so every frontmatter shape a real skill might carry has to
         reach the same verdict as the plain unquoted one.
         """
-        for index, declaration in enumerate(
-            (
-                f"name: {A_SKILL}",
-                f'name: "{A_SKILL}"',
-                f"name: '{A_SKILL}'",
-                f"name: {A_SKILL}  # canonical",
-                f"name:    {A_SKILL}",
-            )
+        for declaration in (
+            f"name: {A_SKILL}",
+            f'name: "{A_SKILL}"',
+            f"name: '{A_SKILL}'",
+            f"name: {A_SKILL}  # canonical",
+            f"name:    {A_SKILL}",
         ):
             with self.subTest(declaration=declaration):
-                self.setUp()
-                installed = self.install(A_SKILL, as_directory=f"{A_SKILL}-old{index}")
+                self.fresh_skills_root()
+                installed = self.install(A_SKILL, as_directory=f"{A_SKILL}-old")
                 document = installed / "SKILL.md"
                 body = document.read_text(encoding="utf-8").splitlines()
+                # Pinned: replacing a line that is not the declaration would
+                # leave the original in place and test a two-`name:` document.
+                self.assertTrue(body[1].startswith("name:"), body[1])
                 body[1] = declaration
                 document.write_text(
                     "\n".join(body) + "\nSTALE RUBRIC\n", encoding="utf-8"
@@ -281,7 +349,11 @@ class CheckInstalledSkillsTests(unittest.TestCase):
         self.assertIn("could not be read in full", output)
         self.assertIn(f"unreadable: {blocked}", output)
         self.assertNotIn("skills update", output)
-        self.assertFalse(report.is_clean)
+        self.assertNotIn("extra:", output)
+        self.assertEqual(
+            check_installed_skills.exit_code(report),
+            check_installed_skills.EXIT_MISCONFIGURED,
+        )
 
     def test_named_skills_root_that_does_not_exist_is_an_error(self) -> None:
         self.skills_root = self.skills_root / "typo"

--- a/scripts/tests/test_check_installed_skills.py
+++ b/scripts/tests/test_check_installed_skills.py
@@ -205,6 +205,35 @@ class CheckInstalledSkillsTests(unittest.TestCase):
         self.assertIn("drift  alpha", output)
         self.assertNotIn(str(installed_root / "beta"), output.split("Remove:")[-1])
 
+    def test_removal_advice_survives_a_case_insensitive_filesystem(self) -> None:
+        """The default skills root lives on one, where two names are one directory."""
+        installed = self.install(A_SKILL, as_directory=A_SKILL.title())
+        canonical = self.skills_root / A_SKILL
+        if not canonical.is_dir() or not installed.samefile(canonical):
+            self.skipTest("filesystem is case-sensitive")
+
+        status, output = self.run_check()
+
+        self.assertEqual(status, 1)
+        self.assertNotIn("Remove:", output)
+
+    def test_content_after_the_frontmatter_is_not_the_declared_name(self) -> None:
+        """Reading past the closing fence would let prose rename a copy."""
+        repository = self.skills_root / "repository"
+        self.write_skill(repository / "skills" / "alpha", "alpha")
+
+        installed_root = self.skills_root / "installed"
+        stray = installed_root / "zzz"
+        stray.mkdir(parents=True)
+        (stray / "SKILL.md").write_text(
+            "---\nname: unrelated\n---\n\nname: alpha\n", encoding="utf-8"
+        )
+
+        report = check_installed_skills.compare(repository, installed_root)
+
+        self.assertEqual(report.compared, [])
+        self.assertEqual(report.not_installed, ["alpha"])
+
     def test_a_duplicated_name_key_resolves_the_way_a_loader_resolves_it(self) -> None:
         """Last wins, so this check and the runtime agree on what is declared."""
         repository = self.skills_root / "repository"

--- a/scripts/tests/test_check_installed_skills.py
+++ b/scripts/tests/test_check_installed_skills.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import contextlib
 import importlib.util
 import io
-import json
+import os
 import shutil
 import sys
 import tempfile
@@ -22,9 +22,12 @@ check_installed_skills = importlib.util.module_from_spec(SPEC)
 sys.modules[SPEC.name] = check_installed_skills
 SPEC.loader.exec_module(check_installed_skills)
 
-DISTRIBUTION_EXCLUSIONS = shutil.ignore_patterns(
-    "__pycache__", "*.pyc", ".skill-state", ".DS_Store"
-)
+DISTRIBUTION_EXCLUSIONS = shutil.ignore_patterns("__pycache__", "*.pyc", ".DS_Store")
+
+# Named only as fixture material. Assertions below never depend on their prose,
+# so renaming a heading inside either skill cannot silently defuse a test.
+A_SKILL = "review-correctness"
+ANOTHER_SKILL = "review-code-change"
 
 
 class CheckInstalledSkillsTests(unittest.TestCase):
@@ -35,7 +38,7 @@ class CheckInstalledSkillsTests(unittest.TestCase):
         self.addCleanup(directory.cleanup)
         self.skills_root = Path(directory.name)
 
-    def install(self, *skills: str) -> None:
+    def install(self, *skills: str, as_directory: str | None = None) -> Path:
         """Copy repository skills into the fixture as a distribution would."""
         sources = (
             [REPOSITORY_ROOT / "skills" / skill for skill in skills]
@@ -46,18 +49,28 @@ class CheckInstalledSkillsTests(unittest.TestCase):
                 if path.is_file()
             )
         )
+        destination = self.skills_root
         for source in sources:
-            shutil.copytree(
-                source, self.skills_root / source.name, ignore=DISTRIBUTION_EXCLUSIONS
-            )
+            destination = self.skills_root / (as_directory or source.name)
+            shutil.copytree(source, destination, ignore=DISTRIBUTION_EXCLUSIONS)
+        return destination
 
     def run_check(self, *extra_argv: str) -> tuple[int, str]:
         stream = io.StringIO()
-        with contextlib.redirect_stdout(stream):
+        errors = io.StringIO()
+        with contextlib.redirect_stdout(stream), contextlib.redirect_stderr(errors):
             status = check_installed_skills.main(
                 ["--skills-root", str(self.skills_root), *extra_argv]
             )
-        return status, stream.getvalue()
+        return status, stream.getvalue() + errors.getvalue()
+
+    def not_installed_line(self, output: str) -> str:
+        """The skills the report says are absent, as one line."""
+        return next(
+            (line for line in output.splitlines() if "not installed: " in line), ""
+        )
+
+    # --- a faithful install ------------------------------------------------
 
     def test_faithful_install_reports_no_drift(self) -> None:
         self.install()
@@ -68,38 +81,35 @@ class CheckInstalledSkillsTests(unittest.TestCase):
         self.assertIn("Installed skills match this repository.", output)
         self.assertNotIn("drift", output)
 
+    # --- drift the check exists to catch ------------------------------------
+
     def test_stale_bundled_review_contract_is_reported(self) -> None:
         """A stale bundled contract is the drift that silently weakens review."""
-        self.install()
+        installed = self.install(A_SKILL)
         bundled = (
-            self.skills_root
-            / "review-correctness"
-            / "references"
-            / "review-suite"
-            / "review-result.schema.json"
+            installed / "references" / "review-suite" / "review-result.schema.json"
         )
-        schema = json.loads(bundled.read_text(encoding="utf-8"))
-        schema["properties"]["schema_version"] = {"const": "1.0"}
-        schema["properties"].pop("lens_executions", None)
-        bundled.write_text(json.dumps(schema), encoding="utf-8")
+        bundled.write_text(
+            bundled.read_text(encoding="utf-8").replace('"1.', '"0.', 1),
+            encoding="utf-8",
+        )
 
         status, output = self.run_check()
 
         self.assertEqual(status, 1)
-        self.assertIn("drift  review-correctness", output)
+        self.assertIn(f"drift  {A_SKILL}", output)
         self.assertIn(
             "differs: references/review-suite/review-result.schema.json", output
         )
-        self.assertIn("Installed skills are stale: review-correctness", output)
+        self.assertIn(f"Installed skills are stale: {A_SKILL}", output)
 
-    def test_stale_skill_prose_is_reported(self) -> None:
-        """A dropped required section is drift even when every file is present."""
-        self.install()
-        skill_document = self.skills_root / "review-correctness" / "SKILL.md"
-        body = skill_document.read_text(encoding="utf-8")
-        skill_document.write_text(
-            body.replace("## Perform the required traversal pass", ""), encoding="utf-8"
-        )
+    def test_same_length_edit_is_reported(self) -> None:
+        """Byte comparison, not size comparison: one flipped character is drift."""
+        installed = self.install(A_SKILL)
+        document = installed / "SKILL.md"
+        original = document.read_bytes()
+        document.write_bytes(bytes([original[0] ^ 0x20]) + original[1:])
+        self.assertEqual(len(document.read_bytes()), len(original))
 
         status, output = self.run_check()
 
@@ -107,10 +117,8 @@ class CheckInstalledSkillsTests(unittest.TestCase):
         self.assertIn("differs: SKILL.md", output)
 
     def test_absent_bundled_directory_is_reported(self) -> None:
-        self.install()
-        shutil.rmtree(
-            self.skills_root / "review-code-change" / "references" / "review-suite"
-        )
+        installed = self.install(ANOTHER_SKILL)
+        shutil.rmtree(installed / "references" / "review-suite")
 
         status, output = self.run_check()
 
@@ -118,31 +126,172 @@ class CheckInstalledSkillsTests(unittest.TestCase):
         self.assertIn("missing: references/review-suite/validate.py", output)
 
     def test_file_only_in_the_installed_copy_is_reported(self) -> None:
-        self.install()
-        (self.skills_root / "review-correctness" / "leftover.md").write_text(
-            "from an older release\n", encoding="utf-8"
-        )
+        installed = self.install(A_SKILL)
+        (installed / "leftover.md").write_text("from an older release\n", "utf-8")
 
         status, output = self.run_check()
 
         self.assertEqual(status, 1)
         self.assertIn("extra: leftover.md", output)
 
+    def test_stale_copy_under_another_directory_name_is_reported(self) -> None:
+        """A renamed copy still declares its skill, so it still loads and runs."""
+        installed = self.install(A_SKILL, as_directory=f"{A_SKILL}-old")
+        document = installed / "SKILL.md"
+        document.write_text(
+            document.read_text(encoding="utf-8") + "\nSTALE RUBRIC\n", encoding="utf-8"
+        )
+
+        status, output = self.run_check()
+
+        self.assertEqual(status, 1)
+        self.assertIn(f"drift  {A_SKILL}", output)
+        self.assertIn(f"installed in directory {A_SKILL}-old", output)
+        self.assertNotIn(A_SKILL, self.not_installed_line(output))
+
+    def test_faithful_copy_under_another_directory_name_is_still_reported(self) -> None:
+        """The directory name is itself drift: re-installing will not replace it."""
+        self.install(A_SKILL, as_directory=f"{A_SKILL}-backup")
+
+        status, output = self.run_check()
+
+        self.assertEqual(status, 1)
+        self.assertIn(f"installed in directory {A_SKILL}-backup", output)
+
+    def test_gutted_install_is_reported_rather_than_called_absent(self) -> None:
+        installed = self.install(A_SKILL)
+        (installed / "SKILL.md").unlink()
+
+        status, output = self.run_check()
+
+        self.assertEqual(status, 1)
+        self.assertIn("missing: SKILL.md", output)
+        self.assertNotIn(A_SKILL, self.not_installed_line(output))
+
+    # --- failures that must not pass quietly --------------------------------
+
+    def test_skills_root_holding_no_repository_skill_is_not_a_match(self) -> None:
+        """The misconfigured-path case must never render as a clean result."""
+        foreign = self.skills_root / "some-unrelated-skill"
+        foreign.mkdir()
+        (foreign / "SKILL.md").write_text("---\nname: unrelated\n---\n", "utf-8")
+
+        status, output = self.run_check()
+
+        self.assertEqual(status, 1)
+        self.assertIn("nothing was compared", output)
+        self.assertNotIn("Installed skills match this repository.", output)
+
+    def test_named_skills_root_that_does_not_exist_is_an_error(self) -> None:
+        self.skills_root = self.skills_root / "typo"
+
+        status, output = self.run_check()
+
+        self.assertEqual(status, 2)
+        self.assertIn("is not a directory", output)
+
+    def test_named_skills_root_that_is_a_file_is_an_error(self) -> None:
+        target = self.skills_root / "not-a-directory"
+        target.write_text("", encoding="utf-8")
+        self.skills_root = target
+
+        status, output = self.run_check()
+
+        self.assertEqual(status, 2)
+        self.assertIn("is not a directory", output)
+
+    def test_absent_default_skills_root_is_skipped(self) -> None:
+        """Continuous integration has no installed distribution to compare."""
+        with tempfile.TemporaryDirectory() as home:
+            environment = {key: value for key, value in os.environ.items()}
+            environment.pop(check_installed_skills.SKILLS_ROOT_ENV, None)
+            environment["HOME"] = home
+            with unittest.mock.patch.dict(os.environ, environment, clear=True):
+                stream = io.StringIO()
+                with contextlib.redirect_stdout(stream):
+                    status = check_installed_skills.main([])
+
+        self.assertEqual(status, 0)
+        self.assertIn("nothing to compare", stream.getvalue())
+
+    def test_unreadable_file_is_reported_and_later_skills_still_compared(self) -> None:
+        """One dangling entry must not abort the rest of the run."""
+        installed = self.install(A_SKILL)
+        self.install(ANOTHER_SKILL)
+        document = installed / "SKILL.md"
+        document.unlink()
+        document.symlink_to(self.skills_root / "does-not-exist")
+
+        status, output = self.run_check()
+
+        self.assertEqual(status, 1)
+        self.assertIn("differs: SKILL.md", output)
+        self.assertIn(f"ok     {ANOTHER_SKILL}", output)
+
+    def test_unreadable_directory_is_reported_rather_than_skipped(self) -> None:
+        installed = self.install(A_SKILL)
+        blocked = installed / "references"
+        original_mode = blocked.stat().st_mode
+        blocked.chmod(0o000)
+        self.addCleanup(blocked.chmod, original_mode)
+        if os.access(blocked, os.R_OK):  # pragma: no cover - root ignores the mode
+            self.skipTest("filesystem does not enforce directory permissions")
+
+        status, output = self.run_check()
+
+        self.assertEqual(status, 1)
+        self.assertIn("unreadable:", output)
+
+    # --- what is deliberately not drift -------------------------------------
+
     def test_runtime_byproducts_are_not_drift(self) -> None:
         """Caches and skill-local state are written at runtime, not distributed."""
-        self.install()
-        installed = self.skills_root / "review-correctness"
+        installed = self.install(A_SKILL)
         (installed / "scripts" / "__pycache__").mkdir(parents=True, exist_ok=True)
         (installed / "scripts" / "__pycache__" / "helper.cpython-313.pyc").write_bytes(
             b"\x00"
         )
+        (installed / "stray.pyc").write_bytes(b"\x00")
         (installed / ".skill-state").mkdir(exist_ok=True)
         (installed / ".skill-state" / "run.json").write_text("{}", encoding="utf-8")
-        (installed / ".review-correctness").mkdir(exist_ok=True)
-        (installed / ".review-correctness" / "notes.md").write_text(
-            "scratch\n", encoding="utf-8"
-        )
+        (installed / f".{A_SKILL}").mkdir(exist_ok=True)
+        (installed / f".{A_SKILL}" / "notes.md").write_text("scratch\n", "utf-8")
         (installed / ".DS_Store").write_bytes(b"\x00")
+
+        status, output = self.run_check()
+
+        self.assertEqual(status, 0)
+        self.assertIn("Installed skills match this repository.", output)
+
+    def test_eval_receipts_are_not_drift(self) -> None:
+        """`just eval-record` appends receipts that no installed skill reads."""
+        installed = self.install(A_SKILL)
+        receipts = installed / "evals" / "results"
+        receipts.mkdir(parents=True, exist_ok=True)
+        (receipts / "2099-01-01T000000Z-0001-baseline.json").write_text("{}", "utf-8")
+
+        status, output = self.run_check()
+
+        self.assertEqual(status, 0)
+        self.assertIn("Installed skills match this repository.", output)
+
+    def test_skill_local_ignore_applies_only_at_the_skill_root(self) -> None:
+        """The record-keeping convention is a root concern, not a name wildcard."""
+        installed = self.install(A_SKILL)
+        nested = installed / "references" / f".{A_SKILL}"
+        nested.mkdir(parents=True, exist_ok=True)
+        (nested / "smuggled.md").write_text("distributed content\n", "utf-8")
+
+        status, output = self.run_check()
+
+        self.assertEqual(status, 1)
+        self.assertIn(f"extra: references/.{A_SKILL}/smuggled.md", output)
+
+    def test_symlinked_directory_with_identical_content_is_not_drift(self) -> None:
+        installed = self.install(A_SKILL)
+        moved = self.skills_root / "elsewhere"
+        shutil.move(str(installed / "references"), str(moved))
+        (installed / "references").symlink_to(moved, target_is_directory=True)
 
         status, output = self.run_check()
 
@@ -151,28 +300,21 @@ class CheckInstalledSkillsTests(unittest.TestCase):
 
     def test_uninstalled_skill_is_named_without_failing(self) -> None:
         """Choosing not to install a skill is not drift in the ones installed."""
-        self.install("review-correctness")
+        self.install(A_SKILL)
 
         status, output = self.run_check()
 
         self.assertEqual(status, 0)
-        self.assertIn("ok     review-correctness", output)
+        self.assertIn(f"ok     {A_SKILL}", output)
         self.assertIn("not installed: ", output)
-        self.assertIn("babysit-pr", output.split("not installed: ")[1])
+        self.assertIn(ANOTHER_SKILL, self.not_installed_line(output))
 
-    def test_absent_skills_root_is_skipped(self) -> None:
-        """Continuous integration has no installed distribution to compare."""
-        self.skills_root = self.skills_root / "nonexistent"
-
-        status, output = self.run_check()
-
-        self.assertEqual(status, 0)
-        self.assertIn("nothing to compare", output)
+    # --- root resolution ----------------------------------------------------
 
     def test_skills_root_comes_from_the_environment_when_unset(self) -> None:
         self.install()
         with unittest.mock.patch.dict(
-            "os.environ",
+            os.environ,
             {check_installed_skills.SKILLS_ROOT_ENV: str(self.skills_root)},
         ):
             stream = io.StringIO()
@@ -181,6 +323,18 @@ class CheckInstalledSkillsTests(unittest.TestCase):
 
         self.assertEqual(status, 0)
         self.assertIn(str(self.skills_root), stream.getvalue())
+
+    def test_named_skills_root_wins_over_the_environment(self) -> None:
+        self.install()
+        with unittest.mock.patch.dict(
+            os.environ,
+            {check_installed_skills.SKILLS_ROOT_ENV: "/nonexistent/from/environment"},
+        ):
+            status, output = self.run_check()
+
+        self.assertEqual(status, 0)
+        self.assertIn(str(self.skills_root), output)
+        self.assertNotIn("from/environment", output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds `scripts/check_installed_skills.py` and the `just check-installed` recipe,
which compare an installed skills directory against this repository's working
tree, name every differing, absent, and leftover file per skill, and exit
non-zero on drift. Root resolution is `--skills-root` → `$AGENTS_SKILLS_DIR` →
`~/.agents/skills`.

Six commits: the check, then five rounds of adversarial read-only review that
found and fixed 17 defects in it.

## Why

A skill is distributed by copying its folder out of this repository, so an
installed copy is a snapshot that never learns about later commits.
`just sync-contracts` does not reach it — that recipe refreshes only the bundles
inside this repository.

The resulting failure is silent in the worst possible place. A stale review
skill still runs, still validates its own result against the stale schema it
bundles, and still returns a verdict, because the snapshot is internally
consistent: old prose, old schema, and old validator all agree with each other.
No check confined to the snapshot can detect the problem, so detection has to
compare against a source of truth outside it.

Found in the field, not hypothesized. An installed distribution had all four
review skills pinned at `schema_version` 1.0 — accepting an aggregate `clean`
result with no `lens_executions` evidence, which the canonical 1.4 contract
rejects — `review-correctness/SKILL.md` missing its entire required
consumer/impact traversal pass, and `babysit-pr` and `implement-ticket` missing
their whole bundled `references/review-suite/` directory and
`scripts/review_gate.py`.

## What the review loop found

A check against silent failure that has silent failures of its own is worse than
no check, so the loop concentrated there. In order:

1. **A stale copy under any other directory name was invisible.** The comparison
   was source-driven, so `review-correctness-old/` — whose `SKILL.md` still
   declares `name: review-correctness`, so a runtime still loads it — was never
   compared, and the command printed "Installed skills match this repository"
   and exited 0. Also: comparing nothing rendered as a match; an explicitly
   named root that did not exist exited 0; `os.walk` swallowed permission
   errors; a dangling symlink aborted the run; `evals/results/` receipts
   re-dirtied every copy after each `just eval-record`.
2. **The fix for (1) worked for exactly one spelling.** `name: "review-correctness"`
   parsed to `'"review-correctness"'` — truthy, so the directory-name fallback
   never ran — reproducing the same exit-0 silent success. `gh-fix-ci` in the
   live distribution already writes a quoted name. Matching is now declared name
   **or** directory name, so a parse this check gets wrong cannot hide a copy.
3. **The one destructive instruction could undo a re-install.** A directory
   matchable as two skills could be named for deletion while also being where a
   re-install writes. Also: the untrustworthy-source banner printed *below* the
   fabricated entries it disclaimed; a repository-side read failure was reported
   as installed-copy drift with remediation that would overwrite good files.
4. **That guard was defeated by case-folding** on the very filesystem the
   default root lives on, restoring the destructive advice. Now decided by
   `Path.samefile`; `Path.resolve` would not have caught it.
5. **That fix's only regression test skipped on CI.** `ubuntu-latest` is
   case-sensitive, and no other test distinguished the implementations — a
   revert would have gone green. Pinned portably with a symlink instead.

Round six found nothing blocking.

## Deliberate boundaries

- Runtime byproducts and `evals/results/` receipts are not drift; neither
  changes what an installed skill does.
- A repository skill that is not installed is named but does not fail the check.
- Kept out of `lint` and `check`: those gates must stay reproducible in CI,
  where no installed distribution exists.
- The comparison is against the working tree, not `origin/main`.

## Test evidence

32 behavioral tests, each bound to one acceptance criterion and asserting only
at the public surface — exit status and printed report. Every test added in each
round was observed failing at that round's base SHA and passing at head, with no
other test moving. Assertions were checked against mutants: removing content
comparison, the byproduct exclusions, the leftover-file reporting, the canonical
guard, last-wins name resolution, or the fence stop each turns exactly the
corresponding test red.

Every finding was independently reproduced against the pre-fix script before
being implemented, per `review-suite/consumption-disciplines.md`.

`just check` passes (exit 0, 13 test groups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
