### PR TITLE
docs(carve-changesets): rebuild on GitHub native stacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,36 @@ summary: Chronological history of repository and skill changes.
 
 # Changelog
 
-## 2026-08-05 — Fixed the intermittent claude_executor real-model parsing failure blocking implement-ticket eval evidence, added scoped per-finding re-review and escalated final-cycle execution to implement-ticket's fix loop, then made installed-distribution drift detectable and drove that check through five adversarial review rounds until it no longer had the silent successes it exists to catch, then separately triaged the real-model forward-eval failures that run surfaced, fixed implement-epic's terminal-state passthrough and implement-ticket's acceptance-ledger currency/correctness conflation, and ran a 3-round adversarial read-only review loop against those two fixes to convergence, verified with a fresh real-model run
+## 2026-08-05 — Proposed, hardened, and planned rebuilding carve-changesets on GitHub's native stacked pull request engine, fixed the intermittent claude_executor real-model parsing failure blocking implement-ticket eval evidence, added scoped per-finding re-review and escalated final-cycle execution to implement-ticket's fix loop, then made installed-distribution drift detectable and drove that check through five adversarial review rounds until it no longer had the silent successes it exists to catch, then separately triaged the real-model forward-eval failures that run surfaced, fixed implement-epic's terminal-state passthrough and implement-ticket's acceptance-ledger currency/correctness conflation, and ran a 3-round adversarial read-only review loop against those two fixes to convergence, verified with a fresh real-model run
+
+- docs(carve-changesets): add gh stack implementation plan
+
+- docs(carve-changesets): scope native fences and close publication gaps
+  (`9717064bf7edce07542a0aa40ab6120d12be4655`)
+
+- docs(carve-changesets): complete native state and equivalence fences
+  (`f215c2ce7adb19b4b0836adf1eb7c9fed0805202`)
+
+- docs(carve-changesets): close native adoption and rebase bypasses
+  (`ad035913ac83810913f0754b609b0f3d2b948f01`)
+
+- docs(carve-changesets): fence every native mutation state
+  (`827f7796ef5a0c40a38b89cee438f24f037daa1d`)
+
+- docs(carve-changesets): bind native mutations to exact heads
+  (`e955968bccce4b9c61500eaf3c98d6a96dfa98e6`)
+
+- docs(carve-changesets): simplify native metadata adoption
+  (`cd64000fee57641d482af34465049ba592880969`)
+
+- docs(carve-changesets): establish one native metadata authority
+  (`bc173a759e8bae16260cf4e7c51c5f5fa82b2f2b`)
+
+- docs(carve-changesets): correct native stack operation contracts
+  (`899f98656c9d6d0c3f1b8937455f1c577849b920`)
+
+- docs(carve-changesets): propose rebuilding on gh stack
+  (`6ed9b543e9230fd16916494c68d0226b05d7bdcc`)
 
 - chore(implement-ticket): record final real-model eval verification for the
   adversarial review loop — commits the summary

--- a/design/carve-changesets-on-gh-stack.md
+++ b/design/carve-changesets-on-gh-stack.md
@@ -227,7 +227,21 @@ GitHub state.
 ### Merged truth
 
 GitHub merge state and live mainline establish merged truth. The skill must also
-prove that the represented result matches the active immutable source.
+prove the merged prefix on that mainline and the live-chain equivalence
+invariant below.
+
+## Live-chain equivalence invariant
+
+At every materialized or later phase, the exact current trunk must represent the
+already merged prefix in order, and applying every open suffix layer in native
+stack order to that trunk must reproduce the active immutable source. Before any
+merge, the prefix is empty. When the suffix is empty, the invariant reduces to
+current trunk equaling the active source.
+
+Any head, base, trunk, membership, or source-lineage change invalidates this
+proof. The skill must re-establish it after repair, recovery, every native
+landing, and synchronization, and before returning candidates to lifecycle
+owners or claiming a terminal state.
 
 ## Layer identity and metadata
 
@@ -278,13 +292,10 @@ applicable:
 
 - an authenticated compatible GitHub CLI;
 - `gh stack rebase`, `push`, `submit`, `sync`, and `merge`;
-- push, submit, and push-capable sync operations that accept the manifest's
-  expected remote state for every branch—an exact SHA or absence—and reject each
-  mismatch before creating or overwriting an unexpected ref;
-- merge operations that accept the manifest's exact mutation set and reject a
-  direct merge if any selected head differs; and
-- queue operations that durably fence the bottom pull request and every suffix
-  head and base that its landing may rebase or retarget;
+- every remote-mutating command accepting the complete native mutation
+  precondition defined below and rejecting before any effect when it differs;
+- queue operations that keep that complete precondition fenced from admission
+  through landing;
 - rebase and sync operations that either skip trunk with `--no-trunk` or bind
   any fetched trunk/base state before rewriting candidates;
 - GitHub native stacks enabled for the repository; and
@@ -294,15 +305,14 @@ The skill checks capability before the affected mutation. Missing or
 incompatible capability returns `blocked`. It does not download a substitute
 tool or enter the retired custom stack path.
 
-At the reviewed public-preview revision, the CLI does not expose the required
-expected-state preconditions for remote updates or durable full-mutation-set
-fencing for merges. It also does not provide a phased default rebase that can
-pause after fetch for approval of a changed trunk. Until a tested compatible
-version closes the relevant gap, the skill may propose and materialize a local
-native stack, but must block before publication, remote repair, recovery, merge,
-or a trunk-refreshing rewrite. Post-command readback cannot substitute for a
-precondition because it observes an unauthorized write only after it has
-occurred.
+At the reviewed public-preview revision, the CLI does not expose the complete
+native mutation precondition or durable full-state fencing for merges. It also
+does not provide a phased default rebase that can pause after fetch for approval
+of a changed trunk. Until a tested compatible version closes the relevant gap,
+the skill may propose and materialize a local native stack, but must block
+before publication, remote repair, recovery, merge, or a trunk-refreshing
+rewrite. Post-command readback cannot substitute for a precondition because it
+observes an unauthorized write only after it has occurred.
 
 ### Command effects and authority
 
@@ -313,10 +323,10 @@ The adapter treats dependency commands by their real effects:
 | `gh stack init`        | Enables `rerere`, writes stack state, may create branches, and checks out the top branch  | Preview config, branch, state, and checkout changes; require local materialization authority                           |
 | `gh stack view --json` | Reads GitHub and may refresh saved stack state                                            | Declare the refresh; require scoped local-state authority and verify that the checkout is unchanged                    |
 | `gh stack rebase`      | By default fetches, may move trunk, rewrites layer commits, and records recovery state    | Use `--no-trunk` for a bounded suffix fix; otherwise preview the new base and complete affected set; require authority |
-| `gh stack push`        | Updates active remote branches and may partly succeed                                     | Bind each update to an expected SHA or absence; require publish or stack mutation authority                            |
-| `gh stack submit`      | Pushes branches, creates or updates pull requests, and updates the native stack           | Bind each push to an expected SHA or absence; preview PR and ready-state effects; require authority                    |
-| `gh stack sync`        | May fetch, fast-forward trunk, rebase, push, relink, save state, and prune when requested | Preview every phase; bind each push to an expected SHA or absence; require authority for every mutation                |
-| `gh stack merge`       | Directly merges an exact prefix or enqueues one exact bottom pull request                 | Bind direct heads or durably fence the queued bottom and affected suffix; require authority for the mutation set       |
+| `gh stack push`        | Updates active remote branches and may partly succeed                                     | Bind each ref update to the complete precondition; require publish or stack mutation authority                         |
+| `gh stack submit`      | Pushes branches, creates or updates pull requests, and updates the native stack           | Bind ref, PR, and stack effects to the complete precondition; require authority                                        |
+| `gh stack sync`        | May fetch, fast-forward trunk, rebase, push, relink, save state, and prune when requested | Bind every enabled phase to the complete precondition; require authority for every mutation                            |
+| `gh stack merge`       | Directly merges an exact prefix or enqueues one exact bottom pull request                 | Bind direct merge or queue residence to the complete precondition; require authority for the mutation set              |
 
 Status-only work must not hide the local refresh performed by
 `gh stack view --json`. If the caller has not authorized that bounded state
@@ -372,10 +382,10 @@ The plan no longer controls materialized topology.
 
 ### 4. Publish
 
-Require publish authority. Produce a dry-run manifest containing the exact
-repository, remote, trunk, ordered branches, branch heads, proposed pull
-requests, expected native stack, and the proposed draft or ready state of every
-pull request.
+Require publish authority. Produce a dry-run manifest containing the complete
+current native mutation precondition and the proposed repository, remote, trunk,
+ordered branches, branch heads, pull requests, native stack, and draft or ready
+state of every pull request.
 
 Execution invokes `gh stack submit --auto --remote <remote>` through the skill's
 single command surface. New pull requests are drafts in this mode. The wrapper
@@ -384,10 +394,10 @@ the caller has separately granted authority for that state transition. Since
 `--open` also marks existing drafts ready, the preview lists every affected pull
 request. Layer commit messages already contain the human-readable intent,
 non-goals, and intentional incompleteness from which automatic pull-request text
-is derived. Submission is available only when the dependency binds every branch
-push to the manifest's expected remote state: an exact SHA for an existing ref,
-or absence for a new ref. A dependency that refreshes its own lease expectations
-after manifest approval does not satisfy this contract.
+is derived. Submission is available only when the dependency binds every ref,
+pull-request, and native-stack effect to the manifest's complete precondition. A
+dependency that refreshes or accepts any expectation after manifest approval
+does not satisfy this contract.
 
 After submission:
 
@@ -427,8 +437,9 @@ and current stack identity.
    affected upstack.
 5. Runs a compare-and-swap-capable `gh stack push`.
 6. Reads back local git, `gh stack`, remote refs, and GitHub pull requests.
-7. Rebuilds invalidated validation, review, CI, and feedback evidence.
-8. Returns each corrected pull request to its lifecycle owner.
+7. Re-proves the live-chain equivalence invariant.
+8. Rebuilds invalidated validation, review, CI, and feedback evidence.
+9. Returns each corrected pull request to its lifecycle owner.
 
 `gh stack` owns propagation. `carve-changesets` owns the fix placement,
 provenance, authority, and proof.
@@ -452,16 +463,18 @@ For a direct prefix merge, invoke
 `gh stack merge <boundary-pr-number> --yes [--merge-method <method>]`. The
 boundary pull request selects the contiguous prefix. A stack number may replace
 it only when authority covers the whole stack. The dependency must atomically
-reject the request unless every selected pull request still has the manifest's
-expected head. A direct merge is one all-or-nothing service operation.
+reject the request unless the complete native mutation precondition still holds,
+including exact trunk, native membership, and every selected pull request's
+identity, head, base, and state. A direct merge is one all-or-nothing service
+operation.
 
 On merge-queue repositories, admit only the current bottom pull request with
 `gh stack merge <bottom-pr-number> --yes`. The queue chooses the merge method,
 so the wrapper omits method flags and records that they do not apply. The
-manifest includes the exact bottom head and every suffix head and base that the
-landing may rebase or retarget. The dependency must fence that complete set at
-admission and keep the fence effective until landing, rejecting or canceling the
-operation before native suffix mutation if any member changes.
+manifest includes the complete native mutation precondition. The dependency must
+fence it at admission and keep it effective until landing, rejecting or
+canceling the operation before native suffix mutation if any ref, pull request,
+trunk, or membership field changes.
 
 Queue admission is an asynchronous handoff, not merge completion. Its authority
 covers the native heads and bases produced by landing the exact bottom candidate
@@ -483,7 +496,10 @@ After completion:
 3. Verify every merged pull request on the trunk.
 4. Verify the remaining suffix's new heads and bases.
 5. Rebuild invalidated evidence.
-6. Verify the resulting mainline tree and behavior against the active source.
+6. Prove that the merged prefix is represented on the exact current trunk and
+   that current trunk plus every open suffix layer reproduces the active source.
+7. When the suffix is empty, additionally prove current trunk alone equals the
+   active source.
 
 ### 8. Recover
 
@@ -502,7 +518,8 @@ mechanics to `gh stack rebase --no-trunk --upstack <owning-layer>` and `push`.
 It does not manually recreate propagation.
 
 Recovery preserves merged positions and pull-request identities. It rebuilds all
-evidence bound to changed candidates.
+evidence bound to changed candidates and re-proves the live-chain equivalence
+invariant before returning them to lifecycle owners.
 
 ## Command-surface changes
 
@@ -528,6 +545,20 @@ alone. It resolves the exact stack and branches before invoking the dependency.
 
 Every operation with local or remote side effects has two phases.
 
+The complete native mutation precondition contains:
+
+- exact repository and selected remote;
+- exact trunk identity, remote ref, and SHA;
+- every affected branch ref's expected SHA or expected absence;
+- every existing affected pull request's repository-scoped identity, head, base,
+  open or closed state, draft or ready state, and queue state; and
+- the native stack's identity, trunk, and complete ordered pull-request
+  membership, or its expected absence before creation.
+
+The dependency must evaluate this precondition atomically with every ref,
+pull-request, topology, queue, or merge mutation. A preliminary read followed by
+an unfenced service request does not satisfy it.
+
 ### Preview
 
 The skill prints a bounded manifest of exact targets and intended effects. It
@@ -542,20 +573,17 @@ A successful command followed by conflicting readback returns `blocked`.
 Readback always classifies every declared target as changed as expected,
 unchanged, or changed unexpectedly.
 
-For every push-capable `gh stack` operation, capture the expected remote state
-and proposed head of every active branch. The expected state is an exact SHA for
-an existing ref or absence for a new ref. Pass those states as
-dependency-enforced compare-and-swap preconditions. If any precondition fails,
-classify all declared targets before retry; never create or overwrite the
+For every push-capable `gh stack` operation, include the proposed head of every
+active branch and enforce the complete precondition. If any ref precondition
+fails, classify all declared targets before retry; never create or overwrite the
 unexpected ref. After any result, read every remote ref and report which leases
 advanced, which were rejected, and which heads are unexpected. A retry starts
 from that new snapshot; it never replays the stale manifest.
 
-For direct merge, pass every selected expected pull-request head as one atomic
-precondition and verify that the complete prefix either merged or remained open.
-For queue-backed merge, durably fence the bottom head and every affected suffix
-head and base through landing. Distinguish admission from landing, and do not
-admit another pull request until the rebased suffix has passed fresh
+For direct merge, enforce the complete precondition and verify that the complete
+prefix either merged or remained open. For queue-backed merge, durably fence the
+complete precondition through landing. Distinguish admission from landing, and
+do not admit another pull request until the rebased suffix has passed fresh
 candidate-bound gates.
 
 ## Interruption and divergence
@@ -609,9 +637,9 @@ topology.
 
 The adoption path does not invoke `gh stack link`. That command can push branch
 arguments, create pull requests, retarget existing pull-request bases, and
-change native stack membership, but it is not covered by the required
-expected-state interface. If the tested `gh stack submit` version cannot adopt
-the existing pull requests non-interactively through the fenced submit path,
+change native stack membership, but it is not covered by the complete native
+mutation precondition. If the tested `gh stack submit` version cannot adopt the
+existing pull requests non-interactively through the fenced submit path,
 adoption returns `blocked` rather than widening to `link`.
 
 If adoption cannot be proved safe, return `blocked` with one concrete action.
@@ -636,9 +664,10 @@ non-merge gate.
 
 ### `all_merged`
 
-Requires every selected pull request verified merged, native synchronization
-complete, final mainline equivalence proven, required validation passing, and
-authorized cleanup complete or precisely limited.
+Requires every changeset pull request in the chain verified merged, an empty
+open suffix, native synchronization complete, current trunk equivalence to the
+active source proven, required validation passing, and authorized cleanup
+complete or precisely limited.
 
 ### `blocked`
 
@@ -660,7 +689,9 @@ Verify:
 - in-place legacy adoption without a metadata-only head rewrite;
 - no legacy stack-manager fallback;
 - no single-PR implicit stack mutation; and
-- candidate-evidence invalidation after stack-wide changes.
+- candidate-evidence invalidation after stack-wide changes;
+- current trunk plus the open suffix reproducing the active source; and
+- `all_merged` requiring an empty suffix and every chain pull request merged.
 
 ### Unit tests
 
@@ -674,10 +705,9 @@ Cover:
 - default-rebase fetch and trunk/base effect classification;
 - fix-only `rebase --no-trunk --upstack <branch>` construction;
 - phased trunk-refresh manifests and expected-base enforcement;
-- exact expected-SHA and expected-absence enforcement for push, submit, and
-  push-capable sync;
-- exact expected-head enforcement for direct merge;
-- durable bottom-and-suffix fencing for queue admission through landing;
+- complete ref, pull-request, trunk, and native-membership preconditions for
+  submit, sync, and merge;
+- durable complete-state fencing for queue admission through landing;
 - post-command readback;
 - partial push and queued-merge state classification;
 - interrupted and divergent states;
@@ -703,18 +733,26 @@ Use disposable repositories and controlled `gh stack` fixtures to cover:
 - a remote advance after manifest approval that rejects without overwriting it;
 - a same-named remote branch created after manifest approval that rejects
   without mutation;
+- pull-request base, draft state, or native membership changing after approval
+  and rejecting before submit or sync mutation;
 - local and remote divergence;
 - partial publication;
 - an all-or-nothing direct prefix merge;
 - a selected pull-request head advance that rejects direct merge and queue
   admission;
+- trunk movement or native stack reordering that rejects direct merge before
+  landing;
 - a queue whose group limit is smaller than the desired prefix, proving that
   only one bottom pull request is admitted before suffix revalidation;
 - an upstack head advance during queue residence that cancels or rejects the
   landing before suffix mutation;
-- post-merge synchronization;
-- successor-source recovery; and
-- final source equivalence.
+- native membership or trunk movement during queue residence that cancels or
+  rejects the landing before mutation;
+- post-merge synchronization followed by live-chain equivalence;
+- partial direct-prefix and one-bottom queue landings whose trunk plus open
+  suffix reproduces the active source;
+- successor-source recovery followed by live-chain equivalence; and
+- full-chain mainline equivalence only after the suffix is empty.
 
 ### Evaluations
 
@@ -757,8 +795,8 @@ not part of the design-document changeset.
 
 - `carve-changesets` gains a hard dependency on a preview tool and API.
 - Compatible versions must be tested and bounded.
-- Publication and merge remain unavailable until `gh stack` exposes the required
-  expected-state preconditions and durable queue fencing.
+- Publication and merge remain unavailable until `gh stack` exposes the complete
+  native mutation precondition and durable queue fencing.
 - Dependency commands may require interactive recovery.
 - Native stack behavior may change during public preview.
 - Existing chains require adoption before continued operation.

--- a/design/carve-changesets-on-gh-stack.md
+++ b/design/carve-changesets-on-gh-stack.md
@@ -237,14 +237,13 @@ Machine-readable trailers on each exact layer head commit retain only
 information that GitHub stacks do not provide:
 
 - semantic slug;
-- immutable root source identity;
-- active successor source identity when recovery has occurred;
-- ordered source lineage; and
+- non-empty ordered source lineage; and
 - recovery provenance when a suffix has been corrected.
 
-Every published lineage identity includes the selected remote plus an exact
-branch and stamped commit. Local-only reachability cannot establish durable
-source provenance.
+The immutable root source and active source are derived from the first and last
+lineage entries. They are not stored separately. Every published lineage
+identity includes the selected remote plus an exact branch and stamped commit.
+Local-only reachability cannot establish durable source provenance.
 
 Before reading a trailer, the skill verifies that the native pull-request head
 and remote branch head identify the same commit. GitHub's preserved pull-request
@@ -259,7 +258,10 @@ The redesign introduces a trailer-only metadata version for native stacks.
 Pull-request bodies remain human-readable and carry no new machine-readable
 `carve-changesets` block. Existing v1 and v2 commit trailers and pull-request
 blocks remain historical input for legacy adoption. They do not establish the
-post-adoption topology.
+post-adoption topology. The native trailer version is written only for a newly
+materialized layer or a layer whose head changes for a semantic or recovery
+reason. Legacy trailer fields are normalized when read rather than rewritten
+solely for adoption.
 
 ## Capability contract
 
@@ -529,17 +531,21 @@ repair, propagation, or merge work. Adoption must:
 
 1. Resolve every exact branch, head, pull request, and predecessor base.
 2. Verify same-repository ownership and linear ancestry.
-3. Verify semantic slugs and immutable source provenance, using v1 and v2
-   pull-request blocks only as adoption evidence.
-4. Prove the complete chain against the active source.
-5. Promote active open-layer commits to the native trailer version, then verify
-   the rewritten heads and reconstructed chain.
-6. Run non-interactive `gh stack init` over the rewritten open branches.
+3. Verify semantic slugs and source provenance from v1 and v2 commit trailers,
+   using legacy pull-request blocks only as adoption evidence.
+4. Normalize legacy metadata in memory to a semantic slug, non-empty source
+   lineage, and recovery provenance. Ignore legacy index, predecessor, and
+   topology fields after native adoption.
+5. Prove the complete chain against the active source.
+6. Run non-interactive `gh stack init` over the unchanged open branches.
 7. Submit or link the native GitHub stack.
 8. Read back local and remote stack state.
 
 Merged legacy commits and pull-request blocks remain unchanged historical
-evidence. Native GitHub state controls the adopted open topology.
+evidence. Adoption does not rewrite an open head merely to change its metadata
+version. The native trailer version is added when a layer is newly materialized
+or its head legitimately changes. Native GitHub state controls the adopted open
+topology.
 
 If adoption cannot be proved safe, return `blocked` with one concrete action.
 The skill does not resume the retired custom stack manager.
@@ -581,8 +587,10 @@ Verify:
 - responsibility and authority boundaries;
 - required `gh stack` capability;
 - semantic identity independent of stack position;
+- root and active source identity derived from ordered lineage;
 - topology read through documented surfaces;
 - one machine-readable semantic and provenance record for new native layers;
+- in-place legacy adoption without a metadata-only head rewrite;
 - no legacy stack-manager fallback;
 - no single-PR implicit stack mutation; and
 - candidate-evidence invalidation after stack-wide changes.
@@ -601,7 +609,9 @@ Cover:
 - interrupted and divergent states;
 - native commit-trailer decoding;
 - legacy pull-request blocks accepted only as adoption evidence;
-- legacy adoption checks; and
+- v1 and v2 trailer normalization with native topology superseding positional
+  fields;
+- in-place legacy adoption checks; and
 - terminal-state rendering.
 
 ### Integration tests

--- a/design/carve-changesets-on-gh-stack.md
+++ b/design/carve-changesets-on-gh-stack.md
@@ -37,10 +37,12 @@ intent, code structure, migration safety, review load, and final behavior.
 
 GitHub native stacks and `gh stack` now cover most of the second problem. The
 CLI can adopt existing branches, record stack order, expose machine-readable
-state, perform cascading rebases, push the stack atomically, submit native
-stacked pull requests, and synchronize local and remote state. GitHub owns the
-published stack object, trunk-relative protections, merge queues, and atomic
-prefix merges.
+state, perform cascading rebases, push each branch with explicit lease
+protection, submit native stacked pull requests, and synchronize local and
+remote state. GitHub owns the published stack object, trunk-relative
+protections, direct prefix merges, and merge-queue admission. A stack push may
+partly succeed, and a queued prefix may land in separate groups. The design must
+preserve exact identity and recovery across both cases.
 
 Keeping both stack engines would preserve duplicated state and conflicting
 mutation paths. It would also force `carve-changesets` to understand every
@@ -51,7 +53,7 @@ References:
 
 - [GitHub stacked pull requests announcement](https://github.blog/changelog/2026-07-30-stacked-pull-requests-are-now-in-public-preview/)
 - [`gh-stack` repository](https://github.com/github/gh-stack)
-- [`gh stack` CLI reference](https://github.github.com/gh-stack/reference/cli/)
+- [`gh stack` CLI reference](https://docs.github.com/en/pull-requests/reference/stacked-prs-cli-commands)
 
 ## Goals
 
@@ -140,7 +142,7 @@ mechanics. GitHub provides published topology and merge behavior.
 - adoption of materialized branches;
 - linear ancestry maintenance;
 - cascading rebases;
-- atomic stack pushes with leases;
+- lease-protected per-branch stack pushes;
 - native stacked-pull-request submission;
 - local and remote stack synchronization;
 - merged-layer reconciliation; and
@@ -154,7 +156,8 @@ GitHub owns:
 - stack trunk and ordered pull-request membership;
 - trunk-relative protection and check evaluation;
 - merge-queue integration;
-- native atomic prefix merges; and
+- all-or-nothing direct prefix merges;
+- queue processing that may land one authorized prefix in separate groups; and
 - automatic rebase and retarget behavior after a partial merge.
 
 ### `review-code-change`
@@ -201,8 +204,10 @@ requirements.
 ### Materialized truth
 
 Live git commits and branches establish layer contents. `gh stack view --json`
-establishes local stack membership and order. The skill cross-checks both
-sources before accepting the chain.
+establishes local stack membership and order. It also refreshes pull-request
+state and may save `.git/gh-stack`, so it is a scoped local mutation rather than
+a side-effect-free read. The skill cross-checks its output with git before
+accepting the chain.
 
 The `.git/gh-stack` file is operational state owned by the dependency. The skill
 never parses that file directly. It consumes the documented CLI surface.
@@ -235,6 +240,10 @@ not provide:
 - ordered source lineage; and
 - recovery provenance when a suffix has been corrected.
 
+Every published lineage identity includes the selected remote plus an exact
+branch and stamped commit. Local-only reachability cannot establish durable
+source provenance.
+
 Native stack number, position, predecessor, trunk, and size must not be copied
 into durable `carve-changesets` metadata. Those values come from GitHub and
 `gh stack` at read time.
@@ -252,13 +261,32 @@ boundary require:
 - a tested compatible `gh-stack` extension version;
 - `gh stack view --json`;
 - non-interactive `gh stack init` for explicit branches;
-- `gh stack rebase`, `push`, `submit`, and `sync`;
+- `gh stack rebase`, `push`, `submit`, `sync`, and `merge`;
 - GitHub native stacks enabled for the repository; and
 - live read access to stack, pull-request, review, check, and merge state.
 
 The skill checks capability before the affected mutation. Missing or
 incompatible capability returns `blocked`. It does not download a substitute
 tool or enter the retired custom stack path.
+
+### Command effects and authority
+
+The adapter treats dependency commands by their real effects:
+
+| Command                | Material effects                                                                          | Required disclosure and authority                                                                                     |
+| ---------------------- | ----------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `gh stack init`        | Enables `rerere`, writes stack state, may create branches, and checks out the top branch  | Preview config, branch, state, and checkout changes; require local materialization authority                          |
+| `gh stack view --json` | Reads GitHub and may refresh saved stack state                                            | Declare the refresh; require scoped local-state authority and verify that the checkout is unchanged                   |
+| `gh stack rebase`      | Rewrites local layer commits and records recovery state                                   | Preview the affected suffix; require stack mutation authority                                                         |
+| `gh stack push`        | Updates active remote branches with per-branch leases and may partly succeed              | Preview old and proposed heads; require publish or stack mutation authority                                           |
+| `gh stack submit`      | Pushes branches, creates or updates pull requests, and updates the native stack           | Preview remote, heads, pull requests, and draft or ready state; require publish and any ready-state authority         |
+| `gh stack sync`        | May fetch, fast-forward trunk, rebase, push, relink, save state, and prune when requested | Preview every enabled phase; require authority for every resulting local or remote mutation                           |
+| `gh stack merge`       | Directly merges an exact prefix or enqueues it                                            | Preview the boundary pull request, full prefix, method or queue behavior; require merge authority for the full prefix |
+
+Status-only work must not hide the local refresh performed by
+`gh stack view --json`. If the caller has not authorized that bounded state
+write, the skill reports local stack state as unavailable and relies only on
+side-effect-free git and GitHub reads. It does not silently widen authority.
 
 ## Workflow
 
@@ -303,10 +331,15 @@ The plan no longer controls materialized topology.
 
 Require publish authority. Produce a dry-run manifest containing the exact
 repository, remote, trunk, ordered branches, branch heads, proposed pull
-requests, and expected native stack.
+requests, expected native stack, and the proposed draft or ready state of every
+pull request.
 
-Execution invokes `gh stack submit` through the skill's single command surface.
-The wrapper selects non-interactive flags and passes explicit remote identity.
+Execution invokes `gh stack submit --auto --remote <remote>` through the skill's
+single command surface. New pull requests are drafts in this mode. The wrapper
+adds `--open` only when the manifest requests ready-for-review pull requests and
+the caller has separately granted authority for that state transition. Since
+`--open` also marks existing drafts ready, the preview lists every affected pull
+request.
 
 After submission:
 
@@ -363,8 +396,19 @@ Before mutation, resolve and report:
 - merge method and merge-queue behavior; and
 - authority covering the complete affected prefix.
 
-GitHub performs the native stack merge. The custom sequential merge and suffix
-propagation path is retired.
+For a prefix merge, invoke
+`gh stack merge <boundary-pr-number> --yes [--merge-method <method>]`. The
+boundary pull request selects the contiguous prefix. A stack number may replace
+it only when authority covers the whole stack. On merge-queue repositories, the
+queue chooses the merge method, so the wrapper omits method flags and records
+that they do not apply. The custom sequential merge and suffix propagation path
+is retired.
+
+A direct merge is one all-or-nothing service operation. Queue admission is an
+asynchronous handoff, not merge completion. The selected pull requests may land
+in separate groups. After every observed landing, the skill records the exact
+merged set, rebuilds evidence for changed open candidates, and resumes only from
+a fresh live prefix.
 
 After completion:
 
@@ -381,6 +425,13 @@ An accepted fix after a prefix merge may change the intended final result.
 `carve-changesets` still creates or verifies a distinct immutable successor
 source and continuous lineage.
 
+Before any remote push, submit, sync, or metadata edit for a recovered suffix,
+every root and successor identity in that lineage must resolve at its exact
+stamped SHA on the selected remote. The preview includes those remote
+identities. Post-mutation readback verifies them again. A local-only source
+blocks recovery because a fresh clone could not reconstruct the published
+lineage.
+
 The skill applies the fix at the correct open layer and delegates suffix
 mechanics to `gh stack rebase`, `push`, and `sync`. It does not manually
 recreate propagation.
@@ -395,22 +446,22 @@ wraps exact `gh stack` argv and performs preflight and readback.
 
 Retire or replace:
 
-| Current command   | Target behavior                                                   |
-| ----------------- | ----------------------------------------------------------------- |
-| `create-chain`    | Materialize semantic layers, then adopt them with `gh stack init` |
-| `push-chain`      | Preview and invoke `gh stack push`                                |
-| `pr-create`       | Preview and invoke `gh stack submit`                              |
-| `propagate`       | Remove; use verified `gh stack sync` or `rebase` plus `push`      |
-| `merge-propagate` | Replace with native stack merge coordination and `gh stack sync`  |
-| `recover-suffix`  | Retain semantic recovery, delegate mechanics to `gh stack`        |
-| `status`          | Combine git, `gh stack view --json`, and live GitHub evidence     |
+| Current command   | Target behavior                                                                 |
+| ----------------- | ------------------------------------------------------------------------------- |
+| `create-chain`    | Materialize semantic layers, then adopt them with `gh stack init`               |
+| `push-chain`      | Preview and invoke `gh stack push`                                              |
+| `pr-create`       | Preview and invoke `gh stack submit`                                            |
+| `propagate`       | Remove; use verified `gh stack sync` or `rebase` plus `push`                    |
+| `merge-propagate` | Preview and invoke exact-prefix `gh stack merge`, then verified `gh stack sync` |
+| `recover-suffix`  | Retain semantic recovery, delegate mechanics to `gh stack`                      |
+| `status`          | Combine git, `gh stack view --json`, and live GitHub evidence                   |
 
 The wrapper must never infer a mutation target from the checked-out branch
 alone. It resolves the exact stack and branches before invoking the dependency.
 
 ## Mutation and readback contract
 
-Every remote-mutating operation has two phases.
+Every operation with local or remote side effects has two phases.
 
 ### Preview
 
@@ -422,8 +473,18 @@ does not invoke the mutating `gh stack` command.
 The skill re-verifies the manifest, invokes the exact command, and reads back
 all affected state.
 
-A successful command followed by conflicting readback returns `blocked`. Partial
-mutations remain visible and are reported precisely.
+A successful command followed by conflicting readback returns `blocked`.
+Readback always classifies every declared target as changed as expected,
+unchanged, or changed unexpectedly.
+
+For `gh stack push`, capture the old and proposed head of every active branch.
+After any result, read every remote ref and report which leases advanced, which
+were rejected, and which heads are unexpected. A retry starts from that new
+snapshot; it never replays the stale manifest.
+
+For direct merge, verify that the complete selected prefix either merged or
+remained open. For queue-backed merge, distinguish admission from landing and
+track each landed group until the selected prefix reaches a terminal state.
 
 ## Interruption and divergence
 
@@ -436,6 +497,10 @@ In unattended execution:
 - a rebase conflict preserves the dependency's recovery state and reports the
   exact continuation command;
 - a diverged local and remote stack performs no write;
+- a partly successful push preserves the advanced refs and requires a fresh
+  manifest for the rejected remainder;
+- a partly landed queued prefix preserves each merged group and resumes from the
+  remaining live prefix;
 - an interrupted modify or rebase is never discarded automatically;
 - a stack lock identifies the owning process or last trustworthy state when
   available; and
@@ -516,7 +581,9 @@ Cover:
 - `gh stack view --json` decoding;
 - dry-run manifests;
 - exact argv construction;
+- command-effect and authority classification;
 - post-command readback;
+- partial push and queued-merge state classification;
 - interrupted and divergent states;
 - native metadata decoding;
 - legacy adoption checks; and
@@ -529,10 +596,11 @@ Use disposable repositories and controlled `gh stack` fixtures to cover:
 - materialization and adoption;
 - native submission;
 - a lower-layer fix and cascading rebase;
-- atomic push and remote-head verification;
+- a rejected branch lease after earlier branches have updated;
 - local and remote divergence;
 - partial publication;
-- native prefix merge;
+- an all-or-nothing direct prefix merge;
+- a queued prefix that lands in separate groups;
 - post-merge synchronization;
 - successor-source recovery; and
 - final source equivalence.

--- a/design/carve-changesets-on-gh-stack.md
+++ b/design/carve-changesets-on-gh-stack.md
@@ -41,8 +41,8 @@ state, perform cascading rebases, push each branch with explicit lease
 protection, submit native stacked pull requests, and synchronize local and
 remote state. GitHub owns the published stack object, trunk-relative
 protections, direct prefix merges, and merge-queue admission. A stack push may
-partly succeed, and a queued prefix may land in separate groups. The design must
-preserve exact identity and recovery across both cases.
+partly succeed, and a queue landing may automatically rebase the remaining
+suffix. The design must preserve exact identity and recovery across both cases.
 
 Keeping both stack engines would preserve duplicated state and conflicting
 mutation paths. It would also force `carve-changesets` to understand every
@@ -53,6 +53,7 @@ References:
 
 - [GitHub stacked pull requests announcement](https://github.blog/changelog/2026-07-30-stacked-pull-requests-are-now-in-public-preview/)
 - [`gh-stack` repository](https://github.com/github/gh-stack)
+- [Reviewed `gh-stack` revision](https://github.com/github/gh-stack/tree/14fc42ed9b6c376a53b2f999f138d3bd26dac546)
 - [`gh stack` CLI reference](https://docs.github.com/en/pull-requests/reference/stacked-prs-cli-commands)
 
 ## Goals
@@ -157,7 +158,7 @@ GitHub owns:
 - trunk-relative protection and check evaluation;
 - merge-queue integration;
 - all-or-nothing direct prefix merges;
-- queue processing that may land one authorized prefix in separate groups; and
+- single-pull-request queue processing and automatic suffix rebases; and
 - automatic rebase and retarget behavior after a partial merge.
 
 ### `review-code-change`
@@ -273,6 +274,11 @@ boundary require:
 - `gh stack view --json`;
 - non-interactive `gh stack init` for explicit branches;
 - `gh stack rebase`, `push`, `submit`, `sync`, and `merge`;
+- push, submit, and push-capable sync operations that accept the manifest's
+  exact expected-old SHA for every remote branch and reject each mismatched
+  update before overwriting an unexpected head;
+- merge operations that accept the manifest's exact pull-request head set and
+  reject the request before direct merge or queue admission if any head differs;
 - GitHub native stacks enabled for the repository; and
 - live read access to stack, pull-request, review, check, and merge state.
 
@@ -280,19 +286,26 @@ The skill checks capability before the affected mutation. Missing or
 incompatible capability returns `blocked`. It does not download a substitute
 tool or enter the retired custom stack path.
 
+At the reviewed public-preview revision, the CLI does not expose the required
+expected-head preconditions for remote updates or merges. Until a tested
+compatible version does, the skill may propose and materialize a local native
+stack, but must block before publication, remote repair, recovery, or merge.
+Post-command readback cannot substitute for a precondition because it observes
+an unauthorized write only after it has occurred.
+
 ### Command effects and authority
 
 The adapter treats dependency commands by their real effects:
 
-| Command                | Material effects                                                                          | Required disclosure and authority                                                                                     |
-| ---------------------- | ----------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `gh stack init`        | Enables `rerere`, writes stack state, may create branches, and checks out the top branch  | Preview config, branch, state, and checkout changes; require local materialization authority                          |
-| `gh stack view --json` | Reads GitHub and may refresh saved stack state                                            | Declare the refresh; require scoped local-state authority and verify that the checkout is unchanged                   |
-| `gh stack rebase`      | Rewrites local layer commits and records recovery state                                   | Preview the affected suffix; require stack mutation authority                                                         |
-| `gh stack push`        | Updates active remote branches with per-branch leases and may partly succeed              | Preview old and proposed heads; require publish or stack mutation authority                                           |
-| `gh stack submit`      | Pushes branches, creates or updates pull requests, and updates the native stack           | Preview remote, heads, pull requests, and draft or ready state; require publish and any ready-state authority         |
-| `gh stack sync`        | May fetch, fast-forward trunk, rebase, push, relink, save state, and prune when requested | Preview every enabled phase; require authority for every resulting local or remote mutation                           |
-| `gh stack merge`       | Directly merges an exact prefix or enqueues it                                            | Preview the boundary pull request, full prefix, method or queue behavior; require merge authority for the full prefix |
+| Command                | Material effects                                                                          | Required disclosure and authority                                                                                   |
+| ---------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `gh stack init`        | Enables `rerere`, writes stack state, may create branches, and checks out the top branch  | Preview config, branch, state, and checkout changes; require local materialization authority                        |
+| `gh stack view --json` | Reads GitHub and may refresh saved stack state                                            | Declare the refresh; require scoped local-state authority and verify that the checkout is unchanged                 |
+| `gh stack rebase`      | Rewrites local layer commits and records recovery state                                   | Preview the affected suffix; require stack mutation authority                                                       |
+| `gh stack push`        | Updates active remote branches and may partly succeed                                     | Bind every update to the manifest's expected-old SHA; require publish or stack mutation authority                   |
+| `gh stack submit`      | Pushes branches, creates or updates pull requests, and updates the native stack           | Bind every pushed branch to its expected-old SHA; preview pull requests and draft or ready state; require authority |
+| `gh stack sync`        | May fetch, fast-forward trunk, rebase, push, relink, save state, and prune when requested | Preview every enabled phase; bind any push to expected-old SHAs; require authority for every resulting mutation     |
+| `gh stack merge`       | Directly merges an exact prefix or enqueues one exact bottom pull request                 | Bind the request to expected PR heads; require merge authority for the direct prefix or queued bottom PR            |
 
 Status-only work must not hide the local refresh performed by
 `gh stack view --json`. If the caller has not authorized that bounded state
@@ -352,7 +365,9 @@ the caller has separately granted authority for that state transition. Since
 `--open` also marks existing drafts ready, the preview lists every affected pull
 request. Layer commit messages already contain the human-readable intent,
 non-goals, and intentional incompleteness from which automatic pull-request text
-is derived.
+is derived. Submission is available only when the dependency binds every branch
+push to the manifest's exact expected-old SHA. A dependency that refreshes its
+own lease expectations after manifest approval does not satisfy this contract.
 
 After submission:
 
@@ -389,7 +404,8 @@ and current stack identity.
 2. Applies the fix to the layer that owns it.
 3. Creates or verifies a successor source when the accepted result has changed.
 4. Runs `gh stack rebase` across the affected upstack.
-5. Runs `gh stack push` or `gh stack sync` as appropriate.
+5. Runs a compare-and-swap-capable `gh stack push` or `gh stack sync` as
+   appropriate.
 6. Reads back local git, `gh stack`, remote refs, and GitHub pull requests.
 7. Rebuilds invalidated validation, review, CI, and feedback evidence.
 8. Returns each corrected pull request to its lifecycle owner.
@@ -408,21 +424,30 @@ Before mutation, resolve and report:
 - current stack and trunk identity;
 - applicable checks, reviews, and protection gates;
 - merge method and merge-queue behavior; and
-- authority covering the complete affected prefix.
+- authority covering the complete direct prefix or the one queued bottom pull
+  request.
 
-For a prefix merge, invoke
+For a direct prefix merge, invoke
 `gh stack merge <boundary-pr-number> --yes [--merge-method <method>]`. The
 boundary pull request selects the contiguous prefix. A stack number may replace
-it only when authority covers the whole stack. On merge-queue repositories, the
-queue chooses the merge method, so the wrapper omits method flags and records
-that they do not apply. The custom sequential merge and suffix propagation path
-is retired.
+it only when authority covers the whole stack. The dependency must atomically
+reject the request unless every selected pull request still has the manifest's
+expected head. A direct merge is one all-or-nothing service operation.
 
-A direct merge is one all-or-nothing service operation. Queue admission is an
-asynchronous handoff, not merge completion. The selected pull requests may land
-in separate groups. After every observed landing, the skill records the exact
-merged set, rebuilds evidence for changed open candidates, and resumes only from
-a fresh live prefix.
+On merge-queue repositories, admit only the current bottom pull request with
+`gh stack merge <bottom-pr-number> --yes`. The queue chooses the merge method,
+so the wrapper omits method flags and records that they do not apply. The merge
+request must reject admission unless that pull request still has the manifest's
+expected head. Queue admission is an asynchronous handoff, not merge completion.
+After it lands, GitHub may rebase the remaining suffix. The skill then
+synchronizes, reads every new head, and rebuilds all candidate-bound validation,
+review, CI, and feedback evidence before separately authorizing and admitting
+the next bottom pull request. It never admits a prefix that GitHub may process
+in multiple autonomous groups.
+
+This one-at-a-time queue admission is lifecycle coordination through the native
+stack engine, not a return to custom propagation: GitHub and `gh stack` still
+own merge, rebase, retargeting, and synchronization mechanics.
 
 After completion:
 
@@ -459,15 +484,15 @@ wraps exact `gh stack` argv and performs preflight and readback.
 
 Retire or replace:
 
-| Current command   | Target behavior                                                                 |
-| ----------------- | ------------------------------------------------------------------------------- |
-| `create-chain`    | Materialize semantic layers, then adopt them with `gh stack init`               |
-| `push-chain`      | Preview and invoke `gh stack push`                                              |
-| `pr-create`       | Preview and invoke `gh stack submit`                                            |
-| `propagate`       | Remove; use verified `gh stack sync` or `rebase` plus `push`                    |
-| `merge-propagate` | Preview and invoke exact-prefix `gh stack merge`, then verified `gh stack sync` |
-| `recover-suffix`  | Retain semantic recovery, delegate mechanics to `gh stack`                      |
-| `status`          | Combine git, `gh stack view --json`, and live GitHub evidence                   |
+| Current command   | Target behavior                                                             |
+| ----------------- | --------------------------------------------------------------------------- |
+| `create-chain`    | Materialize semantic layers, then adopt them with `gh stack init`           |
+| `push-chain`      | Preview and invoke `gh stack push`                                          |
+| `pr-create`       | Preview and invoke `gh stack submit`                                        |
+| `propagate`       | Remove; use verified `gh stack sync` or `rebase` plus `push`                |
+| `merge-propagate` | Invoke a direct exact-prefix or one queued-bottom merge, then verified sync |
+| `recover-suffix`  | Retain semantic recovery, delegate mechanics to `gh stack`                  |
+| `status`          | Combine git, `gh stack view --json`, and live GitHub evidence               |
 
 The wrapper must never infer a mutation target from the checked-out branch
 alone. It resolves the exact stack and branches before invoking the dependency.
@@ -490,14 +515,19 @@ A successful command followed by conflicting readback returns `blocked`.
 Readback always classifies every declared target as changed as expected,
 unchanged, or changed unexpectedly.
 
-For `gh stack push`, capture the old and proposed head of every active branch.
-After any result, read every remote ref and report which leases advanced, which
-were rejected, and which heads are unexpected. A retry starts from that new
-snapshot; it never replays the stale manifest.
+For every push-capable `gh stack` operation, capture the old and proposed head
+of every active branch and pass the old heads as dependency-enforced
+compare-and-swap preconditions. If any precondition fails, classify all declared
+targets before retry; never overwrite the unexpected head. After any result,
+read every remote ref and report which leases advanced, which were rejected, and
+which heads are unexpected. A retry starts from that new snapshot; it never
+replays the stale manifest.
 
-For direct merge, verify that the complete selected prefix either merged or
-remained open. For queue-backed merge, distinguish admission from landing and
-track each landed group until the selected prefix reaches a terminal state.
+For direct merge, pass every selected expected pull-request head as one atomic
+precondition and verify that the complete prefix either merged or remained open.
+For queue-backed merge, pass the bottom pull request's expected head,
+distinguish admission from landing, and do not admit another pull request until
+the rebased suffix has passed fresh candidate-bound gates.
 
 ## Interruption and divergence
 
@@ -512,8 +542,8 @@ In unattended execution:
 - a diverged local and remote stack performs no write;
 - a partly successful push preserves the advanced refs and requires a fresh
   manifest for the rejected remainder;
-- a partly landed queued prefix preserves each merged group and resumes from the
-  remaining live prefix;
+- a landed queued pull request preserves the remaining native suffix and blocks
+  its next admission until synchronization and fresh exact-head gates complete;
 - an interrupted modify or rebase is never discarded automatically;
 - a stack lock identifies the owning process or last trustworthy state when
   available; and
@@ -604,6 +634,8 @@ Cover:
 - dry-run manifests;
 - exact argv construction;
 - command-effect and authority classification;
+- exact expected-old SHA enforcement for push, submit, and push-capable sync;
+- exact expected-head enforcement for direct merge and queue admission;
 - post-command readback;
 - partial push and queued-merge state classification;
 - interrupted and divergent states;
@@ -622,10 +654,14 @@ Use disposable repositories and controlled `gh stack` fixtures to cover:
 - native submission;
 - a lower-layer fix and cascading rebase;
 - a rejected branch lease after earlier branches have updated;
+- a remote advance after manifest approval that rejects without overwriting it;
 - local and remote divergence;
 - partial publication;
 - an all-or-nothing direct prefix merge;
-- a queued prefix that lands in separate groups;
+- a selected pull-request head advance that rejects direct merge and queue
+  admission;
+- a queue whose group limit is smaller than the desired prefix, proving that
+  only one bottom pull request is admitted before suffix revalidation;
 - post-merge synchronization;
 - successor-source recovery; and
 - final source equivalence.
@@ -671,6 +707,8 @@ not part of the design-document changeset.
 
 - `carve-changesets` gains a hard dependency on a preview tool and API.
 - Compatible versions must be tested and bounded.
+- Publication and merge remain unavailable until `gh stack` exposes the required
+  expected-head preconditions.
 - Dependency commands may require interactive recovery.
 - Native stack behavior may change during public preview.
 - Existing chains require adoption before continued operation.

--- a/design/carve-changesets-on-gh-stack.md
+++ b/design/carve-changesets-on-gh-stack.md
@@ -243,6 +243,17 @@ proof. The skill must re-establish it after repair, recovery, every native
 landing, and synchronization, and before returning candidates to lifecycle
 owners or claiming a terminal state.
 
+A changed trunk is not merely a new comparison base for the same source. Before
+accepting it, the skill constructs and verifies a distinct immutable successor
+source: the exact new trunk plus the preserved intended effect of the prior
+active source. With separate source-publication authority, it publishes that
+source at an exact ref and SHA on the selected remote, appends it to the ordered
+lineage, and proves that the transition adds only the approved trunk change
+while preserving the intended effect. A conflict, missing authority, or
+unprovable transition blocks before any candidate rewrite. The ensuing rebase or
+synchronization invalidates candidate evidence and must re-establish the
+invariant against the successor source.
+
 ## Layer identity and metadata
 
 A semantic slug identifies a changeset. Position comes from live stack order.
@@ -292,12 +303,15 @@ applicable:
 
 - an authenticated compatible GitHub CLI;
 - `gh stack rebase`, `push`, `submit`, `sync`, and `merge`;
-- every remote-mutating command accepting the complete native mutation
-  precondition defined below and rejecting before any effect when it differs;
-- queue operations that keep that complete precondition fenced from admission
-  through landing;
+- every remote-mutating command accepting its operation mutation precondition as
+  defined below and rejecting before any effect when it differs;
+- queue operations that keep their operation mutation precondition fenced from
+  admission through landing;
 - rebase and sync operations that either skip trunk with `--no-trunk` or bind
   any fetched trunk/base state before rewriting candidates;
+- a non-interactive submit mode that accepts and preserves every explicit
+  per-layer pull-request title and body, even when the repository has a pull
+  request template;
 - GitHub native stacks enabled for the repository; and
 - live read access to stack, pull-request, review, check, and merge state.
 
@@ -305,28 +319,29 @@ The skill checks capability before the affected mutation. Missing or
 incompatible capability returns `blocked`. It does not download a substitute
 tool or enter the retired custom stack path.
 
-At the reviewed public-preview revision, the CLI does not expose the complete
-native mutation precondition or durable full-state fencing for merges. It also
-does not provide a phased default rebase that can pause after fetch for approval
-of a changed trunk. Until a tested compatible version closes the relevant gap,
-the skill may propose and materialize a local native stack, but must block
-before publication, remote repair, recovery, merge, or a trunk-refreshing
-rewrite. Post-command readback cannot substitute for a precondition because it
+At the reviewed public-preview revision, the CLI does not expose the required
+operation mutation preconditions or durable fencing for merges. Its automatic
+submit path also cannot be relied on to preserve explicit per-layer bodies in a
+repository with a pull-request template, and its default rebase cannot pause
+after fetch for approval of a changed trunk. Capabilities are assessed per
+operation: a future command may be usable without making every remote phase
+usable. Until a tested version closes a phase's relevant gaps, that phase is
+blocked. Post-command readback cannot substitute for a precondition because it
 observes an unauthorized write only after it has occurred.
 
 ### Command effects and authority
 
 The adapter treats dependency commands by their real effects:
 
-| Command                | Material effects                                                                          | Required disclosure and authority                                                                                      |
-| ---------------------- | ----------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `gh stack init`        | Enables `rerere`, writes stack state, may create branches, and checks out the top branch  | Preview config, branch, state, and checkout changes; require local materialization authority                           |
-| `gh stack view --json` | Reads GitHub and may refresh saved stack state                                            | Declare the refresh; require scoped local-state authority and verify that the checkout is unchanged                    |
-| `gh stack rebase`      | By default fetches, may move trunk, rewrites layer commits, and records recovery state    | Use `--no-trunk` for a bounded suffix fix; otherwise preview the new base and complete affected set; require authority |
-| `gh stack push`        | Updates active remote branches and may partly succeed                                     | Bind each ref update to the complete precondition; require publish or stack mutation authority                         |
-| `gh stack submit`      | Pushes branches, creates or updates pull requests, and updates the native stack           | Bind ref, PR, and stack effects to the complete precondition; require authority                                        |
-| `gh stack sync`        | May fetch, fast-forward trunk, rebase, push, relink, save state, and prune when requested | Bind every enabled phase to the complete precondition; require authority for every mutation                            |
-| `gh stack merge`       | Directly merges an exact prefix or enqueues one exact bottom pull request                 | Bind direct merge or queue residence to the complete precondition; require authority for the mutation set              |
+| Command                | Material effects                                                                                     | Required disclosure and authority                                                                                      |
+| ---------------------- | ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `gh stack init`        | Enables `rerere`, writes stack state, may create branches, and checks out the top branch             | Preview config, branch, state, and checkout changes; require local materialization authority                           |
+| `gh stack view --json` | Reads GitHub and may refresh saved stack state                                                       | Declare the refresh; require scoped local-state authority and verify that the checkout is unchanged                    |
+| `gh stack rebase`      | By default fetches, may move trunk, rewrites layer commits, and records recovery state               | Use `--no-trunk` for a bounded suffix fix; otherwise preview the new base and complete affected set; require authority |
+| `gh stack push`        | Updates active remote branches and may partly succeed                                                | Fence selected refs plus the topology and PR state that select them; require publish or stack mutation authority       |
+| `gh stack submit`      | Pushes branches, creates or updates pull requests, disables auto-merge, and updates the native stack | Fence refs, expected PR identity or absence, PR state, and topology; require separate authority for every transition   |
+| `gh stack sync`        | May fetch, fast-forward trunk, rebase, push, relink, save state, and prune when requested            | Fence every enabled phase's writes and all state that selects or authorizes them; require authority for every mutation |
+| `gh stack merge`       | Directly merges an exact prefix or enqueues one exact bottom pull request                            | Fence the prefix and every automatically affected suffix resource; require authority for the complete affected set     |
 
 Status-only work must not hide the local refresh performed by
 `gh stack view --json`. If the caller has not authorized that bounded state
@@ -335,10 +350,10 @@ side-effect-free git and GitHub reads. It does not silently widen authority.
 
 A bounded repair or recovery always uses `rebase --no-trunk` so the dependency
 does not fetch or move the comparison base. A deliberate trunk refresh is a
-separate operation: the dependency must expose a fetch/read phase followed by a
-new manifest and an expected-base-bound rewrite phase. If it cannot pause before
-rewriting candidates against the newly observed trunk, that operation is
-blocked.
+separate operation: the dependency must expose a fetch/read phase, successor-
+source construction and remote verification, a new manifest, and an expected-
+base-bound rewrite phase. If it cannot pause before rewriting candidates against
+the newly observed trunk, that operation is blocked.
 
 ## Workflow
 
@@ -382,29 +397,39 @@ The plan no longer controls materialized topology.
 
 ### 4. Publish
 
-Require publish authority. Produce a dry-run manifest containing the complete
-current native mutation precondition and the proposed repository, remote, trunk,
-ordered branches, branch heads, pull requests, native stack, and draft or ready
-state of every pull request.
+Require publish authority. Before initial publication, verify that every entry
+in the ordered source lineage resolves at its stamped SHA on the selected
+remote. A source branch is never pushed implicitly; a missing remote source
+blocks with the exact prerequisite and authority needed to publish it.
 
-Execution invokes `gh stack submit --auto --remote <remote>` through the skill's
-single command surface. New pull requests are drafts in this mode. The wrapper
-adds `--open` only when the manifest requests ready-for-review pull requests and
-the caller has separately granted authority for that state transition. Since
-`--open` also marks existing drafts ready, the preview lists every affected pull
-request. Layer commit messages already contain the human-readable intent,
-non-goals, and intentional incompleteness from which automatic pull-request text
-is derived. Submission is available only when the dependency binds every ref,
-pull-request, and native-stack effect to the manifest's complete precondition. A
-dependency that refreshes or accepts any expectation after manifest approval
-does not satisfy this contract.
+Produce a dry-run manifest containing the submit operation mutation
+precondition; the proposed repository, remote, trunk, ordered branches, branch
+heads, pull requests, native stack, and draft or ready state of every pull
+request; every lineage ref and SHA; and the exact title and human-readable body
+for every layer. Each body retains the layer's intent, non-goals, intentional
+incompleteness, and the later layer that resolves it.
+
+Execution invokes a tested non-interactive `gh stack submit` mode through the
+skill's single command surface. It is available only when the dependency accepts
+and preserves the manifest's exact per-layer titles and bodies despite
+repository templates, and binds every ref, pull-request, and native-stack effect
+to the submit operation precondition. New pull requests are drafts unless the
+manifest requests ready-for-review pull requests and the caller separately
+authorizes that transition. The preview includes every existing draft that would
+be opened and every existing pull request whose auto-merge setting would be
+disabled; those are separate authorities. A dependency that derives bodies from
+templates, requires an unfenced post-submit metadata edit, or refreshes an
+expectation after manifest approval does not satisfy this contract.
 
 After submission:
 
 1. Read the native GitHub stack.
 2. Verify trunk and ordered pull-request membership.
 3. Verify every remote head and pull-request base.
-4. Verify every layer diff.
+4. Verify every exact pull-request title and body and every intended state
+   transition.
+5. Verify every lineage ref and stamped SHA.
+6. Verify every layer diff.
 
 No post-submit pull-request metadata edit is required. Commit trailers are the
 sole new machine-readable semantic and provenance record.
@@ -455,23 +480,26 @@ Before mutation, resolve and report:
 - current stack and trunk identity;
 - applicable checks, reviews, and protection gates;
 - merge method and merge-queue behavior; and
-- authority covering the complete mutation set: the direct prefix, or the queued
-  bottom pull request plus every suffix branch and pull request that its landing
-  may rebase or retarget.
+- authority covering the complete mutation set: the direct prefix plus every
+  suffix branch and pull request the direct landing may rebase or retarget, or
+  the queued bottom pull request plus that same affected suffix.
 
 For a direct prefix merge, invoke
 `gh stack merge <boundary-pr-number> --yes [--merge-method <method>]`. The
 boundary pull request selects the contiguous prefix. A stack number may replace
 it only when authority covers the whole stack. The dependency must atomically
-reject the request unless the complete native mutation precondition still holds,
-including exact trunk, native membership, and every selected pull request's
-identity, head, base, and state. A direct merge is one all-or-nothing service
+reject the request unless the direct-merge operation precondition still holds,
+including exact trunk, native membership, and every prefix and automatically
+affected suffix pull request's identity, head, base, and state. Partial direct
+merge is blocked when the dependency cannot durably fence and authorize that
+complete affected set; whole-stack direct merge remains possible when its own
+precondition is supported. A direct merge is one all-or-nothing service
 operation.
 
 On merge-queue repositories, admit only the current bottom pull request with
 `gh stack merge <bottom-pr-number> --yes`. The queue chooses the merge method,
 so the wrapper omits method flags and records that they do not apply. The
-manifest includes the complete native mutation precondition. The dependency must
+manifest includes the queue-merge operation precondition. The dependency must
 fence it at admission and keep it effective until landing, rejecting or
 canceling the operation before native suffix mutation if any ref, pull request,
 trunk, or membership field changes.
@@ -483,7 +511,7 @@ After landing, the skill synchronizes, reads every new head, and rebuilds all
 candidate-bound validation, review, CI, and feedback evidence before separately
 authorizing and admitting the next bottom pull request. It never admits a prefix
 that GitHub may process in multiple autonomous groups. If the dependency cannot
-maintain the complete fence through landing, queue admission is blocked.
+maintain the operation fence through landing, queue admission is blocked.
 
 This one-at-a-time queue admission is lifecycle coordination through the native
 stack engine, not a return to custom propagation: GitHub and `gh stack` still
@@ -545,19 +573,38 @@ alone. It resolves the exact stack and branches before invoking the dependency.
 
 Every operation with local or remote side effects has two phases.
 
-The complete native mutation precondition contains:
+Each operation mutation precondition contains the exact repository and selected
+remote, plus:
 
-- exact repository and selected remote;
-- exact trunk identity, remote ref, and SHA;
-- every affected branch ref's expected SHA or expected absence;
-- every existing affected pull request's repository-scoped identity, head, base,
-  open or closed state, draft or ready state, and queue state; and
-- the native stack's identity, trunk, and complete ordered pull-request
-  membership, or its expected absence before creation.
+- every direct and automatic write the operation may perform;
+- every resource state that selects mutation targets or bounds authority, even
+  when the operation does not write that resource; and
+- expected absence for every ref, pull request, or native stack the operation
+  may create.
 
-The dependency must evaluate this precondition atomically with every ref,
-pull-request, topology, queue, or merge mutation. A preliminary read followed by
-an unfenced service request does not satisfy it.
+The concrete fence is operation-scoped:
+
+- push binds active native membership and order, the pull-request merged or
+  queued state that selects active branches, and every selected branch ref's
+  exact SHA or expected absence;
+- submit and legacy adoption bind every ref SHA or absence, per-branch expected
+  pull-request identity or absence, existing pull-request head, base, open or
+  closed, draft or ready, queue, and auto-merge state, exact native-stack
+  identity or absence, trunk and order, and every explicitly authorized
+  transition;
+- sync binds the exact enabled phases and every trunk, ref, pull request, and
+  topology field those phases read to select targets or may write;
+- direct merge binds the exact trunk and base, native membership and order, and
+  every prefix and automatically affected suffix ref and pull-request identity,
+  head, base, and state; and
+- queue merge binds the admitted bottom pull request plus the entire affected
+  suffix and keeps that fence effective through landing.
+
+The dependency must evaluate the applicable precondition atomically with every
+ref, pull-request, topology, queue, or merge mutation. A preliminary read
+followed by an unfenced service request does not satisfy it. An operation is
+blocked if the tested dependency cannot express its complete scoped fence;
+support for a different operation does not widen that capability.
 
 ### Preview
 
@@ -574,17 +621,17 @@ Readback always classifies every declared target as changed as expected,
 unchanged, or changed unexpectedly.
 
 For every push-capable `gh stack` operation, include the proposed head of every
-active branch and enforce the complete precondition. If any ref precondition
-fails, classify all declared targets before retry; never create or overwrite the
-unexpected ref. After any result, read every remote ref and report which leases
-advanced, which were rejected, and which heads are unexpected. A retry starts
-from that new snapshot; it never replays the stale manifest.
+active branch and enforce the applicable operation precondition. If any ref
+precondition fails, classify all declared targets before retry; never create or
+overwrite the unexpected ref. After any result, read every remote ref and report
+which leases advanced, which were rejected, and which heads are unexpected. A
+retry starts from that new snapshot; it never replays the stale manifest.
 
-For direct merge, enforce the complete precondition and verify that the complete
-prefix either merged or remained open. For queue-backed merge, durably fence the
-complete precondition through landing. Distinguish admission from landing, and
-do not admit another pull request until the rebased suffix has passed fresh
-candidate-bound gates.
+For direct merge, enforce its operation precondition and verify that the
+complete prefix either merged or remained open. For queue-backed merge, durably
+fence its operation precondition through landing. Distinguish admission from
+landing, and do not admit another pull request until the rebased suffix has
+passed fresh candidate-bound gates.
 
 ## Interruption and divergence
 
@@ -637,7 +684,7 @@ topology.
 
 The adoption path does not invoke `gh stack link`. That command can push branch
 arguments, create pull requests, retarget existing pull-request bases, and
-change native stack membership, but it is not covered by the complete native
+change native stack membership, but it is not covered by the required operation
 mutation precondition. If the tested `gh stack submit` version cannot adopt the
 existing pull requests non-interactively through the fenced submit path,
 adoption returns `blocked` rather than widening to `link`.
@@ -705,9 +752,13 @@ Cover:
 - default-rebase fetch and trunk/base effect classification;
 - fix-only `rebase --no-trunk --upstack <branch>` construction;
 - phased trunk-refresh manifests and expected-base enforcement;
-- complete ref, pull-request, trunk, and native-membership preconditions for
-  submit, sync, and merge;
-- durable complete-state fencing for queue admission through landing;
+- operation-scoped ref, pull-request, trunk, and native-membership
+  preconditions, including their target-selection and authority inputs;
+- expected pull-request absence and auto-merge-state fencing for submit;
+- durable affected-suffix fencing for direct and queue merge;
+- initial-publication source-lineage remote verification;
+- explicit per-layer body preservation with a repository pull-request template;
+- successor-source construction and equivalence proof after trunk drift;
 - post-command readback;
 - partial push and queued-merge state classification;
 - interrupted and divergent states;
@@ -728,16 +779,25 @@ Use disposable repositories and controlled `gh stack` fixtures to cover:
   when only unfenced link can represent the chain;
 - a lower-layer fix and cascading rebase;
 - base movement before a default rebase, requiring a new manifest before any
-  rewrite;
+  rewrite and a remotely stamped successor source before accepting the base;
 - a rejected branch lease after earlier branches have updated;
 - a remote advance after manifest approval that rejects without overwriting it;
 - a same-named remote branch created after manifest approval that rejects
   without mutation;
+- a pull request created after expected absence was approved that rejects submit
+  without mutation;
+- an auto-merge-state change after approval that rejects submit without
+  mutation;
+- initial publication blocked by a missing remote source-lineage ref;
+- explicit per-layer bodies preserved despite a repository pull-request
+  template;
 - pull-request base, draft state, or native membership changing after approval
   and rejecting before submit or sync mutation;
 - local and remote divergence;
 - partial publication;
 - an all-or-nothing direct prefix merge;
+- a partial direct merge blocked without authority and a fence for every
+  automatically affected suffix resource;
 - a selected pull-request head advance that rejects direct merge and queue
   admission;
 - trunk movement or native stack reordering that rejects direct merge before

--- a/design/carve-changesets-on-gh-stack.md
+++ b/design/carve-changesets-on-gh-stack.md
@@ -275,10 +275,12 @@ boundary require:
 - non-interactive `gh stack init` for explicit branches;
 - `gh stack rebase`, `push`, `submit`, `sync`, and `merge`;
 - push, submit, and push-capable sync operations that accept the manifest's
-  exact expected-old SHA for every remote branch and reject each mismatched
-  update before overwriting an unexpected head;
-- merge operations that accept the manifest's exact pull-request head set and
-  reject the request before direct merge or queue admission if any head differs;
+  expected remote state for every branch—an exact SHA or absence—and reject each
+  mismatch before creating or overwriting an unexpected ref;
+- merge operations that accept the manifest's exact mutation set and reject a
+  direct merge if any selected head differs; and
+- queue operations that durably fence the bottom pull request and every suffix
+  head and base that its landing may rebase or retarget;
 - GitHub native stacks enabled for the repository; and
 - live read access to stack, pull-request, review, check, and merge state.
 
@@ -287,25 +289,26 @@ incompatible capability returns `blocked`. It does not download a substitute
 tool or enter the retired custom stack path.
 
 At the reviewed public-preview revision, the CLI does not expose the required
-expected-head preconditions for remote updates or merges. Until a tested
-compatible version does, the skill may propose and materialize a local native
-stack, but must block before publication, remote repair, recovery, or merge.
-Post-command readback cannot substitute for a precondition because it observes
-an unauthorized write only after it has occurred.
+expected-state preconditions for remote updates or durable full-mutation-set
+fencing for merges. Until a tested compatible version does, the skill may
+propose and materialize a local native stack, but must block before publication,
+remote repair, recovery, or merge. Post-command readback cannot substitute for a
+precondition because it observes an unauthorized write only after it has
+occurred.
 
 ### Command effects and authority
 
 The adapter treats dependency commands by their real effects:
 
-| Command                | Material effects                                                                          | Required disclosure and authority                                                                                   |
-| ---------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `gh stack init`        | Enables `rerere`, writes stack state, may create branches, and checks out the top branch  | Preview config, branch, state, and checkout changes; require local materialization authority                        |
-| `gh stack view --json` | Reads GitHub and may refresh saved stack state                                            | Declare the refresh; require scoped local-state authority and verify that the checkout is unchanged                 |
-| `gh stack rebase`      | Rewrites local layer commits and records recovery state                                   | Preview the affected suffix; require stack mutation authority                                                       |
-| `gh stack push`        | Updates active remote branches and may partly succeed                                     | Bind every update to the manifest's expected-old SHA; require publish or stack mutation authority                   |
-| `gh stack submit`      | Pushes branches, creates or updates pull requests, and updates the native stack           | Bind every pushed branch to its expected-old SHA; preview pull requests and draft or ready state; require authority |
-| `gh stack sync`        | May fetch, fast-forward trunk, rebase, push, relink, save state, and prune when requested | Preview every enabled phase; bind any push to expected-old SHAs; require authority for every resulting mutation     |
-| `gh stack merge`       | Directly merges an exact prefix or enqueues one exact bottom pull request                 | Bind the request to expected PR heads; require merge authority for the direct prefix or queued bottom PR            |
+| Command                | Material effects                                                                          | Required disclosure and authority                                                                                |
+| ---------------------- | ----------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `gh stack init`        | Enables `rerere`, writes stack state, may create branches, and checks out the top branch  | Preview config, branch, state, and checkout changes; require local materialization authority                     |
+| `gh stack view --json` | Reads GitHub and may refresh saved stack state                                            | Declare the refresh; require scoped local-state authority and verify that the checkout is unchanged              |
+| `gh stack rebase`      | Rewrites local layer commits and records recovery state                                   | Preview the affected suffix; require stack mutation authority                                                    |
+| `gh stack push`        | Updates active remote branches and may partly succeed                                     | Bind each update to an expected SHA or absence; require publish or stack mutation authority                      |
+| `gh stack submit`      | Pushes branches, creates or updates pull requests, and updates the native stack           | Bind each push to an expected SHA or absence; preview PR and ready-state effects; require authority              |
+| `gh stack sync`        | May fetch, fast-forward trunk, rebase, push, relink, save state, and prune when requested | Preview every phase; bind each push to an expected SHA or absence; require authority for every mutation          |
+| `gh stack merge`       | Directly merges an exact prefix or enqueues one exact bottom pull request                 | Bind direct heads or durably fence the queued bottom and affected suffix; require authority for the mutation set |
 
 Status-only work must not hide the local refresh performed by
 `gh stack view --json`. If the caller has not authorized that bounded state
@@ -366,8 +369,9 @@ the caller has separately granted authority for that state transition. Since
 request. Layer commit messages already contain the human-readable intent,
 non-goals, and intentional incompleteness from which automatic pull-request text
 is derived. Submission is available only when the dependency binds every branch
-push to the manifest's exact expected-old SHA. A dependency that refreshes its
-own lease expectations after manifest approval does not satisfy this contract.
+push to the manifest's expected remote state: an exact SHA for an existing ref,
+or absence for a new ref. A dependency that refreshes its own lease expectations
+after manifest approval does not satisfy this contract.
 
 After submission:
 
@@ -424,8 +428,9 @@ Before mutation, resolve and report:
 - current stack and trunk identity;
 - applicable checks, reviews, and protection gates;
 - merge method and merge-queue behavior; and
-- authority covering the complete direct prefix or the one queued bottom pull
-  request.
+- authority covering the complete mutation set: the direct prefix, or the queued
+  bottom pull request plus every suffix branch and pull request that its landing
+  may rebase or retarget.
 
 For a direct prefix merge, invoke
 `gh stack merge <boundary-pr-number> --yes [--merge-method <method>]`. The
@@ -436,14 +441,20 @@ expected head. A direct merge is one all-or-nothing service operation.
 
 On merge-queue repositories, admit only the current bottom pull request with
 `gh stack merge <bottom-pr-number> --yes`. The queue chooses the merge method,
-so the wrapper omits method flags and records that they do not apply. The merge
-request must reject admission unless that pull request still has the manifest's
-expected head. Queue admission is an asynchronous handoff, not merge completion.
-After it lands, GitHub may rebase the remaining suffix. The skill then
-synchronizes, reads every new head, and rebuilds all candidate-bound validation,
-review, CI, and feedback evidence before separately authorizing and admitting
-the next bottom pull request. It never admits a prefix that GitHub may process
-in multiple autonomous groups.
+so the wrapper omits method flags and records that they do not apply. The
+manifest includes the exact bottom head and every suffix head and base that the
+landing may rebase or retarget. The dependency must fence that complete set at
+admission and keep the fence effective until landing, rejecting or canceling the
+operation before native suffix mutation if any member changes.
+
+Queue admission is an asynchronous handoff, not merge completion. Its authority
+covers the native heads and bases produced by landing the exact bottom candidate
+against the exact fenced suffix; it does not cover arbitrary replacement heads.
+After landing, the skill synchronizes, reads every new head, and rebuilds all
+candidate-bound validation, review, CI, and feedback evidence before separately
+authorizing and admitting the next bottom pull request. It never admits a prefix
+that GitHub may process in multiple autonomous groups. If the dependency cannot
+maintain the complete fence through landing, queue admission is blocked.
 
 This one-at-a-time queue admission is lifecycle coordination through the native
 stack engine, not a return to custom propagation: GitHub and `gh stack` still
@@ -515,19 +526,21 @@ A successful command followed by conflicting readback returns `blocked`.
 Readback always classifies every declared target as changed as expected,
 unchanged, or changed unexpectedly.
 
-For every push-capable `gh stack` operation, capture the old and proposed head
-of every active branch and pass the old heads as dependency-enforced
-compare-and-swap preconditions. If any precondition fails, classify all declared
-targets before retry; never overwrite the unexpected head. After any result,
-read every remote ref and report which leases advanced, which were rejected, and
-which heads are unexpected. A retry starts from that new snapshot; it never
-replays the stale manifest.
+For every push-capable `gh stack` operation, capture the expected remote state
+and proposed head of every active branch. The expected state is an exact SHA for
+an existing ref or absence for a new ref. Pass those states as
+dependency-enforced compare-and-swap preconditions. If any precondition fails,
+classify all declared targets before retry; never create or overwrite the
+unexpected ref. After any result, read every remote ref and report which leases
+advanced, which were rejected, and which heads are unexpected. A retry starts
+from that new snapshot; it never replays the stale manifest.
 
 For direct merge, pass every selected expected pull-request head as one atomic
 precondition and verify that the complete prefix either merged or remained open.
-For queue-backed merge, pass the bottom pull request's expected head,
-distinguish admission from landing, and do not admit another pull request until
-the rebased suffix has passed fresh candidate-bound gates.
+For queue-backed merge, durably fence the bottom head and every affected suffix
+head and base through landing. Distinguish admission from landing, and do not
+admit another pull request until the rebased suffix has passed fresh
+candidate-bound gates.
 
 ## Interruption and divergence
 
@@ -634,8 +647,10 @@ Cover:
 - dry-run manifests;
 - exact argv construction;
 - command-effect and authority classification;
-- exact expected-old SHA enforcement for push, submit, and push-capable sync;
-- exact expected-head enforcement for direct merge and queue admission;
+- exact expected-SHA and expected-absence enforcement for push, submit, and
+  push-capable sync;
+- exact expected-head enforcement for direct merge;
+- durable bottom-and-suffix fencing for queue admission through landing;
 - post-command readback;
 - partial push and queued-merge state classification;
 - interrupted and divergent states;
@@ -655,6 +670,8 @@ Use disposable repositories and controlled `gh stack` fixtures to cover:
 - a lower-layer fix and cascading rebase;
 - a rejected branch lease after earlier branches have updated;
 - a remote advance after manifest approval that rejects without overwriting it;
+- a same-named remote branch created after manifest approval that rejects
+  without mutation;
 - local and remote divergence;
 - partial publication;
 - an all-or-nothing direct prefix merge;
@@ -662,6 +679,8 @@ Use disposable repositories and controlled `gh stack` fixtures to cover:
   admission;
 - a queue whose group limit is smaller than the desired prefix, proving that
   only one bottom pull request is admitted before suffix revalidation;
+- an upstack head advance during queue residence that cancels or rejects the
+  landing before suffix mutation;
 - post-merge synchronization;
 - successor-source recovery; and
 - final source equivalence.
@@ -708,7 +727,7 @@ not part of the design-document changeset.
 - `carve-changesets` gains a hard dependency on a preview tool and API.
 - Compatible versions must be tested and bounded.
 - Publication and merge remain unavailable until `gh stack` exposes the required
-  expected-head preconditions.
+  expected-state preconditions and durable queue fencing.
 - Dependency commands may require interactive recovery.
 - Native stack behavior may change during public preview.
 - Existing chains require adoption before continued operation.

--- a/design/carve-changesets-on-gh-stack.md
+++ b/design/carve-changesets-on-gh-stack.md
@@ -1,0 +1,621 @@
+# Carve Changesets on GitHub Stacks
+
+Status: proposed\
+Date: 2026-08-05
+
+## Decision summary
+
+Rebuild `carve-changesets` around GitHub native stacked pull requests and the
+`gh stack` CLI.
+
+`carve-changesets` will decide how to divide one large, coherent source branch.
+It will identify reviewable seams, preserve indivisible work, construct safe
+intermediate states, materialize the layers, and prove that the complete stack
+reproduces the intended result.
+
+GitHub and `gh stack` will own the mechanics of maintaining that breakdown. The
+skill will no longer carry a parallel implementation for stack topology,
+cascading rebases, remote publication, pull-request retargeting, or downstream
+propagation.
+
+This design replaces the current dual role in which `carve-changesets` owns both
+semantic decomposition and stack management. Ticket planning follows approval of
+this document.
+
+## Context
+
+The current skill solves two different problems:
+
+1. It determines where a large candidate can be cut without making a layer
+   incoherent, unsafe, or impossible to review.
+2. It implements a stacked-pull-request manager with custom branch naming,
+   topology metadata, publication, rebasing, force-pushing, pull-request
+   retargeting, merge sequencing, and suffix propagation.
+
+The first problem is the reason for the skill. It requires knowledge of product
+intent, code structure, migration safety, review load, and final behavior.
+
+GitHub native stacks and `gh stack` now cover most of the second problem. The
+CLI can adopt existing branches, record stack order, expose machine-readable
+state, perform cascading rebases, push the stack atomically, submit native
+stacked pull requests, and synchronize local and remote state. GitHub owns the
+published stack object, trunk-relative protections, merge queues, and atomic
+prefix merges.
+
+Keeping both stack engines would preserve duplicated state and conflicting
+mutation paths. It would also force `carve-changesets` to understand every
+change in GitHub's stack behavior. A single stack engine gives each component a
+clearer purpose.
+
+References:
+
+- [GitHub stacked pull requests announcement](https://github.blog/changelog/2026-07-30-stacked-pull-requests-are-now-in-public-preview/)
+- [`gh-stack` repository](https://github.com/github/gh-stack)
+- [`gh stack` CLI reference](https://github.github.com/gh-stack/reference/cli/)
+
+## Goals
+
+The redesigned skill must:
+
+01. Analyze one immutable, review-ready source branch and its complete diff.
+02. Identify cohesive, independently reviewable changeset seams.
+03. Preserve work that cannot be divided safely.
+04. Order foundations, migrations, consumers, cutovers, and removals safely.
+05. Document intentional incompleteness in every intermediate layer.
+06. Materialize the approved layers without mutating the source branch.
+07. Adopt the materialized branches into one verified local `gh stack`.
+08. Use `gh stack` as the sole stack-management engine from materialization
+    onward.
+09. Publish every new chain as one native GitHub stack.
+10. Preserve exact candidate review, validation, and authority boundaries.
+11. Prove that the complete stack remains equivalent to the active immutable
+    source.
+12. Recover accepted post-publication corrections through successor-source
+    provenance and native stack mechanics.
+13. Resume from live git, `gh stack`, and GitHub state after interruption.
+14. Fail closed when the required stack capability or exact identity cannot be
+    verified.
+15. Retire the custom stack manager instead of preserving it as a fallback.
+
+## Non-goals
+
+The redesign does not:
+
+- ask `gh stack` to choose semantic seams;
+- use `gh stack modify` to split the source candidate;
+- weaken immutable-source or whole-chain equivalence requirements;
+- weaken per-layer validation or repository-owned review;
+- give a single pull-request watcher authority over the whole stack;
+- preserve custom stack propagation as a compatibility mode;
+- support pull-request hosts other than GitHub;
+- migrate review remediation to `review-fix-loop`; or
+- create or alter implementation tickets as part of this design.
+
+## Architectural position
+
+The target dependency structure is:
+
+```text
+carve-changesets
+├── semantic decomposition and materialization
+├── validation and whole-chain equivalence
+├── review-code-change
+├── babysit-pr
+└── gh stack
+    ├── local stack topology
+    ├── cascading rebase and push
+    ├── native stack submission and synchronization
+    └── GitHub native stack APIs
+```
+
+`carve-changesets` remains the coordinator. It grants bounded authority, selects
+the exact operation, and verifies the result. `gh stack` performs stack
+mechanics. GitHub provides published topology and merge behavior.
+
+## Responsibility boundary
+
+### `carve-changesets`
+
+`carve-changesets` owns:
+
+- source and base identity;
+- semantic seam selection;
+- indivisibility decisions;
+- safe intermediate-state design;
+- extraction of source work into layer commits;
+- layer descriptions, non-goals, and intentional incompleteness;
+- per-layer validation and review packets;
+- immutable-source and successor-source provenance;
+- whole-chain tree, schema, and behavioral equivalence;
+- mutation authority and exact target resolution;
+- evidence invalidation after candidate changes;
+- stack-level lifecycle coordination; and
+- independent readback after every mutation.
+
+### `gh stack`
+
+`gh stack` owns:
+
+- local stack membership and order;
+- adoption of materialized branches;
+- linear ancestry maintenance;
+- cascading rebases;
+- atomic stack pushes with leases;
+- native stacked-pull-request submission;
+- local and remote stack synchronization;
+- merged-layer reconciliation; and
+- navigation between stack layers.
+
+### GitHub
+
+GitHub owns:
+
+- the published native stack object;
+- stack trunk and ordered pull-request membership;
+- trunk-relative protection and check evaluation;
+- merge-queue integration;
+- native atomic prefix merges; and
+- automatic rebase and retarget behavior after a partial merge.
+
+### `review-code-change`
+
+`review-code-change` remains read-only. It reviews one exact layer against its
+exact predecessor and returns an evidence-bound verdict.
+
+### `babysit-pr`
+
+`babysit-pr` owns CI, published feedback, review threads, and readiness for one
+exact pull request. Stack mutation and native stack merge authority are
+withheld.
+
+When a fix would change a stack member, `babysit-pr` returns a stack-fix
+handback. It does not push the fix, cascade the upstack, or merge an implicit
+prefix.
+
+## Truth model
+
+Truth advances through four phases:
+
+```text
+proposed
+  plan and immutable source
+    ↓
+materialized
+  git commits, branches, and verified gh stack state
+    ↓
+published
+  native GitHub stack, pull requests, and remote git refs
+    ↓
+merged
+  GitHub merge state and mainline representation
+```
+
+Each phase supersedes weaker topology records.
+
+### Proposed truth
+
+The plan is authoritative only before materialization. It records semantic
+slugs, intent, order, selectors, intermediate-state constraints, and validation
+requirements.
+
+### Materialized truth
+
+Live git commits and branches establish layer contents. `gh stack view --json`
+establishes local stack membership and order. The skill cross-checks both
+sources before accepting the chain.
+
+The `.git/gh-stack` file is operational state owned by the dependency. The skill
+never parses that file directly. It consumes the documented CLI surface.
+
+### Published truth
+
+The native GitHub stack establishes trunk and ordered pull-request membership.
+Remote refs establish branch heads. Pull requests establish candidate heads,
+bases, checks, reviews, and mergeability.
+
+Local `gh stack` state remains useful for execution. It cannot override live
+GitHub state.
+
+### Merged truth
+
+GitHub merge state and live mainline establish merged truth. The skill must also
+prove that the represented result matches the active immutable source.
+
+## Layer identity and metadata
+
+A semantic slug identifies a changeset. Position comes from live stack order.
+Branch names and numeric positions do not establish durable semantic identity.
+
+Commit and pull-request metadata retain only information that GitHub stacks do
+not provide:
+
+- semantic slug;
+- immutable root source identity;
+- active successor source identity when recovery has occurred;
+- ordered source lineage; and
+- recovery provenance when a suffix has been corrected.
+
+Native stack number, position, predecessor, trunk, and size must not be copied
+into durable `carve-changesets` metadata. Those values come from GitHub and
+`gh stack` at read time.
+
+The redesign introduces a new metadata version for native stacks. Existing v1
+and v2 metadata remain evidence for legacy adoption. They do not establish the
+post-adoption topology.
+
+## Capability contract
+
+Proposal-only work requires git and Python. Materialization and every later
+boundary require:
+
+- an authenticated compatible GitHub CLI;
+- a tested compatible `gh-stack` extension version;
+- `gh stack view --json`;
+- non-interactive `gh stack init` for explicit branches;
+- `gh stack rebase`, `push`, `submit`, and `sync`;
+- GitHub native stacks enabled for the repository; and
+- live read access to stack, pull-request, review, check, and merge state.
+
+The skill checks capability before the affected mutation. Missing or
+incompatible capability returns `blocked`. It does not download a substitute
+tool or enter the retired custom stack path.
+
+## Workflow
+
+### 1. Resolve
+
+Resolve the repository, checkout, worktree, source, base, approved validation,
+requested terminal boundary, and mutation authority.
+
+When the requested boundary is `chain_ready` or later, verify `gh stack`
+capability before materialization.
+
+### 2. Propose
+
+Analyze the complete source diff. Produce ordered semantic layers with explicit
+intent, inclusions, exclusions, selectors, intermediate-state constraints, and
+validation.
+
+The proposal must explain why each seam is valid and why identified indivisible
+work remains together.
+
+### 3. Materialize
+
+Create the ordered layer commits and branches without mutating the immutable
+source.
+
+`gh stack modify` cannot split one source branch into semantic layers, so the
+existing extraction machinery remains responsible for this step.
+
+After creating the branches:
+
+1. Verify each branch tree and predecessor diff.
+2. Verify the reconstructed full chain against the immutable source.
+3. Run `gh stack init --base <base> <branch-1> ... <branch-n>`.
+4. Read `gh stack view --json`.
+5. Cross-check trunk, ordered branches, heads, and git ancestry.
+6. Run the required per-layer validation and review.
+
+`chain_ready` requires agreement among semantic plan, live git, and `gh stack`.
+The plan no longer controls materialized topology.
+
+### 4. Publish
+
+Require publish authority. Produce a dry-run manifest containing the exact
+repository, remote, trunk, ordered branches, branch heads, proposed pull
+requests, and expected native stack.
+
+Execution invokes `gh stack submit` through the skill's single command surface.
+The wrapper selects non-interactive flags and passes explicit remote identity.
+
+After submission:
+
+1. Read the native GitHub stack.
+2. Verify trunk and ordered pull-request membership.
+3. Verify every remote head and pull-request base.
+4. Verify every layer diff.
+5. Add semantic context and provenance to pull-request bodies.
+6. Read back the edited pull requests.
+
+An exit code alone never proves publication.
+
+### 5. Monitor
+
+Delegate each exact pull request to `babysit-pr` with stack mutation and merge
+authority withheld.
+
+Independent pull requests may be monitored in parallel. Their lifecycle owners
+must not run competing branch updates.
+
+Readiness remains candidate-bound. A stack-wide mutation invalidates every
+affected candidate and returns it to the required validation and review gates.
+
+### 6. Repair
+
+When feedback requires a head-changing fix, `babysit-pr` returns a stack-fix
+handback containing the exact pull request, old head, finding, accepted scope,
+and current stack identity.
+
+`carve-changesets` then:
+
+1. Reclaims exclusive stack mutation ownership.
+2. Applies the fix to the layer that owns it.
+3. Creates or verifies a successor source when the accepted result has changed.
+4. Runs `gh stack rebase` across the affected upstack.
+5. Runs `gh stack push` or `gh stack sync` as appropriate.
+6. Reads back local git, `gh stack`, remote refs, and GitHub pull requests.
+7. Rebuilds invalidated validation, review, CI, and feedback evidence.
+8. Returns each corrected pull request to its lifecycle owner.
+
+`gh stack` owns propagation. `carve-changesets` owns the fix placement,
+provenance, authority, and proof.
+
+### 7. Merge
+
+Collect verified readiness for the exact contiguous prefix selected for merge.
+
+Before mutation, resolve and report:
+
+- every pull request affected by the native merge;
+- exact candidate heads;
+- current stack and trunk identity;
+- applicable checks, reviews, and protection gates;
+- merge method and merge-queue behavior; and
+- authority covering the complete affected prefix.
+
+GitHub performs the native stack merge. The custom sequential merge and suffix
+propagation path is retired.
+
+After completion:
+
+1. Read the asynchronous merge result when applicable.
+2. Run `gh stack sync`.
+3. Verify every merged pull request on the trunk.
+4. Verify the remaining suffix's new heads and bases.
+5. Rebuild invalidated evidence.
+6. Verify the resulting mainline tree and behavior against the active source.
+
+### 8. Recover
+
+An accepted fix after a prefix merge may change the intended final result.
+`carve-changesets` still creates or verifies a distinct immutable successor
+source and continuous lineage.
+
+The skill applies the fix at the correct open layer and delegates suffix
+mechanics to `gh stack rebase`, `push`, and `sync`. It does not manually
+recreate propagation.
+
+Recovery preserves merged positions and pull-request identities. It rebuilds all
+evidence bound to changed candidates.
+
+## Command-surface changes
+
+The consolidated CLI remains the only `carve-changesets` command surface. It
+wraps exact `gh stack` argv and performs preflight and readback.
+
+Retire or replace:
+
+| Current command   | Target behavior                                                   |
+| ----------------- | ----------------------------------------------------------------- |
+| `create-chain`    | Materialize semantic layers, then adopt them with `gh stack init` |
+| `push-chain`      | Preview and invoke `gh stack push`                                |
+| `pr-create`       | Preview and invoke `gh stack submit`                              |
+| `propagate`       | Remove; use verified `gh stack sync` or `rebase` plus `push`      |
+| `merge-propagate` | Replace with native stack merge coordination and `gh stack sync`  |
+| `recover-suffix`  | Retain semantic recovery, delegate mechanics to `gh stack`        |
+| `status`          | Combine git, `gh stack view --json`, and live GitHub evidence     |
+
+The wrapper must never infer a mutation target from the checked-out branch
+alone. It resolves the exact stack and branches before invoking the dependency.
+
+## Mutation and readback contract
+
+Every remote-mutating operation has two phases.
+
+### Preview
+
+The skill prints a bounded manifest of exact targets and intended effects. It
+does not invoke the mutating `gh stack` command.
+
+### Execute
+
+The skill re-verifies the manifest, invokes the exact command, and reads back
+all affected state.
+
+A successful command followed by conflicting readback returns `blocked`. Partial
+mutations remain visible and are reported precisely.
+
+## Interruption and divergence
+
+The skill must account for `gh stack` rebase state, stack locks, merge queues,
+and local or remote divergence.
+
+In unattended execution:
+
+- any prompt requirement returns `blocked`;
+- a rebase conflict preserves the dependency's recovery state and reports the
+  exact continuation command;
+- a diverged local and remote stack performs no write;
+- an interrupted modify or rebase is never discarded automatically;
+- a stack lock identifies the owning process or last trustworthy state when
+  available; and
+- readback distinguishes no-op success from completed mutation.
+
+The skill never parses undocumented dependency files to manufacture recovery. It
+uses documented continuation, abort, checkout, view, and sync commands.
+
+## Legacy adoption
+
+The redesigned skill has one stack engine.
+
+An existing unlinked v1 or v2 chain must be adopted before further publication,
+repair, propagation, or merge work. Adoption must:
+
+1. Resolve every exact branch, head, pull request, and predecessor base.
+2. Verify same-repository ownership and linear ancestry.
+3. Verify semantic slugs and immutable source provenance.
+4. Prove the complete chain against the active source.
+5. Run non-interactive `gh stack init` over the existing branches.
+6. Submit or link the native GitHub stack.
+7. Read back local and remote stack state.
+8. Promote open-layer metadata to the native-stack version when required.
+
+Merged legacy metadata remains historical evidence. Native GitHub state controls
+the adopted open topology.
+
+If adoption cannot be proved safe, return `blocked` with one concrete action.
+The skill does not resume the retired custom stack manager.
+
+## Terminal states
+
+### `plan_ready`
+
+Requires a complete validated semantic plan and no materialized stack.
+
+### `chain_ready`
+
+Requires exact layer commits and branches, a verified local `gh stack`, current
+per-layer validation and review, and whole-chain equivalence.
+
+### `prs_open`
+
+Requires `chain_ready` evidence, one verified native GitHub stack, exact remote
+heads and pull-request bases, current semantic metadata, and every applicable
+non-merge gate.
+
+### `all_merged`
+
+Requires every selected pull request verified merged, native synchronization
+complete, final mainline equivalence proven, required validation passing, and
+authorized cleanup complete or precisely limited.
+
+### `blocked`
+
+Requires one concrete blocker, exact phase and identities reached, preserved
+partial artifacts, last trustworthy evidence, and one action needed to resume.
+
+## Validation strategy
+
+### Contract tests
+
+Verify:
+
+- responsibility and authority boundaries;
+- required `gh stack` capability;
+- semantic identity independent of stack position;
+- topology read through documented surfaces;
+- no legacy stack-manager fallback;
+- no single-PR implicit stack mutation; and
+- candidate-evidence invalidation after stack-wide changes.
+
+### Unit tests
+
+Cover:
+
+- version and capability parsing;
+- `gh stack view --json` decoding;
+- dry-run manifests;
+- exact argv construction;
+- post-command readback;
+- interrupted and divergent states;
+- native metadata decoding;
+- legacy adoption checks; and
+- terminal-state rendering.
+
+### Integration tests
+
+Use disposable repositories and controlled `gh stack` fixtures to cover:
+
+- materialization and adoption;
+- native submission;
+- a lower-layer fix and cascading rebase;
+- atomic push and remote-head verification;
+- local and remote divergence;
+- partial publication;
+- native prefix merge;
+- post-merge synchronization;
+- successor-source recovery; and
+- final source equivalence.
+
+### Evaluations
+
+Representative evaluations must distinguish:
+
+- a valid semantic carve from a merely even-sized split;
+- indivisible work from convenient but unsafe separation;
+- dependency failure from semantic decomposition failure;
+- stack command success from verified state transition;
+- single-PR authority from stack-prefix authority; and
+- native adoption from permanent dual-mode behavior.
+
+## Delivery strategy
+
+This design is too broad for one implementation changeset. After approval, the
+work should be decomposed into an epic with independently reviewable children:
+
+1. Revise the normative contract and add the `gh stack` capability adapter.
+2. Materialize semantic layers and adopt them into local stack tracking.
+3. Replace publication and status with native submission and readback.
+4. Add stack-fix handbacks and candidate-evidence rebuilding.
+5. Replace merge and recovery mechanics with native operations.
+6. Add legacy adoption and remove the custom stack manager.
+
+Caller migrations and ticket-graph changes follow proven capability. They are
+not part of the design-document changeset.
+
+## Trade-offs
+
+### Benefits
+
+- One stack engine controls topology and mutation.
+- The skill's purpose narrows to semantic decomposition and proof.
+- GitHub behavior is available without duplicating it locally.
+- Native stack UI, checks, queues, and merges become first-class.
+- Custom force-push and retarget code disappears.
+- Ownership boundaries become easier to audit.
+
+### Costs and accepted limitations
+
+- `carve-changesets` gains a hard dependency on a preview tool and API.
+- Compatible versions must be tested and bounded.
+- Dependency commands may require interactive recovery.
+- Native stack behavior may change during public preview.
+- Existing chains require adoption before continued operation.
+- Stack-wide rebases may invalidate evidence for several layers at once.
+
+These costs are accepted because duplicating the stack engine would preserve
+more code, more state, and more ways to corrupt a published chain.
+
+## Rejected alternatives
+
+### Native-aware dual mode
+
+Keep the custom stack manager and add native-stack detection and API support.
+
+Rejected because two engines would own the same branches, pull-request bases,
+and propagation behavior. Capability drift would multiply rather than shrink.
+
+### Publication-only integration
+
+Keep custom local topology and use `gh stack link` only when opening pull
+requests.
+
+Rejected because the skill would retain cascading rebase, push, synchronization,
+and post-merge propagation machinery. Most duplicated responsibility would
+remain.
+
+### Delegate semantic carving to `gh stack modify`
+
+Create one stack and use the interactive modifier to derive the layers.
+
+Rejected because `gh stack modify` cannot split one branch into semantic
+changesets. It also lacks the source-equivalence, migration-safety, and review
+reasoning required by this skill.
+
+### Trust dependency state without independent proof
+
+Treat successful `gh stack` commands as sufficient evidence.
+
+Rejected because command success does not prove the intended branches, pull
+requests, or mainline result. `carve-changesets` remains accountable for exact
+identity, authority, and equivalence.

--- a/design/carve-changesets-on-gh-stack.md
+++ b/design/carve-changesets-on-gh-stack.md
@@ -266,13 +266,17 @@ solely for adoption.
 
 ## Capability contract
 
-Proposal-only work requires git and Python. Materialization and every later
-boundary require:
+Capabilities are checked at the boundary that first needs them. Proposal-only
+work requires git and Python. Local materialization requires:
+
+- a tested compatible `gh-stack` extension version;
+- `gh stack view --json`; and
+- non-interactive `gh stack init` for explicit branches.
+
+Publication, remote repair, recovery, and merge additionally require, as
+applicable:
 
 - an authenticated compatible GitHub CLI;
-- a tested compatible `gh-stack` extension version;
-- `gh stack view --json`;
-- non-interactive `gh stack init` for explicit branches;
 - `gh stack rebase`, `push`, `submit`, `sync`, and `merge`;
 - push, submit, and push-capable sync operations that accept the manifest's
   expected remote state for every branch—an exact SHA or absence—and reject each
@@ -281,6 +285,8 @@ boundary require:
   direct merge if any selected head differs; and
 - queue operations that durably fence the bottom pull request and every suffix
   head and base that its landing may rebase or retarget;
+- rebase and sync operations that either skip trunk with `--no-trunk` or bind
+  any fetched trunk/base state before rewriting candidates;
 - GitHub native stacks enabled for the repository; and
 - live read access to stack, pull-request, review, check, and merge state.
 
@@ -290,9 +296,11 @@ tool or enter the retired custom stack path.
 
 At the reviewed public-preview revision, the CLI does not expose the required
 expected-state preconditions for remote updates or durable full-mutation-set
-fencing for merges. Until a tested compatible version does, the skill may
-propose and materialize a local native stack, but must block before publication,
-remote repair, recovery, or merge. Post-command readback cannot substitute for a
+fencing for merges. It also does not provide a phased default rebase that can
+pause after fetch for approval of a changed trunk. Until a tested compatible
+version closes the relevant gap, the skill may propose and materialize a local
+native stack, but must block before publication, remote repair, recovery, merge,
+or a trunk-refreshing rewrite. Post-command readback cannot substitute for a
 precondition because it observes an unauthorized write only after it has
 occurred.
 
@@ -300,20 +308,27 @@ occurred.
 
 The adapter treats dependency commands by their real effects:
 
-| Command                | Material effects                                                                          | Required disclosure and authority                                                                                |
-| ---------------------- | ----------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| `gh stack init`        | Enables `rerere`, writes stack state, may create branches, and checks out the top branch  | Preview config, branch, state, and checkout changes; require local materialization authority                     |
-| `gh stack view --json` | Reads GitHub and may refresh saved stack state                                            | Declare the refresh; require scoped local-state authority and verify that the checkout is unchanged              |
-| `gh stack rebase`      | Rewrites local layer commits and records recovery state                                   | Preview the affected suffix; require stack mutation authority                                                    |
-| `gh stack push`        | Updates active remote branches and may partly succeed                                     | Bind each update to an expected SHA or absence; require publish or stack mutation authority                      |
-| `gh stack submit`      | Pushes branches, creates or updates pull requests, and updates the native stack           | Bind each push to an expected SHA or absence; preview PR and ready-state effects; require authority              |
-| `gh stack sync`        | May fetch, fast-forward trunk, rebase, push, relink, save state, and prune when requested | Preview every phase; bind each push to an expected SHA or absence; require authority for every mutation          |
-| `gh stack merge`       | Directly merges an exact prefix or enqueues one exact bottom pull request                 | Bind direct heads or durably fence the queued bottom and affected suffix; require authority for the mutation set |
+| Command                | Material effects                                                                          | Required disclosure and authority                                                                                      |
+| ---------------------- | ----------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `gh stack init`        | Enables `rerere`, writes stack state, may create branches, and checks out the top branch  | Preview config, branch, state, and checkout changes; require local materialization authority                           |
+| `gh stack view --json` | Reads GitHub and may refresh saved stack state                                            | Declare the refresh; require scoped local-state authority and verify that the checkout is unchanged                    |
+| `gh stack rebase`      | By default fetches, may move trunk, rewrites layer commits, and records recovery state    | Use `--no-trunk` for a bounded suffix fix; otherwise preview the new base and complete affected set; require authority |
+| `gh stack push`        | Updates active remote branches and may partly succeed                                     | Bind each update to an expected SHA or absence; require publish or stack mutation authority                            |
+| `gh stack submit`      | Pushes branches, creates or updates pull requests, and updates the native stack           | Bind each push to an expected SHA or absence; preview PR and ready-state effects; require authority                    |
+| `gh stack sync`        | May fetch, fast-forward trunk, rebase, push, relink, save state, and prune when requested | Preview every phase; bind each push to an expected SHA or absence; require authority for every mutation                |
+| `gh stack merge`       | Directly merges an exact prefix or enqueues one exact bottom pull request                 | Bind direct heads or durably fence the queued bottom and affected suffix; require authority for the mutation set       |
 
 Status-only work must not hide the local refresh performed by
 `gh stack view --json`. If the caller has not authorized that bounded state
 write, the skill reports local stack state as unavailable and relies only on
 side-effect-free git and GitHub reads. It does not silently widen authority.
+
+A bounded repair or recovery always uses `rebase --no-trunk` so the dependency
+does not fetch or move the comparison base. A deliberate trunk refresh is a
+separate operation: the dependency must expose a fetch/read phase followed by a
+new manifest and an expected-base-bound rewrite phase. If it cannot pause before
+rewriting candidates against the newly observed trunk, that operation is
+blocked.
 
 ## Workflow
 
@@ -322,8 +337,9 @@ side-effect-free git and GitHub reads. It does not silently widen authority.
 Resolve the repository, checkout, worktree, source, base, approved validation,
 requested terminal boundary, and mutation authority.
 
-When the requested boundary is `chain_ready` or later, verify `gh stack`
-capability before materialization.
+Before each phase, verify every `gh stack` capability needed to reach the
+requested boundary. Missing later-phase capability does not block a verified
+local `chain_ready` result.
 
 ### 2. Propose
 
@@ -407,9 +423,9 @@ and current stack identity.
 1. Reclaims exclusive stack mutation ownership.
 2. Applies the fix to the layer that owns it.
 3. Creates or verifies a successor source when the accepted result has changed.
-4. Runs `gh stack rebase` across the affected upstack.
-5. Runs a compare-and-swap-capable `gh stack push` or `gh stack sync` as
-   appropriate.
+4. Runs `gh stack rebase --no-trunk --upstack <owning-layer>` across only the
+   affected upstack.
+5. Runs a compare-and-swap-capable `gh stack push`.
 6. Reads back local git, `gh stack`, remote refs, and GitHub pull requests.
 7. Rebuilds invalidated validation, review, CI, and feedback evidence.
 8. Returns each corrected pull request to its lifecycle owner.
@@ -482,8 +498,8 @@ readback verifies them again. A local-only source blocks recovery because a
 fresh clone could not reconstruct the published lineage.
 
 The skill applies the fix at the correct open layer and delegates suffix
-mechanics to `gh stack rebase`, `push`, and `sync`. It does not manually
-recreate propagation.
+mechanics to `gh stack rebase --no-trunk --upstack <owning-layer>` and `push`.
+It does not manually recreate propagation.
 
 Recovery preserves merged positions and pull-request identities. It rebuilds all
 evidence bound to changed candidates.
@@ -500,7 +516,7 @@ Retire or replace:
 | `create-chain`    | Materialize semantic layers, then adopt them with `gh stack init`           |
 | `push-chain`      | Preview and invoke `gh stack push`                                          |
 | `pr-create`       | Preview and invoke `gh stack submit`                                        |
-| `propagate`       | Remove; use verified `gh stack sync` or `rebase` plus `push`                |
+| `propagate`       | Remove; use `gh stack rebase --no-trunk` plus fenced `push`                 |
 | `merge-propagate` | Invoke a direct exact-prefix or one queued-bottom merge, then verified sync |
 | `recover-suffix`  | Retain semantic recovery, delegate mechanics to `gh stack`                  |
 | `status`          | Combine git, `gh stack view --json`, and live GitHub evidence               |
@@ -581,7 +597,8 @@ repair, propagation, or merge work. Adoption must:
    topology fields after native adoption.
 5. Prove the complete chain against the active source.
 6. Run non-interactive `gh stack init` over the unchanged open branches.
-7. Submit or link the native GitHub stack.
+7. Use the fenced non-interactive submit path to adopt the existing pull
+   requests into the native GitHub stack.
 8. Read back local and remote stack state.
 
 Merged legacy commits and pull-request blocks remain unchanged historical
@@ -589,6 +606,13 @@ evidence. Adoption does not rewrite an open head merely to change its metadata
 version. The native trailer version is added when a layer is newly materialized
 or its head legitimately changes. Native GitHub state controls the adopted open
 topology.
+
+The adoption path does not invoke `gh stack link`. That command can push branch
+arguments, create pull requests, retarget existing pull-request bases, and
+change native stack membership, but it is not covered by the required
+expected-state interface. If the tested `gh stack submit` version cannot adopt
+the existing pull requests non-interactively through the fenced submit path,
+adoption returns `blocked` rather than widening to `link`.
 
 If adoption cannot be proved safe, return `blocked` with one concrete action.
 The skill does not resume the retired custom stack manager.
@@ -647,6 +671,9 @@ Cover:
 - dry-run manifests;
 - exact argv construction;
 - command-effect and authority classification;
+- default-rebase fetch and trunk/base effect classification;
+- fix-only `rebase --no-trunk --upstack <branch>` construction;
+- phased trunk-refresh manifests and expected-base enforcement;
 - exact expected-SHA and expected-absence enforcement for push, submit, and
   push-capable sync;
 - exact expected-head enforcement for direct merge;
@@ -667,7 +694,11 @@ Use disposable repositories and controlled `gh stack` fixtures to cover:
 
 - materialization and adoption;
 - native submission;
+- legacy pull-request adoption through fenced submit, including a blocked case
+  when only unfenced link can represent the chain;
 - a lower-layer fix and cascading rebase;
+- base movement before a default rebase, requiring a new manifest before any
+  rewrite;
 - a rejected branch lease after earlier branches have updated;
 - a remote advance after manifest approval that rejects without overwriting it;
 - a same-named remote branch created after manifest approval that rejects

--- a/design/carve-changesets-on-gh-stack.md
+++ b/design/carve-changesets-on-gh-stack.md
@@ -216,7 +216,9 @@ never parses that file directly. It consumes the documented CLI surface.
 
 The native GitHub stack establishes trunk and ordered pull-request membership.
 Remote refs establish branch heads. Pull requests establish candidate heads,
-bases, checks, reviews, and mergeability.
+bases, checks, reviews, and mergeability. The exact pull-request head commit
+carries the remaining machine-readable `carve-changesets` identity and
+provenance.
 
 Local `gh stack` state remains useful for execution. It cannot override live
 GitHub state.
@@ -231,8 +233,8 @@ prove that the represented result matches the active immutable source.
 A semantic slug identifies a changeset. Position comes from live stack order.
 Branch names and numeric positions do not establish durable semantic identity.
 
-Commit and pull-request metadata retain only information that GitHub stacks do
-not provide:
+Machine-readable trailers on each exact layer head commit retain only
+information that GitHub stacks do not provide:
 
 - semantic slug;
 - immutable root source identity;
@@ -244,12 +246,19 @@ Every published lineage identity includes the selected remote plus an exact
 branch and stamped commit. Local-only reachability cannot establish durable
 source provenance.
 
+Before reading a trailer, the skill verifies that the native pull-request head
+and remote branch head identify the same commit. GitHub's preserved pull-request
+head identity remains the lookup key after branch deletion. A missing trailer or
+an unexplained head mismatch blocks reconstruction.
+
 Native stack number, position, predecessor, trunk, and size must not be copied
 into durable `carve-changesets` metadata. Those values come from GitHub and
 `gh stack` at read time.
 
-The redesign introduces a new metadata version for native stacks. Existing v1
-and v2 metadata remain evidence for legacy adoption. They do not establish the
+The redesign introduces a trailer-only metadata version for native stacks.
+Pull-request bodies remain human-readable and carry no new machine-readable
+`carve-changesets` block. Existing v1 and v2 commit trailers and pull-request
+blocks remain historical input for legacy adoption. They do not establish the
 post-adoption topology.
 
 ## Capability contract
@@ -339,7 +348,9 @@ single command surface. New pull requests are drafts in this mode. The wrapper
 adds `--open` only when the manifest requests ready-for-review pull requests and
 the caller has separately granted authority for that state transition. Since
 `--open` also marks existing drafts ready, the preview lists every affected pull
-request.
+request. Layer commit messages already contain the human-readable intent,
+non-goals, and intentional incompleteness from which automatic pull-request text
+is derived.
 
 After submission:
 
@@ -347,8 +358,9 @@ After submission:
 2. Verify trunk and ordered pull-request membership.
 3. Verify every remote head and pull-request base.
 4. Verify every layer diff.
-5. Add semantic context and provenance to pull-request bodies.
-6. Read back the edited pull requests.
+
+No post-submit pull-request metadata edit is required. Commit trailers are the
+sole new machine-readable semantic and provenance record.
 
 An exit code alone never proves publication.
 
@@ -425,12 +437,11 @@ An accepted fix after a prefix merge may change the intended final result.
 `carve-changesets` still creates or verifies a distinct immutable successor
 source and continuous lineage.
 
-Before any remote push, submit, sync, or metadata edit for a recovered suffix,
-every root and successor identity in that lineage must resolve at its exact
-stamped SHA on the selected remote. The preview includes those remote
-identities. Post-mutation readback verifies them again. A local-only source
-blocks recovery because a fresh clone could not reconstruct the published
-lineage.
+Before any remote push, submit, or sync for a recovered suffix, every root and
+successor identity in that lineage must resolve at its exact stamped SHA on the
+selected remote. The preview includes those remote identities. Post-mutation
+readback verifies them again. A local-only source blocks recovery because a
+fresh clone could not reconstruct the published lineage.
 
 The skill applies the fix at the correct open layer and delegates suffix
 mechanics to `gh stack rebase`, `push`, and `sync`. It does not manually
@@ -518,15 +529,17 @@ repair, propagation, or merge work. Adoption must:
 
 1. Resolve every exact branch, head, pull request, and predecessor base.
 2. Verify same-repository ownership and linear ancestry.
-3. Verify semantic slugs and immutable source provenance.
+3. Verify semantic slugs and immutable source provenance, using v1 and v2
+   pull-request blocks only as adoption evidence.
 4. Prove the complete chain against the active source.
-5. Run non-interactive `gh stack init` over the existing branches.
-6. Submit or link the native GitHub stack.
-7. Read back local and remote stack state.
-8. Promote open-layer metadata to the native-stack version when required.
+5. Promote active open-layer commits to the native trailer version, then verify
+   the rewritten heads and reconstructed chain.
+6. Run non-interactive `gh stack init` over the rewritten open branches.
+7. Submit or link the native GitHub stack.
+8. Read back local and remote stack state.
 
-Merged legacy metadata remains historical evidence. Native GitHub state controls
-the adopted open topology.
+Merged legacy commits and pull-request blocks remain unchanged historical
+evidence. Native GitHub state controls the adopted open topology.
 
 If adoption cannot be proved safe, return `blocked` with one concrete action.
 The skill does not resume the retired custom stack manager.
@@ -569,6 +582,7 @@ Verify:
 - required `gh stack` capability;
 - semantic identity independent of stack position;
 - topology read through documented surfaces;
+- one machine-readable semantic and provenance record for new native layers;
 - no legacy stack-manager fallback;
 - no single-PR implicit stack mutation; and
 - candidate-evidence invalidation after stack-wide changes.
@@ -585,7 +599,8 @@ Cover:
 - post-command readback;
 - partial push and queued-merge state classification;
 - interrupted and divergent states;
-- native metadata decoding;
+- native commit-trailer decoding;
+- legacy pull-request blocks accepted only as adoption evidence;
 - legacy adoption checks; and
 - terminal-state rendering.
 

--- a/docs/superpowers/plans/2026-08-05-carve-changesets-on-gh-stack.md
+++ b/docs/superpowers/plans/2026-08-05-carve-changesets-on-gh-stack.md
@@ -1,0 +1,1459 @@
+# Carve Changesets on GitHub Stacks Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rebuild `carve-changesets` so it owns semantic decomposition and proof
+while GitHub's native `gh stack` extension is the sole engine for stack
+topology, publication, synchronization, and merge mechanics.
+
+**Architecture:** Preserve the existing planning and changeset-materialization
+core, then place a narrow `gh stack` adapter beneath a native topology model and
+operation-scoped transition planner. Local operations become native immediately.
+Every remote transition is derived from fresh Git, GitHub, and
+`gh stack view --json` evidence and fails with a structured `blocked` result
+unless the installed extension exposes every required fence. The initially
+supported preview profile therefore stops at `chain_ready`; it does not silently
+fall back to the existing custom stack manager.
+
+**Tech Stack:** Python 3.11 standard library, `unittest`, Git CLI, GitHub CLI,
+`github/gh-stack` extension, JSON fixtures, existing `just` quality and eval
+targets.
+
+## Global Constraints
+
+- Work on `scott/carve-changesets-gh-stack`; do not implement this multi-commit
+  change on detached HEAD or directly on `main`.
+- Treat [the proposal](../../../design/carve-changesets-on-gh-stack.md) as the
+  product contract. When implementation pressure exposes ambiguity, amend the
+  proposal in a dedicated design commit before changing behavior.
+- `gh_stack.py` is the only module permitted to invoke `gh stack`. `github.py`
+  remains the only module permitted to invoke other `gh` commands, and only for
+  read-only GitHub evidence after the cutover.
+- Do not infer a capability from a command name. Probe the installed extension,
+  match its machine-readable and help surface to a tested profile, and require
+  the operation's complete capability set before any automatic or direct
+  mutation begins.
+- Do not retain the custom publication, propagation, recovery, or merge path as
+  a fallback. An unsupported remote transition returns `blocked` before local or
+  remote mutation.
+- Preserve one immutable source identity as `remote + branch + full SHA`. A
+  trunk-drift recovery creates a new remotely stamped successor identity and
+  appends it to lineage.
+- Treat `gh stack view --json` as topology evidence, not as complete safety
+  proof. Cross-check its branch heads, bases, PRs, trunk, remote refs, commit
+  trailers, and GitHub PR state.
+- Preserve dry-run-by-default behavior and require operation-specific authority
+  for every remote effect, including effects performed indirectly by `gh stack`.
+- Keep `babysit-pr` scoped to one exact PR. Its only stack-aware output is a
+  typed handback naming the invalidated suffix and the required carve repair
+  phase.
+- Use `unittest`; do not add a new test framework or runtime dependency.
+- Before each commit, update the newest `CHANGELOG.md` day section, backfill the
+  previous entry with its full SHA, and leave the new entry without a SHA. Write
+  the full Conventional Commit message to a temporary file with `apply_patch`,
+  then commit with `git commit -F <file>`.
+- Before each commit, run `just format`, `just lint`, and `just test`. Run the
+  focused red/green commands in each task before the full gates.
+- Record `carve-changesets` deterministic eval evidence from committed clean
+  trees: one `before` record before behavior changes and one `after` record
+  after the normative prose commit. Commit both result files.
+
+## Verified Dependency Facts
+
+The implementation is pinned to the command surface documented in
+[GitHub's stacked PR CLI reference](https://docs.github.com/en/pull-requests/reference/stacked-prs-cli-commands)
+and independently represented by a checked-in contract fixture.
+
+- `gh stack init --base <trunk> <branches...>` adopts an explicit ordered branch
+  chain and enables rerere.
+- `gh stack view --json` emits `trunk`, `currentBranch`, and ordered `branches`;
+  each branch contains `name`, `head`, `base`, `isCurrent`, `isMerged`,
+  `isQueued`, `needsRebase`, and optional PR data.
+- `gh stack rebase --no-trunk --upstack <branch>` can cascade a local suffix
+  without refreshing trunk.
+- `gh stack push` uses per-ref force-with-lease but can partially succeed.
+- `gh stack submit` controls PR creation and native stack registration, but the
+  reviewed preview has no explicit per-PR body input and does not accept the
+  complete expected-old manifest required by this design.
+- `gh stack merge` performs a direct prefix merge, or queues selected PRs when
+  merge queues apply, but the reviewed preview does not expose the durable merge
+  fence required by this design.
+- `gh stack sync` combines fetch, trunk refresh, rebase, push, PR
+  synchronization, and optional pruning; it is not a substitute for
+  phase-separated recovery because its noninteractive divergence behavior and
+  target set are insufficiently fenced.
+
+The first supported profile intentionally grants only `LOCAL_INIT`, `VIEW_JSON`,
+and `LOCAL_REBASE_NO_TRUNK`. Remote capabilities remain absent until an exact
+extension version passes repository contract tests for those semantics.
+
+## File and Responsibility Map
+
+| Path                                                     | Responsibility after cutover                                                                                                       |
+| -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `skills/carve-changesets/scripts/gh_stack.py`            | Sole subprocess adapter for `gh stack`; profile probing; exact argv construction; JSON decoding boundary.                          |
+| `skills/carve-changesets/scripts/native_stack.py`        | Typed native topology, cross-source reconciliation, materialized/published truth, live-equivalence checks.                         |
+| `skills/carve-changesets/scripts/transitions.py`         | Operation manifests, authority inputs, required capabilities, dry-run preview, terminal results, pre/post-readback classification. |
+| `skills/carve-changesets/scripts/metadata.py`            | Trailer-only v3 identity and lineage; legacy v1/v2 PR-block normalization for adoption evidence.                                   |
+| `skills/carve-changesets/scripts/chain.py`               | Semantic changeset materialization, followed by native `gh stack init` adoption and exact topology readback.                       |
+| `skills/carve-changesets/scripts/rehydrate.py`           | Reconstruct active stack truth from native topology, GitHub PR reads, remote refs, and commit trailers.                            |
+| `skills/carve-changesets/scripts/validate.py`            | Step validation and current-trunk plus open-suffix equivalence proof.                                                              |
+| `skills/carve-changesets/scripts/cli.py`                 | Consolidated user surface and structured terminal-state rendering.                                                                 |
+| `skills/carve-changesets/scripts/github.py`              | Read-only repository and PR evidence; no PR create/edit/merge operations.                                                          |
+| `skills/carve-changesets/scripts/propagate.py`           | Deleted after native transition cutover.                                                                                           |
+| `skills/carve-changesets/scripts/recovery.py`            | Deleted after successor-lineage planning moves to `transitions.py`.                                                                |
+| `skills/carve-changesets/references/*.md` and `SKILL.md` | Normative native-stack workflow, authority, terminal states, handbacks, and schema.                                                |
+
+## Public Interfaces to Stabilize
+
+The tasks below may add private helpers, but these types and functions are the
+cross-module contract:
+
+```python
+class StackCapability(str, Enum):
+    LOCAL_INIT = "local_init"
+    VIEW_JSON = "view_json"
+    LOCAL_REBASE_NO_TRUNK = "local_rebase_no_trunk"
+    FENCED_PUSH = "fenced_push"
+    FENCED_SUBMIT = "fenced_submit"
+    FENCED_SYNC = "fenced_sync"
+    FENCED_MERGE = "fenced_merge"
+    EXPLICIT_PULL_REQUEST_BODIES = "explicit_pull_request_bodies"
+    DURABLE_QUEUE_FENCE = "durable_queue_fence"
+    PHASED_TRUNK_REFRESH = "phased_trunk_refresh"
+
+
+@dataclass(frozen=True)
+class GhStackProfile:
+    version: str
+    capabilities: frozenset[StackCapability]
+
+
+@dataclass(frozen=True)
+class NativePullRequest:
+    number: int
+    url: str
+    state: str
+
+
+@dataclass(frozen=True)
+class NativeLayer:
+    branch: str
+    head: str
+    base: str
+    merged: bool
+    queued: bool
+    needs_rebase: bool
+    pull_request: NativePullRequest | None
+
+
+@dataclass(frozen=True)
+class NativeStackSnapshot:
+    trunk_branch: str
+    trunk_head: str
+    current_branch: str
+    layers: tuple[NativeLayer, ...]
+
+
+class TerminalState(str, Enum):
+    PLAN_READY = "plan_ready"
+    CHAIN_READY = "chain_ready"
+    PRS_OPEN = "prs_open"
+    ALL_MERGED = "all_merged"
+    BLOCKED = "blocked"
+
+
+class TruthPhase(str, Enum):
+    PROPOSED = "proposed"
+    MATERIALIZED = "materialized"
+    PUBLISHED = "published"
+    MERGED = "merged"
+
+
+@dataclass(frozen=True)
+class TransitionResult:
+    state: TerminalState
+    phase: str
+    identities: tuple[str, ...]
+    evidence: tuple[str, ...]
+    blocker: str | None
+    next_action: str | None
+
+
+def materialize_native_stack(plan: dict, *, remote: str) -> NativeStackSnapshot:
+    """Create semantic layers, register native topology, and prove materialized truth."""
+
+
+def assess_chain_ready(
+    snapshot: NativeStackSnapshot,
+    *,
+    validation: ValidationEvidence,
+    review: ReviewEvidence,
+    equivalence: LiveEquivalence,
+) -> TransitionResult:
+    """Return chain_ready only when every candidate-bound local gate is current."""
+
+
+def preview_transition(
+    operation: StackOperation,
+    snapshot: NativeStackSnapshot,
+    authority: AuthorityGrant,
+) -> MutationManifest:
+    """Return the complete direct and automatic effect set without mutation."""
+
+
+def execute_transition(
+    manifest: MutationManifest,
+    *,
+    profile: GhStackProfile,
+) -> TransitionResult:
+    """Fail before mutation unless every required capability and expected-old input exists."""
+```
+
+## Task 1: Establish Baseline Evidence and the Native Adapter
+
+**Files:**
+
+- Create: `skills/carve-changesets/scripts/gh_stack.py`
+
+- Create:
+  `skills/carve-changesets/scripts/tests/fixtures/gh-stack/profile-reviewed.json`
+
+- Create:
+  `skills/carve-changesets/scripts/tests/fixtures/gh-stack/view-open.json`
+
+- Create: `skills/carve-changesets/scripts/tests/test_gh_stack.py`
+
+- Modify: `skills/carve-changesets/scripts/tests/test_cli_safety.py`
+
+- Create: `skills/carve-changesets/evals/results/<recorded-before-summary>.json`
+
+- Modify: `CHANGELOG.md`
+
+- [ ] Create the work branch and record the clean-tree baseline before changing
+  behavior.
+
+```bash
+git switch -c scott/carve-changesets-gh-stack
+just eval-record carve-changesets --stage before
+```
+
+Expected: the recorder writes one `before` summary whose `candidate.sha` equals
+the pre-change HEAD. If the deterministic runner cannot start, the summary must
+have status `attempted` and record the observed limitation.
+
+- [ ] Add the baseline result and changelog entry, run all required checks, then
+  commit it as `test: record carve changesets gh stack baseline` using a
+  file-backed commit message.
+
+```markdown
+test: record carve changesets gh stack baseline
+
+## Summary
+- Record the deterministic carve-changesets behavior baseline
+- Bind the evidence to the pre-native-stack candidate SHA
+
+## Why
+- Preserve comparable evidence before the normative workflow changes
+```
+
+- [ ] Add a failing adapter test that proves argv is a list, JSON mode is
+  noninteractive, and the reviewed preview profile grants no remote capability.
+
+```python
+class GhStackClientTest(unittest.TestCase):
+    def test_view_uses_machine_readable_noninteractive_command(self) -> None:
+        runner = mock.Mock(return_value=VIEW_OPEN_JSON)
+        client = GhStackClient(runner=runner)
+
+        payload = client.view_json(allow_state_refresh=True)
+
+        self.assertEqual(payload["trunk"], "main")
+        runner.assert_called_once_with(
+            ["gh", "stack", "view", "--json"],
+            env={"GH_PAGER": "cat", "GH_PROMPT_DISABLED": "1"},
+        )
+
+    def test_view_requires_local_state_refresh_authority(self) -> None:
+        runner = mock.Mock()
+        client = GhStackClient(runner=runner)
+
+        with self.assertRaisesRegex(GhStackError, "local-state authority"):
+            client.view_json(allow_state_refresh=False)
+
+        runner.assert_not_called()
+
+    def test_reviewed_preview_profile_is_local_only(self) -> None:
+        profile = reviewed_preview_profile("14fc42ed9b6c376a53b2f999f138d3bd26dac546")
+
+        self.assertEqual(
+            profile.capabilities,
+            frozenset(
+                {
+                    StackCapability.LOCAL_INIT,
+                    StackCapability.VIEW_JSON,
+                    StackCapability.LOCAL_REBASE_NO_TRUNK,
+                }
+            ),
+        )
+```
+
+- [ ] Capture `gh stack --version` and the `--help` surfaces for `init`, `view`,
+  `rebase`, `push`, `submit`, `sync`, and `merge` from the reviewed revision.
+  Store the normalized version string, source revision
+  `14fc42ed9b6c376a53b2f999f138d3bd26dac546`, command flags, and SHA-256 of each
+  normalized help output in `profile-reviewed.json`. Add `probe_profile()` tests
+  that grant capabilities only when the live probe matches this fixture; an
+  unknown or mismatched profile returns `blocked` with its observed version and
+  differing command surface.
+
+- [ ] Run the focused test and confirm it fails because `gh_stack.py` does not
+  exist.
+
+```bash
+python3 -m unittest skills/carve-changesets/scripts/tests/test_gh_stack.py -v
+```
+
+- [ ] Implement the adapter and capability profile. Keep command execution
+  injectable and reject shell strings.
+
+```python
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from dataclasses import dataclass
+from enum import Enum
+from typing import Callable, Mapping, Sequence
+
+
+class GhStackError(RuntimeError):
+    pass
+
+
+class StackCapability(str, Enum):
+    LOCAL_INIT = "local_init"
+    VIEW_JSON = "view_json"
+    LOCAL_REBASE_NO_TRUNK = "local_rebase_no_trunk"
+    FENCED_PUSH = "fenced_push"
+    FENCED_SUBMIT = "fenced_submit"
+    FENCED_SYNC = "fenced_sync"
+    FENCED_MERGE = "fenced_merge"
+    EXPLICIT_PULL_REQUEST_BODIES = "explicit_pull_request_bodies"
+    DURABLE_QUEUE_FENCE = "durable_queue_fence"
+    PHASED_TRUNK_REFRESH = "phased_trunk_refresh"
+
+
+@dataclass(frozen=True)
+class GhStackProfile:
+    version: str
+    capabilities: frozenset[StackCapability]
+
+
+Runner = Callable[[Sequence[str], Mapping[str, str]], str]
+
+
+def _run(argv: Sequence[str], env: Mapping[str, str]) -> str:
+    completed = subprocess.run(
+        list(argv),
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env={**os.environ, **env},
+    )
+    return completed.stdout
+
+
+def reviewed_preview_profile(version: str) -> GhStackProfile:
+    return GhStackProfile(
+        version=version,
+        capabilities=frozenset(
+            {
+                StackCapability.LOCAL_INIT,
+                StackCapability.VIEW_JSON,
+                StackCapability.LOCAL_REBASE_NO_TRUNK,
+            }
+        ),
+    )
+
+
+class GhStackClient:
+    def __init__(self, runner: Runner = _run) -> None:
+        self._runner = runner
+
+    def _capture(self, args: Sequence[str]) -> str:
+        if isinstance(args, (str, bytes)):
+            raise TypeError("gh stack arguments must be a sequence of tokens")
+        return self._runner(
+            ["gh", "stack", *args],
+            env={"GH_PAGER": "cat", "GH_PROMPT_DISABLED": "1"},
+        )
+
+    def view_json(self, *, allow_state_refresh: bool) -> dict[str, object]:
+        if not allow_state_refresh:
+            raise GhStackError(
+                "gh stack view --json may refresh saved stack state; "
+                "local-state authority is required"
+            )
+        payload = json.loads(self._capture(["view", "--json"]))
+        if not isinstance(payload, dict):
+            raise GhStackError("gh stack view --json must return an object")
+        return payload
+
+    def init(self, *, base: str, branches: Sequence[str]) -> None:
+        self._capture(["init", "--base", base, *branches])
+
+    def rebase_no_trunk_upstack(self, branch: str) -> None:
+        self._capture(["rebase", "--no-trunk", "--upstack", branch])
+```
+
+- [ ] Update the subprocess safety test so only `gh_stack.py` may contain the
+  literal `gh stack` invocation and only `github.py` may invoke non-stack `gh`
+  commands.
+
+- [ ] Run the focused adapter and safety tests, then the full gates.
+
+```bash
+python3 -m unittest \
+  skills/carve-changesets/scripts/tests/test_gh_stack.py \
+  skills/carve-changesets/scripts/tests/test_cli_safety.py -v
+just format
+just lint
+just test
+```
+
+- [ ] Update `CHANGELOG.md` and commit as `feat: add native gh stack adapter`
+  with a file-backed message that names the local-only capability boundary.
+
+## Task 2: Model and Reconcile Native Topology
+
+**Files:**
+
+- Create: `skills/carve-changesets/scripts/native_stack.py`
+
+- Create: `skills/carve-changesets/scripts/tests/test_native_stack.py`
+
+- Modify:
+  `skills/carve-changesets/scripts/tests/fixtures/gh-stack/view-open.json`
+
+- Modify: `skills/carve-changesets/scripts/rehydrate.py`
+
+- Modify: `skills/carve-changesets/scripts/tests/test_rehydrate.py`
+
+- Modify: `CHANGELOG.md`
+
+- [ ] Populate the checked-in fixture with the exact reviewed JSON schema.
+
+```json
+{
+  "trunk": "main",
+  "currentBranch": "feature-2",
+  "branches": [
+    {
+      "name": "feature-1",
+      "head": "1111111111111111111111111111111111111111",
+      "base": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "isCurrent": false,
+      "isMerged": false,
+      "isQueued": false,
+      "needsRebase": false,
+      "pr": {
+        "number": 101,
+        "url": "https://github.com/acme/widgets/pull/101",
+        "state": "OPEN"
+      }
+    },
+    {
+      "name": "feature-2",
+      "head": "2222222222222222222222222222222222222222",
+      "base": "1111111111111111111111111111111111111111",
+      "isCurrent": true,
+      "isMerged": false,
+      "isQueued": false,
+      "needsRebase": false,
+      "pr": {
+        "number": 102,
+        "url": "https://github.com/acme/widgets/pull/102",
+        "state": "OPEN"
+      }
+    }
+  ]
+}
+```
+
+- [ ] Write failing tests for exact JSON parsing, contiguous base/head linkage,
+  unique current branch, and remote/GitHub disagreement.
+
+- [ ] Add truth-phase tests: a validated plan with no layers is `proposed`;
+  native layers without PRs are `materialized`; a reconciled native GitHub stack
+  with an open suffix is `published`; and an empty suffix with every chain PR
+  verified merged is `merged`. Keep these phases distinct from terminal
+  readiness states.
+
+```python
+class NativeStackSnapshotTest(unittest.TestCase):
+    def test_parses_ordered_native_layers(self) -> None:
+        snapshot = parse_native_stack(VIEW_OPEN, trunk_head=A_SHA)
+
+        self.assertEqual(snapshot.trunk_branch, "main")
+        self.assertEqual(snapshot.current_branch, "feature-2")
+        self.assertEqual(
+            tuple(layer.branch for layer in snapshot.layers),
+            ("feature-1", "feature-2"),
+        )
+
+    def test_rejects_noncontiguous_native_bases(self) -> None:
+        payload = copy.deepcopy(VIEW_OPEN)
+        payload["branches"][1]["base"] = B_SHA
+
+        with self.assertRaisesRegex(NativeStackError, "expected predecessor head"):
+            parse_native_stack(payload, trunk_head=A_SHA)
+
+    def test_reconcile_rejects_remote_head_disagreement(self) -> None:
+        snapshot = parse_native_stack(VIEW_OPEN, trunk_head=A_SHA)
+
+        with self.assertRaisesRegex(NativeStackError, "remote head mismatch"):
+            reconcile_native_stack(
+                snapshot,
+                remote_heads={"feature-1": B_SHA, "feature-2": C_SHA},
+                pull_requests={101: OPEN_PR_101, 102: OPEN_PR_102},
+            )
+```
+
+- [ ] Run the focused tests and confirm failure at the missing parser.
+
+```bash
+python3 -m unittest skills/carve-changesets/scripts/tests/test_native_stack.py -v
+```
+
+- [ ] Implement strict typed parsing and reconciliation. The parser must reject
+  unknown PR states, missing full SHAs, duplicate branches, multiple current
+  branches, and noncontiguous bases.
+
+```python
+@dataclass(frozen=True)
+class NativePullRequest:
+    number: int
+    url: str
+    state: str
+
+
+@dataclass(frozen=True)
+class NativeLayer:
+    branch: str
+    head: str
+    base: str
+    merged: bool
+    queued: bool
+    needs_rebase: bool
+    pull_request: NativePullRequest | None
+
+
+@dataclass(frozen=True)
+class NativeStackSnapshot:
+    trunk_branch: str
+    trunk_head: str
+    current_branch: str
+    layers: tuple[NativeLayer, ...]
+
+    @property
+    def open_suffix(self) -> tuple[NativeLayer, ...]:
+        return tuple(layer for layer in self.layers if not layer.merged)
+
+
+def reconcile_native_stack(
+    snapshot: NativeStackSnapshot,
+    *,
+    remote_heads: Mapping[str, str],
+    pull_requests: Mapping[int, PullRequestRecord],
+) -> NativeStackSnapshot:
+    for layer in snapshot.layers:
+        if not layer.merged and remote_heads.get(layer.branch) != layer.head:
+            raise NativeStackError(f"remote head mismatch for {layer.branch}")
+        if layer.pull_request is None:
+            continue
+        live = pull_requests.get(layer.pull_request.number)
+        if live is None:
+            raise NativeStackError(
+                f"missing GitHub PR #{layer.pull_request.number} for {layer.branch}"
+            )
+        if live.head_branch != layer.branch or live.head_sha != layer.head:
+            raise NativeStackError(
+                f"GitHub PR #{live.number} does not match native layer {layer.branch}"
+            )
+    return snapshot
+```
+
+- [ ] Replace index/suffix-derived ordering in `rehydrate.py` with native layer
+  order. Keep legacy branch discovery only in an explicit `adopt_legacy_chain()`
+  path; ordinary rehydration must require a native snapshot.
+
+- [ ] Make status acquisition authority-aware. With
+  `--allow-stack-state-refresh`, call `gh stack view --json`, verify the
+  checkout did not move, and reconcile native state. Without that flag, do not
+  call `gh stack`; render side-effect-free Git and GitHub evidence with native
+  local topology marked unavailable.
+
+- [ ] Run native topology and rehydration tests, then all required checks.
+
+```bash
+python3 -m unittest \
+  skills/carve-changesets/scripts/tests/test_native_stack.py \
+  skills/carve-changesets/scripts/tests/test_rehydrate.py -v
+just format
+just lint
+just test
+```
+
+- [ ] Update `CHANGELOG.md` and commit as
+  `feat: make native stack topology authoritative`.
+
+## Task 3: Replace Positional Metadata with Trailer-Only Source Lineage
+
+**Files:**
+
+- Modify: `skills/carve-changesets/scripts/metadata.py`
+
+- Modify: `skills/carve-changesets/scripts/tests/test_metadata.py`
+
+- Modify: `skills/carve-changesets/scripts/chain.py`
+
+- Modify: `skills/carve-changesets/scripts/tests/test_chain.py`
+
+- Modify: `CHANGELOG.md`
+
+- [ ] Add failing tests for remote-aware identity, trailer-only v3
+  serialization, successor lineage, and read-only normalization of v1/v2 PR
+  metadata.
+
+```python
+class MetadataV3Test(unittest.TestCase):
+    def test_v3_omits_position_and_pr_metadata_block(self) -> None:
+        metadata = ChangesetMetadata(
+            slug="payments",
+            source_lineage=(
+                SourceIdentity(
+                    remote="origin",
+                    branch="feature",
+                    sha=A_SHA,
+                ),
+            ),
+        )
+
+        message = stamp_commit_message("Extract payment model", metadata)
+
+        self.assertIn("Changeset-Slug: payments", message)
+        self.assertIn(f"Changeset-Source: origin feature @ {A_SHA}", message)
+        self.assertNotIn("Changeset-Index", message)
+        self.assertNotIn("carve-changesets:metadata", message)
+
+    def test_legacy_pr_block_normalizes_without_rewrite(self) -> None:
+        normalized = normalize_legacy_pr_metadata(LEGACY_V2_BODY, remote="origin")
+
+        self.assertEqual(normalized.slug, "payments")
+        self.assertEqual(normalized.active_source.remote, "origin")
+        self.assertEqual(normalized.legacy_position, 2)
+```
+
+- [ ] Run metadata tests and confirm they fail against the positional v2 model.
+
+```bash
+python3 -m unittest skills/carve-changesets/scripts/tests/test_metadata.py -v
+```
+
+- [ ] Implement the v3 identity model and parser. Use JSON only inside the
+  lineage trailer value; do not render a PR-body metadata block.
+
+```python
+TRAILER_SLUG = "Changeset-Slug"
+TRAILER_SOURCE = "Changeset-Source"
+TRAILER_LINEAGE = "Changeset-Lineage"
+TRAILER_RECOVERY_FROM = "Changeset-Recovery-From"
+
+
+@dataclass(frozen=True)
+class SourceIdentity:
+    remote: str
+    branch: str
+    sha: str
+
+    @property
+    def trailer(self) -> str:
+        return f"{self.remote} {self.branch} @ {self.sha}"
+
+
+@dataclass(frozen=True)
+class ChangesetMetadata:
+    slug: str
+    source_lineage: tuple[SourceIdentity, ...]
+    recovery_from_head: str | None = None
+
+    @property
+    def root_source(self) -> SourceIdentity:
+        return self.source_lineage[0]
+
+    @property
+    def active_source(self) -> SourceIdentity:
+        return self.source_lineage[-1]
+
+
+@dataclass(frozen=True)
+class LegacyMetadataEvidence:
+    metadata: ChangesetMetadata
+    legacy_position: int
+    marker_version: int
+```
+
+- [ ] Update chain materialization to stamp `remote`, `branch`, and immutable
+  source SHA on every changeset commit. Derive order exclusively from the plan
+  during creation and from native topology after creation.
+
+- [ ] Run metadata and chain tests, then all required checks.
+
+```bash
+python3 -m unittest \
+  skills/carve-changesets/scripts/tests/test_metadata.py \
+  skills/carve-changesets/scripts/tests/test_chain.py -v
+just format
+just lint
+just test
+```
+
+- [ ] Update `CHANGELOG.md` and commit as
+  `feat: adopt trailer only changeset lineage`.
+
+## Task 4: Materialize and Adopt a Native Local Stack
+
+**Files:**
+
+- Modify: `skills/carve-changesets/scripts/chain.py`
+
+- Modify: `skills/carve-changesets/scripts/cli.py`
+
+- Create: `skills/carve-changesets/scripts/tests/test_native_materialize.py`
+
+- Modify: `skills/carve-changesets/scripts/tests/test_scripts_integration.py`
+
+- Modify: `CHANGELOG.md`
+
+- [ ] Add a failing integration-style unit test proving semantic commits are
+  created before one explicit native adoption, and that topology readback must
+  match exactly.
+
+```python
+class NativeMaterializationTest(unittest.TestCase):
+    @mock.patch("chain.create_chain", return_value=["feature-1", "feature-2"])
+    def test_materialize_registers_exact_order_and_returns_snapshot(
+        self,
+        create_chain: mock.Mock,
+    ) -> None:
+        client = mock.Mock()
+        client.view_json.return_value = VIEW_OPEN_WITHOUT_PRS
+
+        snapshot = materialize_native_stack(
+            PLAN,
+            remote="origin",
+            client=client,
+            trunk_head=A_SHA,
+        )
+
+        create_chain.assert_called_once_with(PLAN)
+        client.init.assert_called_once_with(
+            base="main",
+            branches=["feature-1", "feature-2"],
+        )
+        self.assertEqual(
+            tuple(layer.branch for layer in snapshot.layers),
+            ("feature-1", "feature-2"),
+        )
+
+    def test_materialize_rejects_native_order_disagreement(self) -> None:
+        client = mock.Mock()
+        client.view_json.return_value = VIEW_REVERSED
+
+        with self.assertRaisesRegex(NativeStackError, "native order"):
+            materialize_native_stack(
+                PLAN,
+                remote="origin",
+                client=client,
+                trunk_head=A_SHA,
+            )
+```
+
+- [ ] Run the focused test and confirm the coordinator is missing.
+
+```bash
+python3 -m unittest skills/carve-changesets/scripts/tests/test_native_materialize.py -v
+```
+
+- [ ] Implement `materialize_native_stack()` in `chain.py`. Check out the top
+  layer only for the `init`/`view` boundary, restore the caller's original
+  branch, and include the active source identity plus every layer head in the
+  result evidence.
+
+```python
+def materialize_native_stack(
+    plan: dict,
+    *,
+    remote: str,
+    client: GhStackClient | None = None,
+    trunk_head: str | None = None,
+) -> NativeStackSnapshot:
+    native = client or GhStackClient()
+    branches = create_chain(plan)
+    resolved_trunk = trunk_head or git(
+        "rev-parse", f"refs/remotes/{remote}/{plan['base_branch']}"
+    ).stdout.strip()
+    with checkout_restore():
+        git("checkout", branches[-1])
+        native.init(base=plan["base_branch"], branches=branches)
+        snapshot = parse_native_stack(
+            native.view_json(allow_state_refresh=True),
+            trunk_head=resolved_trunk,
+        )
+    if tuple(layer.branch for layer in snapshot.layers) != tuple(branches):
+        raise NativeStackError("native order does not match the materialized plan")
+    return snapshot
+```
+
+- [ ] Change `create-chain` to require `--ack-local-stack-state`, call the
+  native coordinator, and report materialized truth plus the exact
+  validation/review command needed to reach `chain_ready`. It must not claim
+  `chain_ready` until Task 6 supplies current validation, read-only review, and
+  equivalence evidence. Add an error for invoking materialization without an
+  installed compatible local profile; never create a non-native chain.
+
+- [ ] Add a temporary-repository test that runs the CLI with a fake `gh`
+  executable and asserts `.git/gh-stack` topology is represented by the fixture
+  readback. Assert interruption before `init` leaves semantic commits but
+  returns `blocked` with the exact recovery command.
+
+- [ ] Run materialization and integration tests, then all required checks.
+
+```bash
+python3 -m unittest \
+  skills/carve-changesets/scripts/tests/test_native_materialize.py \
+  skills/carve-changesets/scripts/tests/test_scripts_integration.py -v
+just format
+just lint
+just test
+```
+
+- [ ] Update `CHANGELOG.md` and commit as
+  `feat: materialize changesets as a native stack`.
+
+## Task 5: Add Operation-Scoped Manifests and Fail-Closed Remote Transitions
+
+**Files:**
+
+- Create: `skills/carve-changesets/scripts/transitions.py`
+
+- Create: `skills/carve-changesets/scripts/tests/test_transitions.py`
+
+- Modify: `skills/carve-changesets/scripts/cli.py`
+
+- Modify: `skills/carve-changesets/scripts/tests/test_cli_safety.py`
+
+- Modify: `CHANGELOG.md`
+
+- [ ] Write failing tests that enumerate direct and automatic effects, require
+  expected-old refs and PR states, and prove capability rejection happens before
+  the injected executor is called.
+
+```python
+class TransitionManifestTest(unittest.TestCase):
+    def test_publish_preview_lists_every_effect(self) -> None:
+        manifest = preview_transition(
+            StackOperation.PUBLISH,
+            OPEN_SNAPSHOT,
+            AuthorityGrant.publish(branches=("feature-1", "feature-2")),
+        )
+
+        self.assertEqual(
+            tuple(effect.kind for effect in manifest.effects),
+            (
+                EffectKind.PUSH_REF,
+                EffectKind.PUSH_REF,
+                EffectKind.CREATE_PR,
+                EffectKind.CREATE_PR,
+                EffectKind.DISABLE_AUTO_MERGE,
+                EffectKind.DISABLE_AUTO_MERGE,
+                EffectKind.REGISTER_STACK,
+            ),
+        )
+        self.assertEqual(manifest.expected_refs[0].old_sha, ZERO_SHA)
+        self.assertEqual(manifest.expected_pull_requests[0].state, "absent")
+        self.assertEqual(manifest.expected_native_stack.order, ("feature-1", "feature-2"))
+
+    def test_reviewed_preview_blocks_publish_before_execution(self) -> None:
+        executor = mock.Mock()
+        result = execute_transition(
+            PUBLISH_MANIFEST,
+            profile=reviewed_preview_profile(REVIEWED_SHA),
+            executor=executor,
+        )
+
+        self.assertEqual(result.state, TerminalState.BLOCKED)
+        self.assertIn("explicit_pull_request_bodies", result.blocker)
+        executor.assert_not_called()
+```
+
+- [ ] Run the focused test and confirm the transition model is absent.
+
+```bash
+python3 -m unittest skills/carve-changesets/scripts/tests/test_transitions.py -v
+```
+
+- [ ] Implement typed effects, expected-old inputs, authority grants,
+  required-capability maps, and terminal results.
+
+```python
+class StackOperation(str, Enum):
+    PUBLISH = "publish"
+    REPAIR = "repair"
+    MERGE = "merge"
+    RECOVER = "recover"
+
+
+REQUIRED_CAPABILITIES = {
+    StackOperation.PUBLISH: frozenset(
+        {
+            StackCapability.FENCED_SUBMIT,
+            StackCapability.EXPLICIT_PULL_REQUEST_BODIES,
+        }
+    ),
+    StackOperation.REPAIR: frozenset(
+        {
+            StackCapability.LOCAL_REBASE_NO_TRUNK,
+            StackCapability.FENCED_PUSH,
+        }
+    ),
+    StackOperation.MERGE: frozenset(
+        {
+            StackCapability.FENCED_MERGE,
+        }
+    ),
+    StackOperation.RECOVER: frozenset(
+        {
+            StackCapability.FENCED_PUSH,
+            StackCapability.PHASED_TRUNK_REFRESH,
+        }
+    ),
+}
+
+
+def execute_transition(
+    manifest: MutationManifest,
+    *,
+    profile: GhStackProfile,
+    executor: Callable[[MutationManifest], None],
+) -> TransitionResult:
+    missing = REQUIRED_CAPABILITIES[manifest.operation] - profile.capabilities
+    if missing:
+        names = ", ".join(sorted(capability.value for capability in missing))
+        return TransitionResult.blocked(
+            phase=manifest.operation.value,
+            identities=manifest.identities,
+            evidence=manifest.evidence,
+            blocker=f"gh stack profile {profile.version} lacks: {names}",
+            next_action="install a repository-tested compatible gh-stack profile",
+        )
+    manifest.validate_complete()
+    executor(manifest)
+    return classify_readback(manifest)
+```
+
+- [ ] Define manifest records with exact repository and remote; every selected
+  ref SHA or absence; every selected PR identity or absence, head, base, state,
+  draft, queue, and auto-merge value; native stack identity or absence, trunk,
+  membership, and order; enabled sync phases; exact titles and bodies; all
+  direct and automatic effects; and the authority grant covering the complete
+  effect set.
+
+```python
+@dataclass(frozen=True)
+class ExpectedPullRequest:
+    number: int | None
+    branch: str
+    head: str | None
+    base: str | None
+    state: str
+    draft: bool | None
+    queued: bool | None
+    auto_merge: bool | None
+
+
+@dataclass(frozen=True)
+class ExpectedNativeStack:
+    identity: str | None
+    trunk: str
+    order: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class MutationManifest:
+    operation: StackOperation
+    repository: str
+    remote: str
+    identities: tuple[str, ...]
+    expected_refs: tuple[ExpectedRef, ...]
+    expected_pull_requests: tuple[ExpectedPullRequest, ...]
+    expected_native_stack: ExpectedNativeStack
+    effects: tuple[MutationEffect, ...]
+    evidence: tuple[str, ...]
+    authority: AuthorityGrant
+```
+
+- [ ] Make `push-chain`, `pr-create`, `repair`, `merge-propagate`, and
+  `recover-suffix` render their operation manifest by default. `--execute`
+  requires the corresponding explicit authority acknowledgment, re-reads all
+  inputs, then returns `blocked` under the reviewed preview without invoking
+  `push`, `submit`, `sync`, or `merge`. A queue-backed `merge-propagate`
+  additionally requires `DURABLE_QUEUE_FENCE`; a direct prefix merge does not.
+
+- [ ] Add safety tests that inspect every mutation command and assert dry-run
+  defaults, authority acknowledgment names, and executor non-invocation for an
+  unsupported profile.
+
+- [ ] Add pure readback-classification tests for complete success, no-op
+  success, a rejected lease after earlier refs advanced, an unexpected remote
+  ref creation, PR/base/draft/auto-merge drift, direct-prefix partial merge,
+  queue admission without landing, and stack reordering. Each declared target
+  must classify as `changed_as_expected`, `unchanged`, or
+  `changed_unexpectedly`; any retry must require a newly generated manifest.
+
+- [ ] Run transition and CLI safety tests, then all required checks.
+
+```bash
+python3 -m unittest \
+  skills/carve-changesets/scripts/tests/test_transitions.py \
+  skills/carve-changesets/scripts/tests/test_cli_safety.py -v
+just format
+just lint
+just test
+```
+
+- [ ] Update `CHANGELOG.md` and commit as
+  `feat: fence native stack transitions by capability`.
+
+## Task 6: Prove Live Equivalence and Define Stack-Fix Handbacks
+
+**Files:**
+
+- Modify: `skills/carve-changesets/scripts/validate.py`
+
+- Modify: `skills/carve-changesets/scripts/tests/test_validate.py`
+
+- Modify: `skills/carve-changesets/scripts/rehydrate.py`
+
+- Modify: `skills/carve-changesets/scripts/tests/test_rehydrate.py`
+
+- Modify: `CHANGELOG.md`
+
+- [ ] Add failing equivalence tests for an unmerged stack, a merged prefix,
+  drifted trunk, rewritten suffix heads, and a valid successor source.
+
+```python
+class LiveEquivalenceTest(unittest.TestCase):
+    def test_merged_prefix_plus_open_suffix_matches_active_source(self) -> None:
+        result = validate_live_equivalence(
+            snapshot=MERGED_PREFIX_SNAPSHOT,
+            active_source=SOURCE_V1,
+            compare_trees=fake_compare(equal=True),
+        )
+
+        self.assertTrue(result.valid)
+        self.assertEqual(result.merged_prefix, (101,))
+        self.assertEqual(result.open_suffix, (102, 103))
+
+    def test_trunk_drift_requires_remote_successor_identity(self) -> None:
+        result = validate_live_equivalence(
+            snapshot=DRIFTED_TRUNK_SNAPSHOT,
+            active_source=LOCAL_ONLY_SUCCESSOR,
+            compare_trees=fake_compare(equal=True),
+        )
+
+        self.assertFalse(result.valid)
+        self.assertEqual(result.code, "successor_source_not_remote")
+```
+
+- [ ] Run validation tests and confirm the current whole-chain ancestry
+  validator cannot express the merged-prefix invariant.
+
+```bash
+python3 -m unittest skills/carve-changesets/scripts/tests/test_validate.py -v
+```
+
+- [ ] Implement equivalence reconstruction in a disposable ref: start at exact
+  current remote trunk, apply each open native layer in order, compare its tree
+  to the active immutable source, and delete only the disposable ref on exit.
+
+```python
+@dataclass(frozen=True)
+class LiveEquivalence:
+    valid: bool
+    code: str
+    merged_prefix: tuple[int, ...]
+    open_suffix: tuple[int, ...]
+    reconstructed_tree: str
+    source_tree: str
+
+
+def validate_live_equivalence(
+    *,
+    snapshot: NativeStackSnapshot,
+    active_source: SourceIdentity,
+) -> LiveEquivalence:
+    require_remote_source(active_source)
+    merged, opened = partition_at_first_open(snapshot.layers)
+    reconstructed = reconstruct_open_suffix(
+        trunk_head=snapshot.trunk_head,
+        layers=opened,
+    )
+    return compare_equivalent_trees(
+        reconstructed=reconstructed,
+        source=active_source.sha,
+        merged=merged,
+        opened=opened,
+    )
+```
+
+- [ ] Implement `assess_chain_ready()` so `chain_ready` requires exact-head
+  validation for every layer, a current clean `review-code-change` result for
+  every layer, native topology readback, and successful live equivalence. Return
+  `blocked` naming the first stale or missing gate; never promote
+  materialization alone.
+
+- [ ] Add terminal-state tests for `prs_open` and `all_merged`. `prs_open`
+  requires current `chain_ready` evidence plus exact remote heads, PR bases,
+  semantic trailers, native GitHub membership, and non-merge gates. `all_merged`
+  requires every chain PR merged, an empty suffix, completed native
+  synchronization, current-trunk equivalence, current validation, and authorized
+  cleanup completed or explicitly bounded.
+
+- [ ] Add a `StackFixHandback` parser/renderer in `rehydrate.py`. Require exact
+  PR number/head, invalidated suffix branches and PRs, prior evidence IDs,
+  requested native phase, authority still needed, and resumable command.
+  Document the handback contract in Task 8 so all normative prose changes land
+  together.
+
+```json
+{
+  "kind": "stack_fix_handback",
+  "reviewed_pr": 102,
+  "reviewed_head": "2222222222222222222222222222222222222222",
+  "invalidated_suffix": {
+    "branches": ["feature-2", "feature-3"],
+    "pull_requests": [102, 103]
+  },
+  "invalidated_evidence": ["review:102:2222222", "validation:feature-3:3333333"],
+  "requested_phase": "repair",
+  "authority_required": "rewrite and push the named open suffix",
+  "resume_command": "python3 skills/carve-changesets/scripts/cli.py repair --pr 102"
+}
+```
+
+- [ ] Ensure `repair` consumes this handback only after fresh topology readback
+  and invalidates all evidence tied to changed heads. Under the reviewed
+  profile, it must return `blocked` before local cascading rebase because the
+  complete repair cannot be published safely.
+
+- [ ] Add interruption-state tests for a native rebase conflict, an existing
+  stack lock, local/remote divergence, and an interrupted native modify.
+  Preserve documented dependency recovery state, report the exact continuation
+  or abort command, and never parse `.git/gh-stack` internals to manufacture
+  recovery.
+
+- [ ] Run validation, rehydration, and handoff contract tests, then all required
+  checks.
+
+```bash
+python3 -m unittest \
+  skills/carve-changesets/scripts/tests/test_validate.py \
+  skills/carve-changesets/scripts/tests/test_rehydrate.py \
+  skills/carve-changesets/scripts/tests/test_skill_contract.py -v
+just format
+just lint
+just test
+```
+
+- [ ] Update `CHANGELOG.md` and commit as
+  `feat: validate live native stack equivalence`.
+
+## Task 7: Cut Over the CLI and Remove the Custom Stack Manager
+
+**Files:**
+
+- Modify: `skills/carve-changesets/scripts/cli.py`
+
+- Modify: `skills/carve-changesets/scripts/github.py`
+
+- Delete: `skills/carve-changesets/scripts/propagate.py`
+
+- Delete: `skills/carve-changesets/scripts/recovery.py`
+
+- Delete: `skills/carve-changesets/scripts/tests/test_propagate.py`
+
+- Delete: `skills/carve-changesets/scripts/tests/test_recovery.py`
+
+- Modify: `skills/carve-changesets/scripts/tests/test_github.py`
+
+- Modify: `skills/carve-changesets/scripts/tests/test_scripts_integration.py`
+
+- Create: `skills/carve-changesets/scripts/tests/test_legacy_adoption.py`
+
+- Modify: `CHANGELOG.md`
+
+- [ ] Add failing CLI tests for the final command map and deterministic
+  retirement messages.
+
+```python
+class NativeCommandSurfaceTest(unittest.TestCase):
+    def test_final_remote_commands_are_native_transitions(self) -> None:
+        parser = build_parser()
+
+        self.assertParses(parser, "push-chain")
+        self.assertParses(parser, "pr-create")
+        self.assertParses(parser, "repair")
+        self.assertParses(parser, "merge-propagate")
+        self.assertParses(parser, "recover-suffix")
+
+    def test_custom_propagate_command_is_retired(self) -> None:
+        result = invoke_cli("propagate")
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("use the native repair workflow", result.stderr)
+```
+
+- [ ] Run CLI integration tests and confirm the custom commands still exist.
+
+```bash
+python3 -m unittest skills/carve-changesets/scripts/tests/test_scripts_integration.py -v
+```
+
+- [ ] Remove ordinary PR create/edit/merge functions from `github.py`. Retain
+  authenticated repository lookup, PR reads, branch/head/base/state reads, and
+  remote-source verification.
+
+- [ ] Delete `propagate.py`, `recovery.py`, and their mechanism-specific tests.
+  Move successor-lineage planning into the pure recovery manifest builder in
+  `transitions.py`; it must not rewrite or push under the reviewed profile.
+
+- [ ] Implement final command routing:
+
+```text
+create-chain       semantic materialization -> gh stack init -> materialized truth
+status             gh stack view --json + GitHub/remote/trailer reconciliation
+push-chain         push manifest -> capability gate -> blocked on reviewed profile
+pr-create          submit manifest -> capability gate -> blocked on reviewed profile
+repair             handback + manifest -> capability gate -> blocked on reviewed profile
+merge-propagate    prefix/queue manifest -> capability gate -> blocked on reviewed profile
+recover-suffix     successor manifest -> capability gate -> blocked on reviewed profile
+```
+
+- [ ] Add legacy-adoption tests. A legacy v1/v2 chain may be locally adopted
+  with `gh stack init` only after commit/PR evidence agrees; native GitHub
+  registration remains `blocked` because `gh stack link` is forbidden and the
+  reviewed `submit` profile lacks required fences. Assert that adoption does not
+  amend heads merely to normalize metadata.
+
+- [ ] Search for forbidden custom-manager call sites and stale imports; the
+  command must return no matches.
+
+```bash
+rg -n "pr_create|merge_pull_request|edit_pull_request|push_chain|propagate_from_live|merge_propagate_from_live|recover_suffix_from_live|gh stack link" \
+  skills/carve-changesets/scripts \
+  --glob '*.py'
+```
+
+- [ ] Run the complete carve script suite and all required checks.
+
+```bash
+just test-carve-changesets
+just format
+just lint
+just test
+```
+
+- [ ] Update `CHANGELOG.md` and commit as
+  `refactor: remove custom changeset stack management`.
+
+## Task 8: Cut Over Normative Prose and Record Behavioral Evidence
+
+**Files:**
+
+- Modify: `skills/carve-changesets/SKILL.md`
+
+- Modify: `skills/carve-changesets/references/SPEC.md`
+
+- Modify: `skills/carve-changesets/references/cli.md`
+
+- Modify: `skills/carve-changesets/references/plan-schema.md`
+
+- Modify: `skills/carve-changesets/references/suite-handoffs.md`
+
+- Modify: `skills/carve-changesets/evals/cases.json`
+
+- Modify: `skills/carve-changesets/evals/expectations.json`
+
+- Modify: `skills/carve-changesets/evals/integration_cases.json`
+
+- Create: `skills/carve-changesets/evals/results/<recorded-after-summary>.json`
+
+- Modify: `CHANGELOG.md`
+
+- [ ] Update the deterministic corpus before normative prose so it has explicit
+  cases for native-only topology, `chain_ready` on the reviewed profile,
+  fail-closed publication, operation-scoped authority, live equivalence,
+  stack-fix handback, legacy local adoption, and forbidden fallback.
+
+- [ ] Run the deterministic corpus against the still-old prose and confirm the
+  new expectations fail for the intended contract gap.
+
+```bash
+just eval-carve-changesets
+```
+
+Expected: at least one new case fails because the old skill still delegates
+stack mechanics to custom publication/propagation commands.
+
+- [ ] Rewrite the normative documents to match the implemented contract. Keep
+  semantic seam selection and indivisibility rules prominent; describe native
+  stack mechanics by responsibility and phase, not by duplicating upstream
+  implementation details. In `plan-schema.md`, make `remote` default to
+  `origin`, make source identity immutable, and prohibit persisted position or
+  predecessor. In `suite-handoffs.md`, define the exact `StackFixHandback`
+  payload from Task 6.
+
+- [ ] Add contract assertions covering these exact obligations:
+
+```python
+REQUIRED_NATIVE_CONTRACT = (
+    "gh stack is the sole stack engine",
+    "chain_ready",
+    "operation-scoped authority",
+    "current trunk",
+    "open suffix",
+    "successor source",
+    "stack_fix_handback",
+)
+
+FORBIDDEN_FALLBACK_LANGUAGE = (
+    "use gh pr create",
+    "run propagate.py",
+    "run recovery.py",
+    "fall back to the custom stack manager",
+)
+```
+
+- [ ] Run contract, corpus, and full checks.
+
+```bash
+python3 -m unittest skills/carve-changesets/scripts/tests/test_skill_contract.py -v
+just eval-carve-changesets
+just format
+just lint
+just test
+```
+
+- [ ] Update `CHANGELOG.md` and commit the normative cutover as
+  `docs: rebuild carve changesets on gh stack`.
+
+- [ ] From the resulting committed clean tree, record the `after` evidence.
+
+```bash
+just eval-record carve-changesets --stage after
+```
+
+Expected: the summary names the normative-cutover commit SHA, uses the same tier
+and suite as the baseline, reports every case observation, and includes the
+scoped diff against the recorded `before` run.
+
+- [ ] Inspect the result JSON for candidate SHA, cleanliness, suite, status,
+  totals, and per-case observations.
+
+```bash
+for result in skills/carve-changesets/evals/results/*-after.json; do
+  python3 -m json.tool "$result" >/dev/null
+done
+git diff --check
+git status --short
+```
+
+- [ ] Add the result and changelog entry, run all required checks, and commit as
+  `test: record native gh stack behavior evidence`.
+
+## Task 9: Final Cross-Layer Verification
+
+**Files:**
+
+- Modify only if verification exposes a defect: the smallest file already owned
+  by Tasks 1–8
+
+- Modify when a fix commit is required: `CHANGELOG.md`
+
+- [ ] Run the complete deterministic, unit, integration, lint, and formatting
+  suite from a clean tree.
+
+```bash
+just eval-carve-changesets
+just format
+just lint
+just test
+git diff --check
+git status --short
+```
+
+- [ ] Exercise the command boundary in a disposable local repository with a fake
+  reviewed-profile adapter and capture these terminal outcomes:
+
+```text
+valid proposal                         -> plan_ready
+semantic commits + init                -> materialized truth, no terminal claim
+validated and reviewed local stack     -> chain_ready
+push-chain --execute                   -> blocked before mutation
+pr-create --execute                    -> blocked before mutation
+repair handback --execute              -> blocked before mutation
+merge-propagate --execute              -> blocked before mutation
+recover-suffix --execute               -> blocked before mutation
+```
+
+- [ ] Verify every `blocked` result contains phase, exact stack/source
+  identities, evidence read, missing capabilities, authority still required, and
+  one resumable next action.
+
+- [ ] Verify no code path invokes `gh stack push`, `gh stack submit`,
+  `gh stack sync`, `gh stack merge`, `gh pr create`, `gh pr edit`, or
+  `gh pr merge` under the reviewed profile.
+
+```bash
+rg -n "\[.*gh.*stack.*(push|submit|sync|merge)|gh pr (create|edit|merge)" \
+  skills/carve-changesets/scripts \
+  --glob '*.py'
+```
+
+Expected: only contract fixtures or explicit forbidden-command assertions match;
+executable production call sites do not.
+
+- [ ] If verification required a code or prose correction, add a focused
+  regression test, update `CHANGELOG.md`, repeat the full suite, and commit the
+  correction with a file-backed Conventional Commit message. Because a
+  normative-prose correction changes the candidate, record and commit a fresh
+  `after` eval result from the corrected clean commit.
+
+- [ ] Confirm the branch history is reviewable and every changelog entry except
+  the newest has its full SHA.
+
+```bash
+git log --oneline --decorate main..HEAD
+git status --short
+```
+
+Expected: the worktree is clean, the baseline and final eval summaries point to
+resolvable commits, and the implementation has no custom stack-management
+fallback.


### PR DESCRIPTION
## TL;DR

Rebuild `carve-changesets` around GitHub's native `gh stack` engine while narrowing the skill to semantic decomposition, proof, and authority, with a concrete implementation plan for the migration.

## Summary

This proposal makes `gh stack` the sole owner of stack topology and lifecycle mechanics. `carve-changesets` retains the work that is specific to intentional changesets: choosing semantic seams, identifying indivisible work, preserving immutable source lineage, proving current-trunk-plus-open-suffix equivalence, and binding review, validation, and mutation authority to exact candidates.

The design defines:

- distinct proposed, materialized, published, and merged truth;
- trailer-only semantic and recovery metadata whose topology comes from live native stack state;
- operation-scoped expected-old manifests covering direct and automatic effects;
- explicit stack-fix handbacks that preserve one-PR `babysit-pr` ownership;
- fail-closed legacy adoption without `gh stack link` or a custom fallback engine; and
- terminal-state and recovery contracts for interruption, divergence, partial publication, direct prefix merges, and merge queues.

The implementation plan converts that design into independently reviewable tasks for the adapter and baseline evidence, topology, metadata, local materialization, remote transition fences, live equivalence and handbacks, CLI cutover, normative prose, eval evidence, and final cross-layer verification.

The current reviewed preview can support local native adoption, but publication, repair, recovery, and merge remain deterministically blocked until an exact tested dependency profile exposes the required mutation fences and explicit per-layer PR-body controls.

Implementation is tracked by [Epic #108](https://github.com/shaug/agent-scripts/issues/108) and its native sub-issue/dependency graph.