### PR TITLE
docs(evals): point provenance citations at the renamed repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,23 @@ summary: Chronological history of repository and skill changes.
 
 # Changelog
 
-## 2026-08-05 — Proposed, hardened, and planned rebuilding carve-changesets on GitHub's native stacked pull request engine, fixed the intermittent claude_executor real-model parsing failure blocking implement-ticket eval evidence, added scoped per-finding re-review and escalated final-cycle execution to implement-ticket's fix loop, then made installed-distribution drift detectable and drove that check through five adversarial review rounds until it no longer had the silent successes it exists to catch, then separately triaged the real-model forward-eval failures that run surfaced, fixed implement-epic's terminal-state passthrough and implement-ticket's acceptance-ledger currency/correctness conflation, ran a 3-round adversarial read-only review loop against those two fixes to convergence verified with a fresh real-model run, and closed epic #118 by documenting how the two peer libraries compose end to end, then renamed the project from agent-scripts to compris across every identity it publishes while leaving its recorded history and eval provenance intact
+## 2026-08-06 — Renamed the project from agent-scripts to compris across every identity it publishes, then pointed the eval corpus's own citations at the renamed repository while leaving the absolute paths that record where each run actually happened untouched
+
+- docs(evals): point provenance citations at the renamed repository — rewrite
+  the ten `github.com/shaug/agent-scripts/issues/58` comment citations in
+  `review-suite/evals/baseline/v1/LIMITATIONS.md` and the eight strata
+  provenance records to `github.com/shaug/compris`, and rename the corpus source
+  in `SOURCING.md` while noting that the material was sourced under the old
+  name. Deliberately unchanged: the thirty-seven absolute worktree and
+  scratchpad paths embedded in `review-suite/evals/v2/*.report.json` and
+  `skills/implement-ticket/evals/results/*.json`, and the historical commit
+  title `chore: initialize agent-scripts monorepo`. *Why:* a URL naming an issue
+  in this repository is a live reference to a resource that moved, and leaving
+  it to a GitHub redirect makes the corpus look like it cites a repository that
+  no longer exists. A path recording where a run executed is a measurement, and
+  rewriting it would assert that a run happened somewhere it did not — the same
+  distinction the rename commit drew, applied to what it deliberately left
+  behind
 
 - chore: rename agent-scripts to compris — rename the project across every
   identity it publishes. The plugin and marketplace name, display name, and
@@ -34,6 +50,9 @@ summary: Chronological history of repository and skill changes.
   reviews its own work on the way. `compris` — understood — states what the
   suite claims at the moment work changes hands, and joins the French naming
   convention shared with `atelier` and `savoir`
+  (`d12fc1cd6d65c0c3f0c81be83fb33d47933b1fc8`)
+
+## 2026-08-05 — Proposed, hardened, and planned rebuilding carve-changesets on GitHub's native stacked pull request engine, fixed the intermittent claude_executor real-model parsing failure blocking implement-ticket eval evidence, added scoped per-finding re-review and escalated final-cycle execution to implement-ticket's fix loop, then made installed-distribution drift detectable and drove that check through five adversarial review rounds until it no longer had the silent successes it exists to catch, then separately triaged the real-model forward-eval failures that run surfaced, fixed implement-epic's terminal-state passthrough and implement-ticket's acceptance-ledger currency/correctness conflation, ran a 3-round adversarial read-only review loop against those two fixes to convergence verified with a fresh real-model run, and closed epic #118 by documenting how the two peer libraries compose end to end
 
 - docs: document peer composition rules and the coexistence README section
   (issue #128, epic #118, the epic's final child) — add a "Using beside peer

--- a/review-suite/evals/baseline/v1/LIMITATIONS.md
+++ b/review-suite/evals/baseline/v1/LIMITATIONS.md
@@ -820,9 +820,9 @@ are satisfied, and all three strata now declare `scored: true`.
 The full record of each owner disposition, including the standing
 over-engineering standard applied across all 8 cases, is in the tracker rather
 than duplicated here: see
-[the audit-trail comment](https://github.com/shaug/agent-scripts/issues/58#issuecomment-5099314609)
+[the audit-trail comment](https://github.com/shaug/compris/issues/58#issuecomment-5099314609)
 and
-[its follow-up](https://github.com/shaug/agent-scripts/issues/58#issuecomment-5099339357).
+[its follow-up](https://github.com/shaug/compris/issues/58#issuecomment-5099339357).
 Each case's provenance carries a concise summary and links back to these two
 comments rather than re-deriving the reasoning.
 

--- a/review-suite/evals/baseline/v1/SOURCING.md
+++ b/review-suite/evals/baseline/v1/SOURCING.md
@@ -7,10 +7,10 @@ then miscalibrate every gate that reads the baseline.
 
 ## Sources used
 
-| source                | visibility | what it supplies                                                                                                                   |
-| --------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `shaug/atelier`       | **public** | 899 pull-request review comments, all authored by the repository owner, across ~354 pull requests.                                 |
-| `shaug/agent-scripts` | **public** | This suite's own delivery history, including a defect that survived an aggregate `clean` review verdict and was then caught by CI. |
+| source          | visibility | what it supplies                                                                                                                                                                                       |
+| --------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `shaug/atelier` | **public** | 899 pull-request review comments, all authored by the repository owner, across ~354 pull requests.                                                                                                     |
+| `shaug/compris` | **public** | This suite's own delivery history, including a defect that survived an aggregate `clean` review verdict and was then caught by CI. Sourced while the repository was still named `shaug/agent-scripts`. |
 
 In `shaug/atelier` the reviewer is the repository owner and the candidates are
 in their own repository. This is human review of a real candidate with a real

--- a/review-suite/evals/strata/s2-solution-simplicity-lens/private/provenance/reconciliation-outcome-type.json
+++ b/review-suite/evals/strata/s2-solution-simplicity-lens/private/provenance/reconciliation-outcome-type.json
@@ -12,7 +12,7 @@
     "owner_disposition": {
       "outcome": "confirmed_clean",
       "reasoning": "Owner confirmed: over-engineering is rarely a boolean-vs-enum question. Booleans-as-state are often the real code smell; an enum is typed, self-descriptive, expandable, and boolean fields becoming boolean parameters is its own anti-pattern. Confirms the recommended CLEAN / NOT MATERIAL disposition.",
-      "source": "https://github.com/shaug/agent-scripts/issues/58#issuecomment-5099314609 (owner adjudication, 8 of 8); https://github.com/shaug/agent-scripts/issues/58#issuecomment-5099339357 (case 3/7 cross-reference resolution)"
+      "source": "https://github.com/shaug/compris/issues/58#issuecomment-5099314609 (owner adjudication, 8 of 8); https://github.com/shaug/compris/issues/58#issuecomment-5099339357 (case 3/7 cross-reference resolution)"
     }
   }
 }

--- a/review-suite/evals/strata/s2-solution-simplicity-lens/private/provenance/record-status-transition-guard.json
+++ b/review-suite/evals/strata/s2-solution-simplicity-lens/private/provenance/record-status-transition-guard.json
@@ -12,7 +12,7 @@
     "owner_disposition": {
       "outcome": "confirmed_clean",
       "reasoning": "Owner confirmed: protecting against or recovering from an error case that falls within the scope of the stated requirements is good engineering, not over-engineering. Confirms the recommended CLEAN / NOT MATERIAL disposition.",
-      "source": "https://github.com/shaug/agent-scripts/issues/58#issuecomment-5099314609 (owner adjudication, 8 of 8); https://github.com/shaug/agent-scripts/issues/58#issuecomment-5099339357 (case 3/7 cross-reference resolution)"
+      "source": "https://github.com/shaug/compris/issues/58#issuecomment-5099314609 (owner adjudication, 8 of 8); https://github.com/shaug/compris/issues/58#issuecomment-5099339357 (case 3/7 cross-reference resolution)"
     }
   }
 }

--- a/review-suite/evals/strata/s2-solution-simplicity-lens/private/provenance/registry-client-layering.json
+++ b/review-suite/evals/strata/s2-solution-simplicity-lens/private/provenance/registry-client-layering.json
@@ -12,7 +12,7 @@
     "owner_disposition": {
       "outcome": "confirmed_material",
       "reasoning": "Owner confirmed, and reframed the standard rather than accepting it as given: the defect is not reaching through an abstraction barrier per se, it is failing to question and re-justify the barrier itself. A barrier that holds up under scrutiny should be maintained, not locally worked around. See the case 3/case 7 note for the shared-source resolution: case 7's local duplication is this case's downstream symptom, confirmed as deliberate dual-level coverage rather than a double-count.",
-      "source": "https://github.com/shaug/agent-scripts/issues/58#issuecomment-5099314609 (owner adjudication, 8 of 8); https://github.com/shaug/agent-scripts/issues/58#issuecomment-5099339357 (case 3/7 cross-reference resolution)"
+      "source": "https://github.com/shaug/compris/issues/58#issuecomment-5099314609 (owner adjudication, 8 of 8); https://github.com/shaug/compris/issues/58#issuecomment-5099339357 (case 3/7 cross-reference resolution)"
     }
   }
 }

--- a/review-suite/evals/strata/s2-solution-simplicity-lens/private/provenance/setup-service-path-gateway.json
+++ b/review-suite/evals/strata/s2-solution-simplicity-lens/private/provenance/setup-service-path-gateway.json
@@ -12,7 +12,7 @@
     "owner_disposition": {
       "outcome": "confirmed_material",
       "reasoning": "Owner confirmed: the mirror case of `registry-client-layering` - an abstraction that provides no obvious value and only obfuscates the implementation is the failure mode, not abstraction itself. Good engineering is designing good abstractions, not adding more of them.",
-      "source": "https://github.com/shaug/agent-scripts/issues/58#issuecomment-5099314609 (owner adjudication, 8 of 8); https://github.com/shaug/agent-scripts/issues/58#issuecomment-5099339357 (case 3/7 cross-reference resolution)"
+      "source": "https://github.com/shaug/compris/issues/58#issuecomment-5099314609 (owner adjudication, 8 of 8); https://github.com/shaug/compris/issues/58#issuecomment-5099339357 (case 3/7 cross-reference resolution)"
     }
   }
 }

--- a/review-suite/evals/strata/s3-code-simplicity-lens/private/provenance/compat-accessor-boundary-duplication.json
+++ b/review-suite/evals/strata/s3-code-simplicity-lens/private/provenance/compat-accessor-boundary-duplication.json
@@ -12,7 +12,7 @@
     "owner_disposition": {
       "outcome": "confirmed_clean",
       "reasoning": "Owner confirmed: preferring strong types, edge validation into strong types, and domain-modeling types over a loose seam is the standard applied throughout, not a stylistic preference for this case alone.",
-      "source": "https://github.com/shaug/agent-scripts/issues/58#issuecomment-5099314609 (owner adjudication, 8 of 8); https://github.com/shaug/agent-scripts/issues/58#issuecomment-5099339357 (case 3/7 cross-reference resolution)"
+      "source": "https://github.com/shaug/compris/issues/58#issuecomment-5099314609 (owner adjudication, 8 of 8); https://github.com/shaug/compris/issues/58#issuecomment-5099339357 (case 3/7 cross-reference resolution)"
     }
   }
 }

--- a/review-suite/evals/strata/s3-code-simplicity-lens/private/provenance/env-inventory-bullet-format.json
+++ b/review-suite/evals/strata/s3-code-simplicity-lens/private/provenance/env-inventory-bullet-format.json
@@ -12,7 +12,7 @@
     "owner_disposition": {
       "outcome": "confirmed_clean",
       "reasoning": "Owner confirmed: Markdown must stay readable in its raw form - that is the actual reason for the simplified syntax over a full markup language, and the same reason prose is wrapped and tables are formatted rather than left to a renderer.",
-      "source": "https://github.com/shaug/agent-scripts/issues/58#issuecomment-5099314609 (owner adjudication, 8 of 8); https://github.com/shaug/agent-scripts/issues/58#issuecomment-5099339357 (case 3/7 cross-reference resolution)"
+      "source": "https://github.com/shaug/compris/issues/58#issuecomment-5099314609 (owner adjudication, 8 of 8); https://github.com/shaug/compris/issues/58#issuecomment-5099339357 (case 3/7 cross-reference resolution)"
     }
   }
 }

--- a/review-suite/evals/strata/s3-code-simplicity-lens/private/provenance/metrics-label-formatting-duplication.json
+++ b/review-suite/evals/strata/s3-code-simplicity-lens/private/provenance/metrics-label-formatting-duplication.json
@@ -12,7 +12,7 @@
     "owner_disposition": {
       "outcome": "confirmed_material",
       "reasoning": "Owner confirmed from direct recollection of the real PR, independent of the recommendation offered - including the difficulty at the time of getting the implementing agent to understand the point of the abstraction barrier. Resolved as case 3's downstream symptom, not a double-count of the same finding: deliberate dual-level coverage of one causal chain. See LIMITATIONS.md for the correlated-recall caveat this creates for any aggregate figure over the pair.",
-      "source": "https://github.com/shaug/agent-scripts/issues/58#issuecomment-5099314609 (owner adjudication, 8 of 8); https://github.com/shaug/agent-scripts/issues/58#issuecomment-5099339357 (case 3/7 cross-reference resolution)"
+      "source": "https://github.com/shaug/compris/issues/58#issuecomment-5099314609 (owner adjudication, 8 of 8); https://github.com/shaug/compris/issues/58#issuecomment-5099339357 (case 3/7 cross-reference resolution)"
     }
   }
 }

--- a/review-suite/evals/strata/s3-code-simplicity-lens/private/provenance/watcher-check-policy-duplication.json
+++ b/review-suite/evals/strata/s3-code-simplicity-lens/private/provenance/watcher-check-policy-duplication.json
@@ -12,7 +12,7 @@
     "owner_disposition": {
       "outcome": "confirmed_material",
       "reasoning": "Owner confirmed material, consistent with the recommended disposition and with this repository's own commit history recording the drift this case demonstrates.",
-      "source": "https://github.com/shaug/agent-scripts/issues/58#issuecomment-5099314609 (owner adjudication, 8 of 8); https://github.com/shaug/agent-scripts/issues/58#issuecomment-5099339357 (case 3/7 cross-reference resolution)"
+      "source": "https://github.com/shaug/compris/issues/58#issuecomment-5099314609 (owner adjudication, 8 of 8); https://github.com/shaug/compris/issues/58#issuecomment-5099339357 (case 3/7 cross-reference resolution)"
     }
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #173. Points the eval corpus's own citations at the renamed
repository, and corrects the date the rename entry was filed under.

- Ten `github.com/shaug/agent-scripts/issues/58` comment citations become
  `github.com/shaug/compris` — two in
  `review-suite/evals/baseline/v1/LIMITATIONS.md`, eight across the strata
  provenance records.
- `SOURCING.md` names the corpus source as `shaug/compris`, with an explicit
  note that the material was sourced while the repository still carried the old
  name.
- The rename entry moves from `2026-08-05` to a new `2026-08-06` section — its
  actual merge date — and carries its full SHA.

## Deliberately unchanged

- **Thirty-seven absolute worktree and scratchpad paths** in
  `review-suite/evals/v2/*.report.json` and
  `skills/implement-ticket/evals/results/*.json`. These record where a run
  actually executed; rewriting them would assert a run happened somewhere it did
  not.
- **The historical commit title** `chore: initialize agent-scripts monorepo`.
  That is a quotation of a real commit message, not a reference.

## Why

#173 drew the line between references and records, and deliberately left the
records alone. That was right for filesystem paths but wrong for URLs: an issue
link is a live pointer to a resource that moved, and relying on a GitHub
redirect makes the corpus look like it cites a repository that no longer exists.
This applies the same distinction to what #173 left behind.

## Verification

`just format`, `just lint-py`, `just lint-md`, and `just validate-plugins` clean.
`review-suite/scripts/tests` 339 passing, `scripts/tests` 66 passing.
