### PR TITLE
fix(implement-ticket): retry claude_executor on malformed real-model JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,22 +10,22 @@ summary: Chronological history of repository and skill changes.
   malformed JSON instead of aborting the whole forward-eval run (issue #154) —
   every real-model forward-eval run against `implement-ticket` recorded since
   #131 returned `status: attempted` on a `JSONDecodeError` inside
-  `extract_json_object`, with only an occasional run completing; `run_forward.py`
-  calls the executor once per case across 58 sequential cases and aborts the
-  entire run uncaught on the first executor failure, so even a low per-call
-  malformation rate compounds into most runs failing. `extract_json_object`'s
-  own boundary-finding was verified sound against fenced code blocks, nested
-  objects, and pretty-printed JSON — the malformation is in the model's
-  response content, not the extractor. A live 58-case sweep against the real
-  `claude` CLI reproduced the failure naturally once
-  (`evidence-bug-fix-regression-test`): the API call reported `stop_reason:
-  "end_turn"` and `is_error: false` — not a token-limit stop — yet the returned
-  JSON was missing its final closing brace, confirming the model occasionally
-  ends its turn with the object incomplete rather than the extractor
-  mis-locating a complete one. `run_claude` now retries with a fresh,
+  `extract_json_object`, with only an occasional run completing;
+  `run_forward.py` calls the executor once per case across 58 sequential cases
+  and aborts the entire run uncaught on the first executor failure, so even a
+  low per-call malformation rate compounds into most runs failing.
+  `extract_json_object`'s own boundary-finding was verified sound against fenced
+  code blocks, nested objects, and pretty-printed JSON — the malformation is in
+  the model's response content, not the extractor. A live 58-case sweep against
+  the real `claude` CLI reproduced the failure naturally once
+  (`evidence-bug-fix-regression-test`): the API call reported
+  `stop_reason: "end_turn"` and `is_error: false` — not a token-limit stop — yet
+  the returned JSON was missing its final closing brace, confirming the model
+  occasionally ends its turn with the object incomplete rather than the
+  extractor mis-locating a complete one. `run_claude` now retries with a fresh,
   independent sample (up to 3 attempts) when the response fails to parse, and
-  the prompt's answer-format section explicitly asks for escaped embedded
-  quotes and fully closed brackets. A non-zero `claude` CLI exit still fails
+  the prompt's answer-format section explicitly asks for escaped embedded quotes
+  and fully closed brackets. A non-zero `claude` CLI exit still fails
   immediately, unretried, since that is a different failure class. Three new
   tests in `test_forward_evals.py` mock `subprocess.run` to cover
   retry-then-succeed, exhausting all attempts, and no retry on a CLI exit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,33 @@ summary: Chronological history of repository and skill changes.
 
 # Changelog
 
-## 2026-08-05 — Added scoped per-finding re-review and escalated final-cycle execution to implement-ticket's fix loop
+## 2026-08-05 — Fixed the intermittent claude_executor real-model parsing failure blocking implement-ticket eval evidence, then added scoped per-finding re-review and escalated final-cycle execution to implement-ticket's fix loop
+
+- fix(implement-ticket): retry `claude_executor.py`'s real-model call on
+  malformed JSON instead of aborting the whole forward-eval run (issue #154) —
+  every real-model forward-eval run against `implement-ticket` recorded since
+  #131 returned `status: attempted` on a `JSONDecodeError` inside
+  `extract_json_object`, with only an occasional run completing; `run_forward.py`
+  calls the executor once per case across 58 sequential cases and aborts the
+  entire run uncaught on the first executor failure, so even a low per-call
+  malformation rate compounds into most runs failing. `extract_json_object`'s
+  own boundary-finding was verified sound against fenced code blocks, nested
+  objects, and pretty-printed JSON — the malformation is in the model's
+  response content, not the extractor. A live 58-case sweep against the real
+  `claude` CLI reproduced the failure naturally once
+  (`evidence-bug-fix-regression-test`): the API call reported `stop_reason:
+  "end_turn"` and `is_error: false` — not a token-limit stop — yet the returned
+  JSON was missing its final closing brace, confirming the model occasionally
+  ends its turn with the object incomplete rather than the extractor
+  mis-locating a complete one. `run_claude` now retries with a fresh,
+  independent sample (up to 3 attempts) when the response fails to parse, and
+  the prompt's answer-format section explicitly asks for escaped embedded
+  quotes and fully closed brackets. A non-zero `claude` CLI exit still fails
+  immediately, unretried, since that is a different failure class. Three new
+  tests in `test_forward_evals.py` mock `subprocess.run` to cover
+  retry-then-succeed, exhausting all attempts, and no retry on a CLI exit
+  failure. Not a skill-prose change, so the eval-evidence norm's recorded-run
+  requirement does not apply; the diagnostic evidence above is the record.
 
 - feat(implement-ticket): add scoped per-finding re-review and escalated
   final-cycle execution to the fix loop (issue #132, epic #119) — the fix loop
@@ -54,7 +80,8 @@ summary: Chronological history of repository and skill changes.
   separate follow-up rather than absorbed here. Both subsequent `after` attempts
   reverted to `attempted`, which is itself the finding: the executor is
   intermittently, not durably, functional. Model-behavior evidence for this
-  specific prose change remains unavailable.
+  specific prose change remains unavailable
+  (`ca613b8f8887f1d147193a32de9b8b815569cf5c`).
 
 ## 2026-08-04 — Authored `ready-ticket` and wired `implement-ticket`'s not-ready dead end into it, moved review-packet and dispatch context onto files, instituted the eval-evidence norm, then gave the implementation phase a peer-independent change-demonstrating-test evidence contract with availability-conditioned peer methodology slots, and established the house-owned consumption disciplines for review findings and PR feedback, bundled into `implement-ticket`, `babysit-pr`, and `carve-changesets`, then built the triggering-and-composition corpus that asks the prior question of which skill loads at all, then pressure-tested `ready-ticket` from a real recorded baseline, then sized and de-steered every dispatch the pipeline composes
 

--- a/skills/implement-ticket/scripts/evals/claude_executor.py
+++ b/skills/implement-ticket/scripts/evals/claude_executor.py
@@ -171,7 +171,10 @@ def build_prompt(payload: dict) -> str:
             json.dumps(payload["artifacts"], indent=2, sort_keys=True),
             "",
             "## Answer format",
-            "Return ONLY one JSON object, no prose and no code fence:",
+            "Return ONLY one JSON object, no prose and no code fence. Escape",
+            'any double-quote or backslash inside a string value (e.g. \\"',
+            "and \\\\), and make sure the object is fully closed: every open",
+            "{ and [ has a matching close before you stop.",
             '{"target_skill": "' + payload["target_skill"] + '",',
             ' "terminal_state": <one of ' + json.dumps(list(TERMINAL_STATES)) + ">,",
             ' "actions": <every applicable value from this closed vocabulary>,',
@@ -192,26 +195,47 @@ def extract_json_object(text: str) -> dict:
     return json.loads(candidate[start : end + 1])
 
 
-def run_claude(prompt: str, claude_bin: str, model: str | None) -> dict:
+RESULT_ATTEMPTS = 3
+
+
+def run_claude(
+    prompt: str, claude_bin: str, model: str | None, attempts: int = RESULT_ATTEMPTS
+) -> dict:
     command = [claude_bin, "-p", "--output-format", "json"]
     if model:
         command.extend(["--model", model])
-    completed = subprocess.run(
-        command,
-        input=prompt,
-        text=True,
-        capture_output=True,
-        check=False,
-    )
-    if completed.returncode:
-        raise RuntimeError(
-            f"claude exited {completed.returncode}: {completed.stderr.strip()}"
+
+    # The model occasionally ends its turn (stop_reason "end_turn", not a
+    # token-limit stop) with the JSON object incomplete -- e.g. missing the
+    # final closing brace, or an unescaped quote inside a string value. This
+    # is a malformed *response*, not a boundary-detection bug in
+    # extract_json_object; retrying with a fresh, independent sample clears
+    # it almost every time. A single flaky response must not sink an entire
+    # run of many sequential cases.
+    last_error: ValueError | None = None
+    for _ in range(attempts):
+        completed = subprocess.run(
+            command,
+            input=prompt,
+            text=True,
+            capture_output=True,
+            check=False,
         )
-    envelope = json.loads(completed.stdout)
-    result_text = envelope.get("result")
-    if not isinstance(result_text, str):
-        raise RuntimeError("claude --output-format json returned no result text")
-    return extract_json_object(result_text)
+        if completed.returncode:
+            raise RuntimeError(
+                f"claude exited {completed.returncode}: {completed.stderr.strip()}"
+            )
+        envelope = json.loads(completed.stdout)
+        result_text = envelope.get("result")
+        if not isinstance(result_text, str):
+            raise RuntimeError("claude --output-format json returned no result text")
+        try:
+            return extract_json_object(result_text)
+        except ValueError as error:
+            last_error = error
+    raise RuntimeError(
+        f"executor model returned malformed JSON after {attempts} attempts: {last_error}"
+    )
 
 
 def normalize(payload: dict, observed: dict) -> dict:

--- a/skills/implement-ticket/scripts/tests/test_forward_evals.py
+++ b/skills/implement-ticket/scripts/tests/test_forward_evals.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import copy
 import importlib.util
 import json
+import subprocess
 import sys
 import unittest
 from pathlib import Path
+from unittest import mock
 
 SKILL_ROOT = Path(__file__).resolve().parents[2]
 RUNNER_PATH = SKILL_ROOT / "scripts" / "evals" / "run_forward.py"
@@ -468,6 +470,58 @@ class ForwardEvaluationTests(unittest.TestCase):
                 "forbidden actions" in failure for failure in failed_dependency_failures
             )
         )
+
+
+class ClaudeExecutorRetryTests(unittest.TestCase):
+    """The model occasionally emits a string value with an unescaped quote,
+
+    producing a malformed *response* rather than a boundary-detection bug in
+    extract_json_object. run_claude must retry with a fresh sample instead of
+    letting one bad response sink an entire run of sequential cases.
+    """
+
+    @staticmethod
+    def _completed(result_text):
+        return subprocess.CompletedProcess(
+            args=["claude"],
+            returncode=0,
+            stdout=json.dumps({"result": result_text}),
+            stderr="",
+        )
+
+    def test_retries_after_malformed_json_then_succeeds(self):
+        malformed = '{"note": "quotes the "term" unescaped"}'
+        valid = '{"target_skill": "implement-ticket", "terminal_state": "blocked", "actions": [], "acceptance_ledger": []}'
+        with mock.patch.object(
+            CLAUDE_EXECUTOR.subprocess,
+            "run",
+            side_effect=[self._completed(malformed), self._completed(valid)],
+        ) as run_mock:
+            observed = CLAUDE_EXECUTOR.run_claude("prompt", "claude", None)
+        self.assertEqual(2, run_mock.call_count)
+        self.assertEqual("blocked", observed["terminal_state"])
+
+    def test_raises_after_exhausting_all_attempts(self):
+        malformed = '{"note": "quotes the "term" unescaped"}'
+        with mock.patch.object(
+            CLAUDE_EXECUTOR.subprocess,
+            "run",
+            side_effect=[self._completed(malformed)] * CLAUDE_EXECUTOR.RESULT_ATTEMPTS,
+        ) as run_mock:
+            with self.assertRaises(RuntimeError):
+                CLAUDE_EXECUTOR.run_claude("prompt", "claude", None)
+        self.assertEqual(CLAUDE_EXECUTOR.RESULT_ATTEMPTS, run_mock.call_count)
+
+    def test_does_not_retry_a_nonzero_exit(self):
+        failed = subprocess.CompletedProcess(
+            args=["claude"], returncode=1, stdout="", stderr="boom"
+        )
+        with mock.patch.object(
+            CLAUDE_EXECUTOR.subprocess, "run", side_effect=[failed]
+        ) as run_mock:
+            with self.assertRaises(RuntimeError):
+                CLAUDE_EXECUTOR.run_claude("prompt", "claude", None)
+        self.assertEqual(1, run_mock.call_count)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- `claude_executor.py`'s real-model call now retries with a fresh, independent sample (up to 3 attempts) when the response fails to parse as JSON, instead of letting one bad response abort the whole 58-case forward-eval run.
- Tightened the executor prompt's answer-format instructions to ask for escaped embedded quotes and fully closed brackets.
- Added regression tests mocking `subprocess.run` for retry-then-succeed, exhausting all attempts, and no retry on a CLI exit failure.

## Why
Every real-model forward-eval run recorded against `implement-ticket` since #131 returned `status: attempted` on a `JSONDecodeError` inside `extract_json_object` (tracked as #154), with only an occasional run completing — blocking real model-behavior evidence for `implement-ticket` prose changes.

`extract_json_object`'s boundary-finding logic is sound against fenced code blocks, nested JSON objects, and pretty-printed responses (verified directly). The malformation is in the model's response content, not the extractor. `run_forward.py` calls the executor once per case across 58 sequential cases and aborts the entire run uncaught on the first executor failure, so even a low per-call malformation rate compounds into most runs failing — consistent with the "roughly 1 in 3-4 succeed" pattern reported against three separate ticket implementations.

A live 58-case sweep against the real `claude` CLI reproduced the failure naturally once (`evidence-bug-fix-regression-test`): the API call reported `stop_reason: "end_turn"` and `is_error: false` — not a token-limit stop — yet the returned JSON was missing its final closing brace. That confirms the model occasionally ends its turn with the JSON object incomplete, rather than the extractor mis-locating a complete one. Retrying with an independent sample clears it.

Not a skill-prose change (this touches eval tooling, not a skill's `SKILL.md`/`references`), so the eval-evidence norm's recorded-run requirement doesn't apply; the diagnostic evidence above is the record, and is also written up in today's `CHANGELOG.md` entry.

## Review
Reviewed with the repository's read-only review suite (solution-simplicity → correctness → code-simplicity), each run as an independent subagent against the same packet. All three returned `clean` with zero findings on the first pass.

## Test plan
- [x] `python3 -m unittest skills.implement-ticket.scripts.tests.test_forward_evals -v` — 20/20 passed (3 new retry tests + 17 pre-existing)
- [x] `just format` — clean
- [x] `just lint` — clean (includes `skills-ref validate`)
- [x] `just test` — full repo suite green (852 tests)
- [x] Live 58-case sweep against the real `claude` CLI — 57/58 parsed cleanly, 1 naturally-occurring parse failure reproduced and diagnosed as above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
