### PR TITLE
docs: state what compris does before explaining how to install it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ summary: Chronological history of repository and skill changes.
 
 ## 2026-08-06 — Renamed the project from agent-scripts to compris across every identity it publishes, then pointed the eval corpus's own citations at the renamed repository while leaving the absolute paths that record where each run actually happened untouched
 
+- docs: state what compris does before explaining how to install it — replace
+  the opening line, "A personal monorepo for agent skills and supporting
+  scripts", with what the suite actually does: takes one ticket and returns a
+  merged pull request, `implement-ticket` into `babysit-pr`, with
+  `implement-epic` driving the same path per epic child. Two short sections
+  follow — where the pipeline starts, so the boundary with peer methodology
+  libraries is visible before the composition rules explain it in detail, and
+  what holds it together, namely pre-publication review by independent lenses
+  reconciled against a typed schema its caller can validate, failing closed when
+  evidence cannot be bound. Hardcoded skill counts leave the prose: "all ten
+  skills" and "Current reusable agent skills" carried no information their
+  sentences needed, and the description-tier corpus figure is scoped to the
+  suite as it stood when the corpus ran rather than asserting a current total.
+  `review-fix-loop` is deliberately absent from the opening — it is standalone
+  today with no caller invoking it, so describing convergence-until-clean as
+  part of the pipeline would overstate what runs. *Why:* the old opening
+  described a directory rather than a purpose, so a reader met installation
+  instructions before learning what they would be installing — the genericness
+  the rename set out to retire, left sitting in the first line anyone reads.
+  Counts in prose go stale the moment a skill is added
+
 - docs(evals): point provenance citations at the renamed repository — rewrite
   the ten `github.com/shaug/agent-scripts/issues/58` comment citations in
   `review-suite/evals/baseline/v1/LIMITATIONS.md` and the eight strata
@@ -20,7 +41,7 @@ summary: Chronological history of repository and skill changes.
   no longer exists. A path recording where a run executed is a measurement, and
   rewriting it would assert that a run happened somewhere it did not — the same
   distinction the rename commit drew, applied to what it deliberately left
-  behind
+  behind (`8566327841d7d9d4b481367d4da6316ff2120ba0`)
 
 - chore: rename agent-scripts to compris — rename the project across every
   identity it publishes. The plugin and marketplace name, display name, and

--- a/README.md
+++ b/README.md
@@ -1,11 +1,33 @@
-# shaug/compris
+# compris
 
-A personal monorepo for agent skills and supporting scripts.
+*For when the planning is done, and the work begins.*
+
+Agent skills that take one ticket and return a merged pull request.
+`implement-ticket` resolves the ticket's live context, implements the change in
+an isolated worktree, reviews the candidate through the repository's own review
+suite, publishes a pull request, and delegates its lifecycle to `babysit-pr`,
+which watches CI and re-reviews after every head change. `implement-epic`
+traverses a live epic graph and drives the same path for each ready child.
+
+`compris` is French for *understood* — what the suite claims at the moment work
+changes hands.
+
+**Where it starts.** Not at the idea. Peer methodology libraries own the
+thinking-it-through phase, and `ready-ticket` stops at an implementation-ready
+ticket body without crossing into implementation. Compris begins once the ticket
+is a contract.
+
+**What holds it together.** Every candidate is reviewed before publication by
+independent lenses — correctness, whole-solution simplicity, and local
+implementation simplicity — reconciled into one verdict against a typed schema
+its caller can validate. They fail closed: a review that cannot bind its
+evidence to the candidate says so rather than returning a clean verdict it did
+not earn.
 
 ## Installation
 
-Install the plugin when you need any composed workflow. It packages all ten
-skills together so stable-name dependencies such as `implement-ticket`,
+Install the plugin when you need any composed workflow. It packages every skill
+together so stable-name dependencies such as `implement-ticket`,
 `review-code-change`, and `babysit-pr` are available in the same fresh session.
 
 ### Claude Code
@@ -59,7 +81,7 @@ causes the workflow to fail closed.
   review skills
 - `justfile` — common tasks for testing, validation, and formatting
 
-Current reusable agent skills:
+The skills:
 
 - `skills/ready-ticket` — turn a vague idea or an unready GitHub or Linear
   ticket into an implementation-ready ticket body: elicit the open product
@@ -249,14 +271,14 @@ routing is winner-takes-attention, and a contorted description misroutes the
 requests the skill was built for while still losing the contested ones.
 [Issue #136](https://github.com/shaug/compris/issues/136) landed the
 description-tier corpus that empirically exercises the audit's dispositions: 35
-result-blind cases across all ten skills, five repetitions each, majority wins.
-Its one recorded candidate overlap did not reproduce on retest — see
-`triggering/known-overlaps.json` for the observation and its refutation. Two
-tiers of that corpus remain unmeasured and are recorded as gaps rather than
-claimed: the headless tier, whose ability to observe which skill actually loaded
-is itself unverified, and the peer-installed composition cases in
-`triggering/composition-cases.json`, which need a harness that does not exist
-yet.
+result-blind cases covering every skill in the suite at the time, five
+repetitions each, majority wins. Its one recorded candidate overlap did not
+reproduce on retest — see `triggering/known-overlaps.json` for the observation
+and its refutation. Two tiers of that corpus remain unmeasured and are recorded
+as gaps rather than claimed: the headless tier, whose ability to observe which
+skill actually loaded is itself unverified, and the peer-installed composition
+cases in `triggering/composition-cases.json`, which need a harness that does not
+exist yet.
 
 ### Seam table
 


### PR DESCRIPTION
## Summary

The rename landed everywhere except the sentence that most needed it. The README
still opened with "A personal monorepo for agent skills and supporting scripts"
— a description of a directory, not a purpose, and the exact genericness the
rename set out to retire.

- **New opening** states what the suite does: takes one ticket and returns a
  merged pull request, `implement-ticket` into `babysit-pr`, with
  `implement-epic` driving the same path for each ready epic child.
- **Where it starts** makes the boundary with peer methodology libraries visible
  up front, rather than only in the composition rules 200 lines down.
- **What holds it together** names the property that distinguishes the suite:
  pre-publication review by independent lenses, reconciled against a typed
  schema its caller can validate, failing closed when evidence cannot be bound.
- **Counts leave the prose.** "all ten skills" and "Current reusable agent
  skills" carried no information their sentences needed and go stale the moment
  a skill is added. The description-tier corpus figure is scoped to the suite as
  it stood when the corpus ran rather than asserting a current total.

Everything from `## Installation` down is unchanged. That material is accurate
and specific already; the gap was orientation before it, not the reference
material itself.

## Deliberately not claimed

`review-fix-loop` does not appear in the opening. It is standalone today and no
caller skill invokes it (#103–#105 track the migration), so describing
convergence-until-clean as part of the pipeline would overstate what actually
runs. The opening says the candidate is reviewed, not that findings are fixed.

## Verification

`just format`, `just lint-md`, `just lint-py`, and `just validate-plugins` clean.
`scripts/tests` 66 passing, including the README contract test that pins the
peer-composition section and seam table.
