### PR TITLE
feat(carve-changesets): delegate the per-changeset review and fix loop to review-fix-loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,44 @@ summary: Chronological history of repository and skill changes.
 
 # Changelog
 
-## 2026-08-07 — Migrated babysit-pr's post-publication repository review/fix loop to delegate to review-fix-loop under its update_pr publication policy
+## 2026-08-07 — Migrated carve-changesets' per-changeset review/fix loop and babysit-pr's post-publication review/fix loop to delegate to review-fix-loop, completing the design's caller-migration sequence
+
+- feat(carve-changesets): delegate the per-changeset review and fix loop to
+  review-fix-loop (issue #105) — replace phase 2's inlined "construct and run
+  the required `review-code-change` packet" step, and the successor-source
+  recovery procedure's "build fresh per-changeset review packets" step, with
+  delegation to repository-owned `review-fix-loop` under its `local_commit`
+  publication policy: one independent invocation per changeset, constructed and
+  resolved in chain order because changeset *i*'s comparison base is changeset
+  *i - 1*'s finalized branch. A new `references/review-fix-loop-handoff.md`
+  (mirroring the `implement-ticket`/ `babysit-pr` handoff pattern, adapted for a
+  chain) owns invocation construction —
+  `change_contract.allowed_remediation_scope` bounded to each changeset's own
+  extraction selectors so a fix cannot spill into a sibling changeset — the
+  caller-owned `reviewer`/`decide`/`apply_fix`/validation port policies
+  (including the chain-specific steered-reviewer risk: an earlier changeset
+  reviewing clean tempts a caller to tell the next reviewer the design is
+  already settled), and the `converged`/`changes_remaining`/`blocked`
+  terminal-result mapping. The published PR lifecycle keeps its existing
+  `babysit-pr` delegation unchanged: it already delegates its own post-fix
+  review to `review-fix-loop` under `update_pr` per #104, so no second migration
+  was needed there — the ticket's "each current remediation path has an explicit
+  delegate-or-retain decision" criterion is satisfied by documenting that
+  retention alongside the per-changeset delegation, in both `SPEC.md`'s
+  suite-seams section and the narrowed `references/suite-handoffs.md` (now
+  scoped to the PR-lifecycle and successor-recovery handoffs it retains).
+  `README.md`'s composed dependency diagram and `implement-ticket`'s own inline
+  copy of it are updated to match, the inline copy also picking up a stale line
+  PR #177 missed (`babysit-pr`'s post-fix step still named `review-code-change`
+  directly instead of the `review-fix-loop` delegation #104 actually shipped).
+  *Why:* the design's own migration ticket for this caller names an explicit
+  delegate-or-retain decision per remediation path, safe terminal-state mapping,
+  an unchanged PR watcher integration, no intermediate push before convergence,
+  and continued final-tree/ordered-stack equivalence as what the migration must
+  prove; `carve-changesets` has a deterministic forward-eval corpus but no
+  registered real-model executor, so both a `before` and an `after` summary are
+  recorded under `skills/carve-changesets/evals/results/` per `AGENTS.md`'s
+  eval-backed change norm.
 
 - feat(babysit-pr): delegate repository review and remediation to
   review-fix-loop (issue #104) — replace the inline "Revalidate and review every
@@ -48,7 +85,7 @@ summary: Chronological history of repository and skill changes.
   before the duplicated post-publication loop comes out; `babysit-pr` has no
   registered real-model or deterministic forward-eval corpus, so this evidence
   is recorded as an `attempted` gap per `AGENTS.md`'s eval-backed change norm
-  rather than a before/after run.
+  rather than a before/after run (da26dc3d9d90274890f86019dadff1010dfefe61)
 
 ## 2026-08-06 — Renamed the project from agent-scripts to compris across every identity it publishes, pointed the eval corpus's own citations at the renamed repository while leaving the absolute paths that record where each run actually happened untouched, and migrated implement-ticket's initial candidate review/fix loop to delegate to the now-complete review-fix-loop skill
 

--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ The skills:
   delegate each selected child to `implement-ticket`, then refresh graph state
   and verify separately authorized epic closeout
 - `skills/carve-changesets` — recompose a review-ready source branch into a
-  stateless chain, review each changeset through `review-code-change`, and
-  delegate each published PR lifecycle to `babysit-pr`
+  stateless chain, delegate each changeset's review and fix loop to
+  `review-fix-loop`, and delegate each published PR lifecycle to `babysit-pr`
 - `skills/review-code-change` — orchestrate the repository-owned review lenses
   into one evidence-bound, deduplicated verdict
 - `skills/review-correctness` — find material behavioral, security,
@@ -121,10 +121,9 @@ The skills:
   fast-forward-only Git push immediately after convergence). `implement-ticket`
   delegates its initial candidate's review and fix loop to it under
   `local_commit`; `babysit-pr` delegates its post-publication review and fix
-  loop to it under `update_pr`. `carve-changesets` still runs its own
-  per-changeset review loop directly against `review-code-change` — see
-  [issue #105](https://github.com/shaug/compris/issues/105) for that tracked
-  migration follow-up.
+  loop to it under `update_pr`; `carve-changesets` delegates each changeset's
+  local review and fix loop to it under `local_commit`, one invocation per
+  changeset in chain order.
 
 The composed implementation dependency chain is:
 
@@ -137,7 +136,8 @@ implement-epic
     │   └── review-fix-loop         # after a head-changing fix (update_pr)
     │       └── review-code-change  # each review pass inside the loop
     ├── carve-changesets            # authority-gated oversized path
-    │   ├── review-code-change      # each exact changeset
+    │   ├── review-fix-loop         # each changeset's review/fix/converge loop
+    │   │   └── review-code-change  # each review pass inside the loop
     │   └── babysit-pr              # each changeset PR lifecycle
     │       └── review-fix-loop     # after a head-changing fix (update_pr)
     │           └── review-code-change
@@ -145,7 +145,8 @@ implement-epic
     ┈▷ ready-ticket                 # recommendation only, never invoked
 
 carve-changesets
-├── review-code-change              # direct per-changeset review
+├── review-fix-loop                 # each changeset's review/fix/converge loop
+│   └── review-code-change          # each review pass inside the loop
 └── babysit-pr                      # each published PR lifecycle
     └── review-fix-loop             # after a head-changing fix (update_pr)
         └── review-code-change      # each review pass inside the loop

--- a/skills/carve-changesets/SKILL.md
+++ b/skills/carve-changesets/SKILL.md
@@ -13,9 +13,9 @@ fix changes an unmerged suffix after a prefix has merged, recover that suffix
 onto a distinct immutable successor source without rewriting the prefix.
 
 This skill owns decomposition, truth promotion, chain mechanics, whole-chain
-equivalence, and downstream propagation. It delegates per-changeset review to
-`review-code-change` and a published PR's lifecycle to `babysit-pr` without
-copying either skill's workflow.
+equivalence, and downstream propagation. It delegates each changeset's review
+and fix loop to `review-fix-loop` and a published PR's lifecycle to `babysit-pr`
+without copying either skill's workflow.
 
 ## Load the references
 
@@ -25,8 +25,12 @@ copying either skill's workflow.
   `.carve-changesets/plan.json`.
 - Read [the CLI reference](references/cli.md) before invoking a subcommand or
   selecting flags.
-- Read [the suite handoffs](references/suite-handoffs.md) before reviewing a
-  changeset, publishing PRs, or delegating a PR lifecycle.
+- Always read
+  [the review-fix-loop handoff](references/review-fix-loop-handoff.md) before
+  reviewing a changeset. It requires validating every `review-fix-loop` terminal
+  result against its own bundled contract and schemas before consuming it.
+- Read [the suite handoffs](references/suite-handoffs.md) before publishing PRs,
+  delegating a PR lifecycle, or recovering a successor suffix.
 
 Use `scripts/cli.py` as the single command surface. Resolve script and reference
 paths from this skill's root, not from a repository-relative installation
@@ -41,7 +45,9 @@ Require a runtime that can:
 - run Python 3 and separately approved repository validation commands;
 - reach GitHub over the network and use an authenticated `gh` session whenever
   publication, live PR state, review, merge, or propagation is in scope;
-- load repository-owned `review-code-change` for required per-changeset review;
+- load repository-owned `review-fix-loop` for required per-changeset review and
+  fix; its own dependency gate covers `review-code-change` and its lenses, so
+  this skill does not separately require it;
 - load repository-owned `babysit-pr` and retain task ownership while waiting
   whenever a published PR lifecycle is delegated; and
 - read current checks, reviews, comments, reactions, and resolved-thread state
@@ -127,25 +133,20 @@ commits. Run `validate-chain` with approved validation, `compare` for the
 reconstructed tree, and the applicable `squash-check` or `db-compare` evidence.
 Use `status --local-only` to inspect live local truth without GitHub.
 
-Construct and run the required `review-code-change` packet for every exact
-changeset candidate. The review suite is read-only; this skill applies accepted
-fixes and rebuilds invalidated validation and review evidence. Return
-`chain_ready` only after every local candidate and the full chain satisfy the
-contract.
-
-Each changeset's reviewer receives evidence and contracts, never conclusions. If
-the invocation being written steers the answer — "do not flag", "this is fine",
-a pre-judged severity, or the verdict expected back — stop and rewrite it. The
-pressure is specific to a chain: an earlier changeset reviewed clean, so it is
-tempting to tell the next reviewer the design is already settled. A steered
-reviewer returns confirmation, not review, and a chain compounds one such result
-across every changeset that follows.
-
-Give each changeset review a capability tier adequate for judgment: it inherits
-the session's tier by default rather than the cheapest one, and a review that
-missed a defect a later changeset surfaces escalates one tier instead of
-rerunning identically. Prefer one well-briefed review per changeset to several
-thin ones — a chain multiplies the cost of a rerun by its remaining length.
+Delegate each exact changeset candidate's review and fix loop to
+repository-owned `review-fix-loop` under `publication.policy: local_commit`,
+following [the review-fix-loop handoff](references/review-fix-loop-handoff.md).
+Review changesets in chain order: changeset *i*'s invocation is not constructed
+until changeset *i - 1*'s is `converged`, since *i*'s comparison base is *i -
+1*'s finalized branch. This skill still owns and constructs the `reviewer`,
+`decide`, `apply_fix`, and validation ports the handoff describes; delegation
+transfers judgment about findings and fix authorship for the remediation
+interval, not exclusive ownership of the branch. Treat any `review-fix-loop`
+dependency failure, invocation or terminal-result validation failure, or
+`blocked` result as a failed local gate exactly as a missing dependency or a
+`blocked` verdict was always treated. Return `chain_ready` only after every
+local candidate has a `converged` `review-fix-loop` result bound to its exact
+head and stacked base, and the full chain satisfies the contract.
 
 ### 3. Publish
 

--- a/skills/carve-changesets/evals/results/2026-08-07T195757Z-0007-before.json
+++ b/skills/carve-changesets/evals/results/2026-08-07T195757Z-0007-before.json
@@ -1,0 +1,164 @@
+{
+  "candidate": {
+    "branch": "scott/implement-ticket-105-4098f0",
+    "sha": "da26dc3d9d90274890f86019dadff1010dfefe61",
+    "worktree_clean": true
+  },
+  "case_evidence": {
+    "decompose-independent-subsystems": {
+      "actions": [
+        "split_by_subsystem"
+      ],
+      "executor_pid": 14572,
+      "target_skill": "carve-changesets",
+      "terminal_state": "plan_ready"
+    },
+    "mechanical-guardrail-exception": {
+      "actions": [
+        "accept_mechanical_exception",
+        "document_exception_evidence"
+      ],
+      "executor_pid": 14575,
+      "target_skill": "carve-changesets",
+      "terminal_state": "plan_ready"
+    },
+    "oversized-guardrail-negotiation": {
+      "actions": [
+        "request_guardrail_decision",
+        "stop_for_oversized_changeset"
+      ],
+      "executor_pid": 14574,
+      "target_skill": "carve-changesets",
+      "terminal_state": "blocked"
+    },
+    "publish-with-merge-withheld": {
+      "actions": [
+        "publish_without_merge",
+        "withhold_merge"
+      ],
+      "executor_pid": 14578,
+      "target_skill": "carve-changesets",
+      "terminal_state": "prs_open"
+    },
+    "recover-successor-suffix": {
+      "actions": [
+        "create_successor_lineage",
+        "invalidate_candidate_evidence",
+        "recover_owned_suffix_with_exact_lease",
+        "rehandoff_babysit_pr",
+        "verify_merged_prefix",
+        "verify_successor_equivalence"
+      ],
+      "executor_pid": 14581,
+      "target_skill": "carve-changesets",
+      "terminal_state": "all_merged"
+    },
+    "refuse-dirty-source": {
+      "actions": [
+        "diagnose_dirty_tree",
+        "refuse_dirty_source"
+      ],
+      "executor_pid": 14579,
+      "target_skill": "carve-changesets",
+      "terminal_state": "blocked"
+    },
+    "refuse-source-behind-base": {
+      "actions": [
+        "diagnose_source_behind_base",
+        "refuse_source_behind_base"
+      ],
+      "executor_pid": 14580,
+      "target_skill": "carve-changesets",
+      "terminal_state": "blocked"
+    },
+    "refuse-validated-reorder": {
+      "actions": [
+        "preserve_validated_order",
+        "refuse_reorder_or_renumber"
+      ],
+      "executor_pid": 14576,
+      "target_skill": "carve-changesets",
+      "terminal_state": "blocked"
+    },
+    "reject-conflicting-successor-lineage": {
+      "actions": [
+        "preserve_partial_chain",
+        "reject_conflicting_lineage",
+        "reject_unexpected_suffix_head"
+      ],
+      "executor_pid": 14584,
+      "target_skill": "carve-changesets",
+      "terminal_state": "blocked"
+    },
+    "reject-original-source-mutation": {
+      "actions": [
+        "reject_original_source_mutation",
+        "require_distinct_successor_source"
+      ],
+      "executor_pid": 14585,
+      "target_skill": "carve-changesets",
+      "terminal_state": "blocked"
+    },
+    "separate-mechanical-rename": {
+      "actions": [
+        "separate_rename_from_behavior"
+      ],
+      "executor_pid": 14573,
+      "target_skill": "carve-changesets",
+      "terminal_state": "plan_ready"
+    },
+    "validated-plan-conflict": {
+      "actions": [
+        "escalate_material_decision",
+        "stop_on_plan_conflict"
+      ],
+      "executor_pid": 14577,
+      "target_skill": "carve-changesets",
+      "terminal_state": "blocked"
+    }
+  },
+  "cases": {
+    "decompose-independent-subsystems": "pass",
+    "mechanical-guardrail-exception": "pass",
+    "oversized-guardrail-negotiation": "pass",
+    "publish-with-merge-withheld": "pass",
+    "recover-successor-suffix": "pass",
+    "refuse-dirty-source": "pass",
+    "refuse-source-behind-base": "pass",
+    "refuse-validated-reorder": "pass",
+    "reject-conflicting-successor-lineage": "pass",
+    "reject-original-source-mutation": "pass",
+    "separate-mechanical-rename": "pass",
+    "validated-plan-conflict": "pass"
+  },
+  "command": [
+    "/Users/scott/.local/share/mise/installs/python/3.11/bin/python3",
+    "skills/carve-changesets/scripts/evals/runner.py"
+  ],
+  "compared_to": "2026-08-05T014835Z-0006-after.json",
+  "diff": {
+    "newly_failing": [],
+    "newly_passing": [],
+    "still_failing": [],
+    "unchanged": 12
+  },
+  "exit_code": 0,
+  "failures": [],
+  "forward_evals": false,
+  "gap": "recorded tier is deterministic, so no model read the prose and the model-behavior evidence is absent No real-model executor is registered for this skill, so this tier is the only one available here.",
+  "limitation": null,
+  "note": null,
+  "output_tail": "{\n  \"failed\": 0,\n  \"failures\": [],\n  \"mode\": \"forward\",\n  \"passed\": 12,\n  \"total\": 12\n}",
+  "recorded_at": "2026-08-07T19:57:57Z",
+  "schema": "eval-run-summary/1",
+  "skill": "carve-changesets",
+  "stage": "before",
+  "status": "completed",
+  "suite": "forward",
+  "tier": "deterministic",
+  "totals": {
+    "failed": 0,
+    "passed": 12,
+    "total": 12
+  }
+}

--- a/skills/carve-changesets/evals/results/2026-08-07T201136Z-0008-after.json
+++ b/skills/carve-changesets/evals/results/2026-08-07T201136Z-0008-after.json
@@ -1,0 +1,164 @@
+{
+  "candidate": {
+    "branch": "scott/implement-ticket-105-4098f0",
+    "sha": "23d86f660067a86b0d62e776749ae602dee21a68",
+    "worktree_clean": true
+  },
+  "case_evidence": {
+    "decompose-independent-subsystems": {
+      "actions": [
+        "split_by_subsystem"
+      ],
+      "executor_pid": 46508,
+      "target_skill": "carve-changesets",
+      "terminal_state": "plan_ready"
+    },
+    "mechanical-guardrail-exception": {
+      "actions": [
+        "accept_mechanical_exception",
+        "document_exception_evidence"
+      ],
+      "executor_pid": 46511,
+      "target_skill": "carve-changesets",
+      "terminal_state": "plan_ready"
+    },
+    "oversized-guardrail-negotiation": {
+      "actions": [
+        "request_guardrail_decision",
+        "stop_for_oversized_changeset"
+      ],
+      "executor_pid": 46510,
+      "target_skill": "carve-changesets",
+      "terminal_state": "blocked"
+    },
+    "publish-with-merge-withheld": {
+      "actions": [
+        "publish_without_merge",
+        "withhold_merge"
+      ],
+      "executor_pid": 46514,
+      "target_skill": "carve-changesets",
+      "terminal_state": "prs_open"
+    },
+    "recover-successor-suffix": {
+      "actions": [
+        "create_successor_lineage",
+        "invalidate_candidate_evidence",
+        "recover_owned_suffix_with_exact_lease",
+        "rehandoff_babysit_pr",
+        "verify_merged_prefix",
+        "verify_successor_equivalence"
+      ],
+      "executor_pid": 46517,
+      "target_skill": "carve-changesets",
+      "terminal_state": "all_merged"
+    },
+    "refuse-dirty-source": {
+      "actions": [
+        "diagnose_dirty_tree",
+        "refuse_dirty_source"
+      ],
+      "executor_pid": 46515,
+      "target_skill": "carve-changesets",
+      "terminal_state": "blocked"
+    },
+    "refuse-source-behind-base": {
+      "actions": [
+        "diagnose_source_behind_base",
+        "refuse_source_behind_base"
+      ],
+      "executor_pid": 46516,
+      "target_skill": "carve-changesets",
+      "terminal_state": "blocked"
+    },
+    "refuse-validated-reorder": {
+      "actions": [
+        "preserve_validated_order",
+        "refuse_reorder_or_renumber"
+      ],
+      "executor_pid": 46512,
+      "target_skill": "carve-changesets",
+      "terminal_state": "blocked"
+    },
+    "reject-conflicting-successor-lineage": {
+      "actions": [
+        "preserve_partial_chain",
+        "reject_conflicting_lineage",
+        "reject_unexpected_suffix_head"
+      ],
+      "executor_pid": 46518,
+      "target_skill": "carve-changesets",
+      "terminal_state": "blocked"
+    },
+    "reject-original-source-mutation": {
+      "actions": [
+        "reject_original_source_mutation",
+        "require_distinct_successor_source"
+      ],
+      "executor_pid": 46519,
+      "target_skill": "carve-changesets",
+      "terminal_state": "blocked"
+    },
+    "separate-mechanical-rename": {
+      "actions": [
+        "separate_rename_from_behavior"
+      ],
+      "executor_pid": 46509,
+      "target_skill": "carve-changesets",
+      "terminal_state": "plan_ready"
+    },
+    "validated-plan-conflict": {
+      "actions": [
+        "escalate_material_decision",
+        "stop_on_plan_conflict"
+      ],
+      "executor_pid": 46513,
+      "target_skill": "carve-changesets",
+      "terminal_state": "blocked"
+    }
+  },
+  "cases": {
+    "decompose-independent-subsystems": "pass",
+    "mechanical-guardrail-exception": "pass",
+    "oversized-guardrail-negotiation": "pass",
+    "publish-with-merge-withheld": "pass",
+    "recover-successor-suffix": "pass",
+    "refuse-dirty-source": "pass",
+    "refuse-source-behind-base": "pass",
+    "refuse-validated-reorder": "pass",
+    "reject-conflicting-successor-lineage": "pass",
+    "reject-original-source-mutation": "pass",
+    "separate-mechanical-rename": "pass",
+    "validated-plan-conflict": "pass"
+  },
+  "command": [
+    "/Users/scott/.local/share/mise/installs/python/3.11/bin/python3",
+    "skills/carve-changesets/scripts/evals/runner.py"
+  ],
+  "compared_to": "2026-08-07T195757Z-0007-before.json",
+  "diff": {
+    "newly_failing": [],
+    "newly_passing": [],
+    "still_failing": [],
+    "unchanged": 12
+  },
+  "exit_code": 0,
+  "failures": [],
+  "forward_evals": false,
+  "gap": "recorded tier is deterministic, so no model read the prose and the model-behavior evidence is absent No real-model executor is registered for this skill, so this tier is the only one available here.",
+  "limitation": null,
+  "note": null,
+  "output_tail": "{\n  \"failed\": 0,\n  \"failures\": [],\n  \"mode\": \"forward\",\n  \"passed\": 12,\n  \"total\": 12\n}",
+  "recorded_at": "2026-08-07T20:11:36Z",
+  "schema": "eval-run-summary/1",
+  "skill": "carve-changesets",
+  "stage": "after",
+  "status": "completed",
+  "suite": "forward",
+  "tier": "deterministic",
+  "totals": {
+    "failed": 0,
+    "passed": 12,
+    "total": 12
+  }
+}

--- a/skills/carve-changesets/references/SPEC.md
+++ b/skills/carve-changesets/references/SPEC.md
@@ -401,7 +401,9 @@ The base branch must never be force-pushed under any authority.
 
 ### Suite seams
 
-The candidate packet, authority mapping, ownership transfer, and terminal-result
+The per-changeset review-fix-loop invocation is defined in
+[review-fix-loop-handoff.md](review-fix-loop-handoff.md). The PR-lifecycle
+candidate packet, authority mapping, ownership transfer, and terminal-result
 protocol are defined in [suite-handoffs.md](suite-handoffs.md).
 
 `carve-changesets` uniquely owns:
@@ -414,17 +416,21 @@ protocol are defined in [suite-handoffs.md](suite-handoffs.md).
 - downstream base updates and branch propagation after an upstream merge; and
 - successor-source lineage and corrected unmerged-suffix recovery.
 
-`review-code-change` is the repository-owned per-changeset review mechanism.
-Each invocation receives a raw candidate-bound packet for exactly one changeset,
-including its goal, non-goals, exact head and base, complete diff, repository
-instructions, named specifications, and validation evidence. `carve-changesets`
-consumes the returned verdict and applies accepted changes; the review suite
-remains read-only.
+`review-fix-loop` is the repository-owned per-changeset review-and-fix
+mechanism. Each invocation receives a raw candidate-bound change contract for
+exactly one changeset — its goal, non-goals, exact head and stacked base,
+complete diff, repository instructions, named specifications, and validation
+evidence — and owns that changeset's raw `review-code-change` packet
+construction, finding disposition, fix authorship, re-review, and convergence
+under `carve-changesets`'s caller-owned `reviewer`/`decide`/`apply_fix`/
+validation ports. `carve-changesets` consumes the returned terminal result; the
+underlying review suite remains read-only throughout.
 
 `babysit-pr` owns a published changeset PR's post-publication lifecycle when
 delegated. Its ownership includes current-head CI, published feedback,
-ticket-scoped fixes, post-fix repository review, base drift, mergeability, and
-optional merge under passed-through authority. `carve-changesets` must not run a
+ticket-scoped fixes, post-fix repository review (itself delegated to
+`review-fix-loop` under `update_pr`), base drift, mergeability, and optional
+merge under passed-through authority. `carve-changesets` must not run a
 competing watcher or feedback loop during that delegation. After a verified
 merge result returns, `carve-changesets` resumes ownership for chain rehydration
 and downstream propagation. When a ticket-scoped fix changes the head after an

--- a/skills/carve-changesets/references/review-fix-loop-handoff.md
+++ b/skills/carve-changesets/references/review-fix-loop-handoff.md
@@ -90,14 +90,18 @@ Map that evidence onto one `review-fix-loop` invocation:
   PR exists yet at this point in the workflow, so record
   `source_unavailable_reason` rather than a `source_binding` — this delegation
   never needs publication authority.
-- `change_contract`: goal and acceptance criteria derived from the changeset's
-  slug and description, with `pr_notes` preserving scaffolding, flags, and
-  intentional incompleteness, exactly as
+- `change_contract`: `goal` and `acceptance_criteria` derived from the
+  changeset's slug, description, and plan `pr_notes` (scaffolding, flags, and
+  intentional incompleteness); `non_goals` naming work reserved for later
+  changesets; `preserved_behaviors` naming the applicable invariants from
+  `SPEC.md`; `sources` naming applicable repository instructions, `SPEC.md`,
+  named architecture or design documents, and representative nearby patterns for
+  the files this changeset touches. Set `allowed_remediation_scope` to this
+  changeset's own extraction selectors and boundary — a fix cycle may not spill
+  into a sibling changeset's territory. This mirrors
   [the suite handoffs' per-changeset review packet](suite-handoffs.md#per-changeset-review-packet)
-  has always required; non-goals naming work reserved for later changesets;
-  preserved behaviors naming the applicable invariants from `SPEC.md`. Set
-  `allowed_remediation_scope` to this changeset's own extraction selectors and
-  boundary — a fix cycle may not spill into a sibling changeset's territory.
+  table's `change_contract` and `sources` rows, which describe the same content
+  for the `reviewer` port's own `review-code-change` packet.
 - `review_execution.mode`: `fresh_subagent` by default, matching this skill's
   existing fresh read-only review requirement. Use `in_agent_override` only
   through an explicit current-user or caller-authorized override recorded before
@@ -106,10 +110,15 @@ Map that evidence onto one `review-fix-loop` invocation:
   three-cycle norm used elsewhere in this suite. This is a distinct budget from
   `review-code-change`'s own three-cycle lens-sequence retry budget; neither
   touches the other.
-- `validation`: at least one focused and one full entry with exact commands and
-  results — focused evidence covers the chain prefix through changeset *i*; full
-  evidence records the approved repository or whole-chain validation applicable
-  at this boundary, exactly as the per-changeset review packet already required.
+- `validation`: at least one focused and one full `{name, command, scope}` entry
+  — commands only, matching `review-fix-loop`'s own invocation schema;
+  `review-fix-loop` itself runs them and produces the results. Focused evidence
+  covers the chain prefix through changeset *i*; full evidence names the
+  approved repository or whole-chain validation applicable at this boundary.
+  This is distinct from the `reviewer` port's own `review-code-change` packet,
+  whose `validation` row does carry exact commands and results, per
+  [the suite handoffs' per-changeset review packet](suite-handoffs.md#per-changeset-review-packet)
+  table.
 - `publication.policy`: always `local_commit`. Never supply
   `publication.pull_request` or `remote_iteration_grants` here — no PR exists
   yet, and this skill withholds every changeset's first remote push until

--- a/skills/carve-changesets/references/review-fix-loop-handoff.md
+++ b/skills/carve-changesets/references/review-fix-loop-handoff.md
@@ -1,0 +1,245 @@
+# Review-fix-loop handoff and result mapping
+
+Use repository-owned `review-fix-loop` as the sole canonical owner of one
+changeset's review, finding disposition, fix authorship orchestration,
+re-review, and convergence detection. Read its live skill,
+[`references/CONTRACT.md`](../../review-fix-loop/references/CONTRACT.md), and
+[`references/local-commit.md`](../../review-fix-loop/references/local-commit.md)
+before delegation. If its delivered contract differs materially from this
+boundary, stop and reconcile ownership rather than copying loop mechanics back
+into `carve-changesets`.
+
+This reference applies to every changeset's local review before publication —
+during "Materialize and prove equivalence" and again while rebuilding review
+evidence during successor-source recovery — always under
+`publication.policy: local_commit` — `review-fix-loop` never pushes on this
+skill's behalf. `babysit-pr`'s post-publication remediation loop is a separate,
+already-migrated consumer (delegated to `review-fix-loop` under `update_pr` per
+issue #104); this handoff does not apply to it, and `carve-changesets` never
+constructs that invocation itself. See [the suite handoffs](suite-handoffs.md)
+for the PR lifecycle and recovery handback this reference does not cover.
+
+## One invocation per changeset, in chain order
+
+A chain of *N* changesets is *N* independent `review-fix-loop` invocations, not
+one — `review-fix-loop` has no notion of a changeset stack, and this skill does
+not make it aware of one. Each invocation is bound to exactly one changeset
+branch and is locked, checkpointed, and resolved to a terminal result on its own
+before the next is constructed.
+
+Construct and resolve them in chain order: changeset *i*'s comparison base is
+changeset *i - 1*'s finalized branch (or the chain base for changeset 1), so
+changeset *i*'s invocation is not constructed until changeset *i - 1*'s review
+has returned `converged`. Reviewing out of order would bind a packet to a
+stacked base that has not finished changing.
+
+## Responsibility boundary
+
+`carve-changesets` retains decomposition analysis, plan authoring, chain branch
+creation and ordering, commit-trailer and PR-metadata stamping, each changeset's
+change-contract authored content (goal and acceptance criteria derived from the
+changeset's slug and description, non-goals naming work reserved for later
+changesets, preserved behaviors from `SPEC.md`'s applicable invariants, and
+`allowed_remediation_scope` bounded to that changeset's own extraction
+selectors), the validation commands it approves, invocation construction,
+host-port implementation (see below), terminal-result validation, whole-chain
+equivalence, downstream propagation, publication-path selection, the handoff to
+`babysit-pr`, and successor-source recovery mechanics.
+
+After delegation, `review-fix-loop` owns the local candidate lock for that one
+changeset, reviewer isolation and integrity enforcement, raw
+`review-code-change` packet construction and binding, finding selection and
+ordering, fix-cycle budget accounting, validated commit and fast-forward
+promotion of every accepted fix, evidence invalidation after each new head,
+convergence detection, and its own durable checkpoint and terminal result. Do
+not reproduce those mechanics in this skill.
+
+## Pre-mutation dependency gate
+
+Verify `review-fix-loop` by stable repository-owned name before materializing
+any changeset, per
+[the skill's own capability requirements](../SKILL.md#require-compatible-capabilities).
+`review-fix-loop`'s own dependency gate covers `review-code-change` and its
+three lenses; do not additionally require or substitute a direct
+`review-code-change` binding here. Missing `review-fix-loop` returns `blocked`
+before mutation; do not download an external implementation at runtime, restore
+a private inlined review loop, or accept an unreviewed candidate as ready.
+
+## Constructing the invocation
+
+Immediately before delegating changeset *i*, capture its exact committed head,
+its stacked comparison base (changeset *i - 1*'s branch, or the chain base for
+changeset 1), the complete diff from that base to the head, and
+tracked/staged/unstaged/untracked/ignored worktree state. The worktree must be
+globally clean and every intended change committed — `review-fix-loop`'s own
+invocation schema rejects anything else.
+
+Map that evidence onto one `review-fix-loop` invocation:
+
+- `repository`: exact repository identity and the stacked base branch — the
+  chain's base branch for changeset 1, otherwise changeset *i - 1*'s branch.
+- `candidate`: changeset *i*'s exact branch, head SHA, the stacked base as
+  `comparison_base`, the complete unified diff from that base to the head, and
+  the worktree state above, with `all_changes_committed: true`. No PR exists yet
+  at this point in the workflow, so record `source_unavailable_reason` rather
+  than a `source_binding` — this delegation never needs publication authority.
+- `change_contract`: goal and acceptance criteria derived from the changeset's
+  slug and description, with `pr_notes` preserving scaffolding, flags, and
+  intentional incompleteness, exactly as
+  [the suite handoffs' per-changeset review packet](suite-handoffs.md#per-changeset-review-packet)
+  has always required; non-goals naming work reserved for later changesets;
+  preserved behaviors naming the applicable invariants from `SPEC.md`. Set
+  `allowed_remediation_scope` to this changeset's own extraction selectors and
+  boundary — a fix cycle may not spill into a sibling changeset's territory.
+- `review_execution.mode`: `fresh_subagent` by default, matching this skill's
+  existing fresh read-only review requirement. Use `in_agent_override` only
+  through an explicit current-user or caller-authorized override recorded before
+  delegation; there is no automatic fallback.
+- `fix_cycle_budget.max_fix_cycles`: `3`, matching the repository's existing
+  three-cycle norm used elsewhere in this suite. This is a distinct budget from
+  `review-code-change`'s own three-cycle lens-sequence retry budget; neither
+  touches the other.
+- `validation`: at least one focused and one full entry with exact commands and
+  results — focused evidence covers the chain prefix through changeset *i*; full
+  evidence records the approved repository or whole-chain validation applicable
+  at this boundary, exactly as the per-changeset review packet already required.
+- `publication.policy`: always `local_commit`. Never supply
+  `publication.pull_request` or `remote_iteration_grants` here — no PR exists
+  yet, and this skill withholds every changeset's first remote push until
+  [phase 3, Publish](../SKILL.md#3-publish).
+
+Author the change contract's goal, acceptance criteria, non-goals, and preserved
+behaviors as neutral evidence, never as a pre-judged verdict —
+`review-fix-loop`'s `reviewer` port passes them straight into its own
+`review-code-change` packet, so steering language here steers that review
+exactly as it would have before delegation.
+
+## Host ports remain caller-owned
+
+`review-fix-loop`'s engine is dependency-free: it cannot itself spawn a review
+subagent, write a fix's content, or judge whether a finding is genuinely
+tractable and in scope. Supply its `reviewer`, `decide`, `apply_fix`, and
+validation ports yourself, exactly as
+[`local-commit.md`](../../review-fix-loop/references/local-commit.md)'s "Host
+boundary: the three ports" section describes:
+
+- **`reviewer`**: spawn a fresh read-only context restricted to
+  `Read, Grep, Glob, Bash, Agent, Task, Skill` that invokes repository-owned
+  `review-code-change` with raw candidate evidence only — excluding the plan,
+  the implementation transcript, prior conclusions, and suspected findings. Each
+  changeset's reviewer receives evidence and contracts, never conclusions. If
+  the invocation being written steers the answer — "do not flag", "this is
+  fine", a pre-judged severity, or the verdict expected back — stop and rewrite
+  it. The pressure is specific to a chain: an earlier changeset reviewed clean,
+  so it is tempting to tell the next reviewer the design is already settled. A
+  steered reviewer returns confirmation, not review, and a chain compounds one
+  such result across every changeset that follows.
+
+  Give each changeset review a capability tier adequate for judgment: it
+  inherits the session's tier by default rather than the cheapest one, and a
+  review that missed a defect a later changeset surfaces escalates one tier
+  instead of rerunning identically. Prefer one well-briefed review per changeset
+  to several thin ones — a chain multiplies the cost of a rerun by its remaining
+  length.
+
+- **`decide`**: apply
+  [the consumption disciplines](review-suite/consumption-disciplines.md) to
+  every finding `review-fix-loop` selects — verify it against the codebase
+  before implementing it, clarify every unclear finding before implementing any,
+  never perform agreement, and accept only a finding that is material and within
+  `change_contract.allowed_remediation_scope`. A finding whose correct fix would
+  exceed that changeset's own boundary — spilling into a sibling changeset's
+  territory — is not this changeset's to absorb: return `expands_scope` and let
+  `review-fix-loop` stop as `blocked/scope_decision_required`, surfacing it for
+  this skill to disposition (typically a plan revision) rather than silently
+  widening the changeset.
+
+- **`apply_fix`**: implement the smallest coherent accepted remediation, within
+  this changeset's own boundary. When this port is about to consume the
+  invocation's final remaining cycle, replace the incumbent implementer rather
+  than continuing it: dispatch a fresh context one capability tier above the
+  incumbent's, or a fresh context at the same tier when no higher tier is
+  available in the session, briefed with the surviving finding and a summary of
+  what prior attempts tried and why they failed, not the full transcript. This
+  is a caller-supplied policy layered onto the port — `review-fix-loop`'s own
+  engine has no escalation mechanic and needs none for this to work. When a fix
+  fails repeatedly and `superpowers:systematic-debugging` is available in the
+  session skill listing, load it as the escalated implementer's recommended
+  diagnosis method; when the peer is not in the listing, the escalated
+  implementer diagnoses from logs and evidence without comment.
+
+- **validation ports**: run this changeset's separately approved focused and
+  full validation commands and classify a candidate-attributable failure as
+  tractable remediation input exactly as
+  [phase 2](../SKILL.md#2-materialize-and-prove-equivalence) already requires.
+
+## Resuming an interrupted invocation
+
+`review-fix-loop` resumes from live repository and checkpoint state without
+requiring an uninterrupted transcript. Before constructing a new invocation for
+changeset *i*, check for an existing durable checkpoint under
+`<git-common-directory>/review-fix-loop/checkpoints/` — keyed by Git common
+directory and candidate identity, so each changeset's checkpoint is independent
+of its siblings' and survives independently of any one worktree's lifetime:
+
+- If one exists for this exact repository, changeset branch, and candidate
+  identity, reconcile and resume it rather than starting a fresh invocation,
+  keeping its original `invocation_id` and fix-cycle budget. A reconciliation
+  failure (an active lock holder, a dirty candidate, or a live head/base that
+  cannot be reconciled with the checkpoint) is `blocked/checkpoint_mismatch` or
+  `blocked/candidate_busy` — preserve the checkpoint and candidate for
+  inspection rather than discarding it.
+- If none exists — including when a changeset's materialization happened in an
+  earlier, unrelated session — construct a fresh invocation from live repository
+  state alone, bound to that changeset's exact current head and stacked
+  comparison base. A resumed chain may find some changesets already `converged`
+  (nothing to do but verify) and others with no checkpoint at all (start fresh);
+  handle each independently in chain order.
+
+## Terminal result mapping
+
+Validate the returned terminal result against `review-fix-loop`'s own schema and
+reread live Git state before mapping:
+
+- `converged` ends this changeset's review. The final head and stacked base are
+  clean, required validation passed, and `write_isolation` was `enforced`
+  throughout. Continue to changeset *i + 1*'s invocation, or to `chain_ready`
+  when *i* was the last changeset. Do not invoke an additional invented review
+  cycle once a schema-valid `converged` result is already bound to the current
+  head and base.
+- `changes_remaining` maps to `blocked`. Preserve every already-`converged`
+  changeset's evidence and this changeset's local candidate — every commit
+  `review-fix-loop` made remains locally committed and is reported in
+  `unpushed_commits`. Report the exact `reason` (`cycle_budget_exhausted`,
+  `oscillation`, `expanding_findings`, `repeated_failed_attempt`, or
+  `current_candidate_validation_failure` — `repeated_finding` is in
+  `review-fix-loop`'s general schema but is deliberately never one of
+  `local_commit`'s own automatic stop reasons, per its own
+  [`local-commit.md`](../../review-fix-loop/references/local-commit.md)),
+  `unresolved_or_deferred_findings`, and `operator_action` as the blocking
+  evidence and next action.
+- `blocked` maps to `blocked` with the exact reason, current changeset
+  candidate, and `operator_action`. `missing_capability` and
+  `reviewer_integrity_failure` fold into this skill's existing "treat as a
+  failed local gate" rule for a missing dependency or reviewer mutation.
+  `scope_decision_required` and `operator_input_required` fold into this skill's
+  existing stop condition for a proposed changeset that cannot remain cohesive
+  or independently understandable — a finding that cannot be resolved inside one
+  changeset's boundary is evidence the plan itself needs revision.
+  `remote_advanced` and `publication_failed` never apply under `local_commit`
+  and indicate a contract violation if returned.
+
+Never translate a stale, malformed, or invocation-mismatched terminal result
+into `converged`. Read `review_records` and `unresolved_or_deferred_findings`
+directly from the terminal result for the per-cycle finding history; do not
+reconstruct a separate resolved/unresolved/superseded ledger on top of it —
+`review-fix-loop` already binds every review pass and disposition to the exact
+head that produced it.
+
+## Forward evaluation integrity
+
+Exercise this composition with raw live-shaped candidate, change-contract, and
+validation artifacts. Exclude the plan, implementation transcripts, intended
+fixes, expected outputs, suspected findings, and prior conclusions. Treat
+contaminated evidence as invalid and rerun the evaluation with a fresh isolated
+reviewer or worker context.

--- a/skills/carve-changesets/references/review-fix-loop-handoff.md
+++ b/skills/carve-changesets/references/review-fix-loop-handoff.md
@@ -76,13 +76,20 @@ invocation schema rejects anything else.
 
 Map that evidence onto one `review-fix-loop` invocation:
 
-- `repository`: exact repository identity and the stacked base branch — the
-  chain's base branch for changeset 1, otherwise changeset *i - 1*'s branch.
+- `repository`: `identity` and `git_common_directory` only — `review-fix-loop`'s
+  invocation-level `repository` has no field for a base branch. The stacked base
+  (changeset *i - 1*'s branch, or the chain base for changeset 1) is carried by
+  `candidate.comparison_base` below, and separately by the `reviewer` port's own
+  `review-code-change` packet, whose own `repository.base_branch` field is
+  exactly
+  [the suite handoffs' per-changeset review packet](suite-handoffs.md#per-changeset-review-packet)
+  table's `repository` row — a different schema than this invocation's.
 - `candidate`: changeset *i*'s exact branch, head SHA, the stacked base as
-  `comparison_base`, the complete unified diff from that base to the head, and
-  the worktree state above, with `all_changes_committed: true`. No PR exists yet
-  at this point in the workflow, so record `source_unavailable_reason` rather
-  than a `source_binding` — this delegation never needs publication authority.
+  `comparison_base` (`{ref, sha}`), the complete unified diff from that base to
+  the head, and the worktree state above, with `all_changes_committed: true`. No
+  PR exists yet at this point in the workflow, so record
+  `source_unavailable_reason` rather than a `source_binding` — this delegation
+  never needs publication authority.
 - `change_contract`: goal and acceptance criteria derived from the changeset's
   slug and description, with `pr_notes` preserving scaffolding, flags, and
   intentional incompleteness, exactly as

--- a/skills/carve-changesets/references/suite-handoffs.md
+++ b/skills/carve-changesets/references/suite-handoffs.md
@@ -1,22 +1,28 @@
-# Per-changeset review and PR lifecycle handoffs
+# PR lifecycle and successor-source recovery handoffs
 
 This reference defines how `carve-changesets` composes with the repository-owned
-`review-code-change` and `babysit-pr` skills. The normative changeset state,
-authority, and safety rules remain in [SPEC.md](SPEC.md). The delegated skills'
-live contracts remain authoritative for their internal behavior.
+`babysit-pr` skill for a published PR's lifecycle, and the successor-source
+recovery procedure that follows a returned handback. The normative changeset
+state, authority, and safety rules remain in [SPEC.md](SPEC.md). Each
+changeset's own local review and fix loop is delegated to `review-fix-loop`
+instead — see [the review-fix-loop handoff](review-fix-loop-handoff.md) for that
+composition, including the per-changeset review packet fields it feeds into
+`review-fix-loop`'s `reviewer` port. The delegated skills' live contracts remain
+authoritative for their internal behavior.
 
 ## Ownership boundaries
 
 `carve-changesets` owns changeset boundaries, materialization, chain ordering,
 metadata, whole-chain equivalence, and downstream propagation. It constructs
-review and PR-lifecycle handoffs, applies accepted review fixes, and verifies
-returned identities before promoting chain state.
+each changeset's `review-fix-loop` invocation and the published PR-lifecycle
+handoff, and verifies returned identities before promoting chain state.
 
-`review-code-change` is read-only. It reviews one exact changeset candidate and
-returns an evidence-bound verdict; it does not edit a changeset, choose a new
-boundary, mutate the plan, or push a branch. `carve-changesets` owns any
-accepted fix and must rebuild invalidated validation and review evidence
-afterward.
+`review-code-change` remains read-only underneath `review-fix-loop`: it reviews
+one exact changeset candidate and returns an evidence-bound verdict; it does not
+edit a changeset, choose a new boundary, mutate the plan, or push a branch.
+`review-fix-loop` owns applying an accepted fix and rebuilding invalidated
+validation and review evidence within one changeset's local review loop;
+`carve-changesets` never reproduces that mechanic itself.
 
 Once ownership of a published PR is delegated, `babysit-pr` exclusively owns
 that PR's current-head CI, failed-check diagnosis and eligible retries,
@@ -33,9 +39,11 @@ again.
 
 ## Per-changeset review packet
 
-Construct a fresh `review-code-change` packet for changeset *i* from raw,
-current evidence. Never add the implementation transcript, expected findings,
-prior conclusions, or fixture answers.
+[The review-fix-loop handoff](review-fix-loop-handoff.md)'s `reviewer` port
+constructs a fresh `review-code-change` packet for changeset *i* from raw,
+current evidence for every review pass that invocation runs. Never add the
+implementation transcript, expected findings, prior conclusions, or fixture
+answers.
 
 | Packet section    | Changeset evidence                                                                                                                                                                                                                                                                                                               |
 | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -51,11 +59,12 @@ particular, the diff is complete and candidate-bound, acceptance criteria are
 non-empty, and every required validation command has an exact result or an
 explicit unavailable reason.
 
-Review is required before claiming `chain_ready` or `prs_open`, and the result
-must be clean for every exact changeset candidate represented by that terminal
-state. It is also required before a published candidate is handed to
-`babysit-pr` when no current clean result exists. Any changeset head change
-invalidates its packet, validation, and verdict; rebuild all three before
+Review is required before claiming `chain_ready` or `prs_open`, and the
+`review-fix-loop` result must be `converged` for every exact changeset candidate
+represented by that terminal state. It is also required before a published
+candidate is handed to `babysit-pr` when no current `converged` result exists.
+Any changeset head change invalidates its packet, validation, and verdict;
+rebuild all three through a fresh `review-fix-loop` invocation before
 continuing.
 
 For base-only drift, retain review evidence only when the review-suite contract
@@ -124,8 +133,9 @@ successor source containing all accepted fixes, then:
 4. prove current base plus the recovered suffix equals the successor source;
 5. invalidate every candidate-bound validation, review, CI, connector, feedback,
    and mergeability result for each changed head;
-6. build fresh per-changeset review packets and obtain clean exact-head review;
-   and
+6. delegate a fresh `review-fix-loop` invocation for each recovered changeset,
+   per [the review-fix-loop handoff](review-fix-loop-handoff.md), and obtain a
+   `converged` result bound to the exact recovered head; and
 7. hand the corrected exact PR back to `babysit-pr` under the original bounded
    authority.
 
@@ -150,6 +160,6 @@ evidence must match the handoff. A stale or conflicting result maps to
 
 When propagation changes a downstream head or effective candidate, prior review,
 validation, CI, and feedback evidence is invalid. Rebuild the per-changeset
-packet before the next lifecycle handoff. When only the stacked base identity
-changes, apply the review-suite base-drift rules rather than assuming evidence
-survives.
+review through a fresh `review-fix-loop` invocation before the next lifecycle
+handoff. When only the stacked base identity changes, apply the review-suite
+base-drift rules rather than assuming evidence survives.

--- a/skills/carve-changesets/scripts/recovery.py
+++ b/skills/carve-changesets/scripts/recovery.py
@@ -456,7 +456,7 @@ def recover_suffix_from_live(
         detail = "; ".join(f"{item.code}: {item.message}" for item in validation.errors)
         raise CommandError(f"Recovered live chain validation failed: {detail}")
     print(
-        "[EVIDENCE-INVALIDATED] Rebuild validation, review-code-change, CI, "
+        "[EVIDENCE-INVALIDATED] Rebuild validation, review-fix-loop, CI, "
         "connector, feedback, and thread evidence for every recovered head."
     )
     print("[OK] Suffix recovery completed and matches the immutable successor source.")

--- a/skills/carve-changesets/scripts/tests/test_skill_contract.py
+++ b/skills/carve-changesets/scripts/tests/test_skill_contract.py
@@ -22,6 +22,12 @@ class CarveChangesetsContractTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.skill = compact((SKILL_ROOT / "SKILL.md").read_text())
+        cls.handoff = compact(
+            (SKILL_ROOT / "references" / "review-fix-loop-handoff.md").read_text()
+        )
+        cls.suite_handoffs = compact(
+            (SKILL_ROOT / "references" / "suite-handoffs.md").read_text()
+        )
 
     def test_review_communication_references_the_bundled_disciplines(self):
         self.assertIn("consumption-disciplines.md", self.skill)
@@ -36,16 +42,51 @@ class CarveChangesetsContractTests(unittest.TestCase):
         ):
             self.assertIn(discipline, self.skill)
 
+    def test_skill_delegates_the_per_changeset_review_and_fix_loop(self):
+        self.assertIn("review-fix-loop", self.skill)
+        self.assertIn("publication.policy: local_commit", self.skill)
+        self.assertIn("review-fix-loop-handoff.md", self.skill)
+        self.assertNotIn(
+            "Construct and run the required `review-code-change`", self.skill
+        )
+
     def test_changeset_review_dispatch_carries_integrity_tier_and_turn_count(self):
-        self.assertIn("receives evidence and contracts, never conclusions", self.skill)
-        self.assertIn("stop and rewrite it", self.skill)
-        self.assertIn("returns confirmation, not review", self.skill)
-        self.assertIn("capability tier adequate for judgment", self.skill)
-        self.assertIn("Prefer one well-briefed review per changeset", self.skill)
+        self.assertIn(
+            "receives evidence and contracts, never conclusions", self.handoff
+        )
+        self.assertIn("stop and rewrite it", self.handoff)
+        self.assertIn("returns confirmation, not review", self.handoff)
+        self.assertIn("capability tier adequate for judgment", self.handoff)
+        self.assertIn("Prefer one well-briefed review per changeset", self.handoff)
+
+    def test_handoff_sequences_invocations_in_chain_order(self):
+        self.assertIn("One invocation per changeset, in chain order", self.handoff)
+        self.assertIn(
+            "changeset *i*'s invocation is not constructed until changeset *i - 1*'s",
+            self.handoff,
+        )
+
+    def test_handoff_maps_every_terminal_state(self):
+        for state in ("converged", "changes_remaining", "blocked"):
+            self.assertIn(f"`{state}`", self.handoff)
+        for reason in (
+            "cycle_budget_exhausted",
+            "scope_decision_required",
+            "reviewer_integrity_failure",
+        ):
+            self.assertIn(reason, self.handoff)
+
+    def test_published_pr_lifecycle_is_unchanged_and_retained(self):
+        self.assertIn("babysit-pr", self.suite_handoffs)
+        self.assertIn("must not run a", self.suite_handoffs)
+        self.assertNotIn(
+            "review-code-change` and `babysit-pr` skills", self.suite_handoffs
+        )
 
     def test_tier_guidance_names_no_product_or_model(self):
         for banned in ("gpt", "claude-", "opus", "sonnet", "haiku", "gemini"):
             self.assertNotIn(banned, self.skill.lower())
+            self.assertNotIn(banned, self.handoff.lower())
 
     def test_the_bundled_copy_exists(self):
         self.assertTrue(

--- a/skills/implement-epic/SKILL.md
+++ b/skills/implement-epic/SKILL.md
@@ -48,12 +48,14 @@ A compatible agentic runtime must be able to:
   taking ownership of local review.
 
 The portable dependency chain is `implement-epic` → `implement-ticket` →
-(`review-code-change`, `babysit-pr`, `carve-changesets`), with
-`carve-changesets` → `babysit-pr` per changeset and `babysit-pr` →
-`review-code-change` after a head-changing fix. Verify `implement-ticket`
-directly and require its result to prove that its own dependencies and
-applicable capabilities were available. Do not make this skill invoke
-`review-code-change`, `babysit-pr`, or `carve-changesets` itself.
+(`review-fix-loop`, `babysit-pr`, `carve-changesets`), with `carve-changesets` →
+(`review-fix-loop` per changeset, `babysit-pr` per changeset PR) and
+`babysit-pr` → `review-fix-loop` after a head-changing fix; `review-fix-loop`
+and `review-code-change` sit underneath every one of those edges. Verify
+`implement-ticket` directly and require its result to prove that its own
+dependencies and applicable capabilities were available. Do not make this skill
+invoke `review-fix-loop`, `review-code-change`, `babysit-pr`, or
+`carve-changesets` itself.
 
 Stop before child mutation with an explicit limitation when an applicable
 capability or dependency is unavailable. Product-specific discovery metadata

--- a/skills/implement-epic/scripts/tests/test_orchestration_contract.py
+++ b/skills/implement-epic/scripts/tests/test_orchestration_contract.py
@@ -67,12 +67,12 @@ class ImplementEpicContractTests(unittest.TestCase):
     def test_dependency_chain_is_stable_and_acyclic(self):
         self.assertIn(
             "`implement-epic` → `implement-ticket` → "
-            "(`review-code-change`, `babysit-pr`, `carve-changesets`)",
+            "(`review-fix-loop`, `babysit-pr`, `carve-changesets`)",
             self.contract,
         )
         self.assertIn(
-            "Do not make this skill invoke `review-code-change`, `babysit-pr`, or "
-            "`carve-changesets` itself",
+            "Do not make this skill invoke `review-fix-loop`, "
+            "`review-code-change`, `babysit-pr`, or `carve-changesets` itself",
             self.contract,
         )
         self.assertIn("never recursively invoke this skill", self.contract)

--- a/skills/implement-ticket/SKILL.md
+++ b/skills/implement-ticket/SKILL.md
@@ -272,11 +272,14 @@ implement-epic
     ├── review-fix-loop             # initial candidate review/fix/converge loop
     │   └── review-code-change      # each review pass inside the loop
     ├── babysit-pr                  # ordinary single-PR lifecycle
-    │   └── review-code-change      # after a head-changing fix
+    │   └── review-fix-loop         # after a head-changing fix (update_pr)
+    │       └── review-code-change  # each review pass inside the loop
     ├── carve-changesets            # authority-gated oversized path
-    │   ├── review-code-change      # each exact changeset
+    │   ├── review-fix-loop         # each changeset's review/fix/converge loop
+    │   │   └── review-code-change  # each review pass inside the loop
     │   └── babysit-pr              # each changeset PR lifecycle
-    │       └── review-code-change  # after a head-changing fix
+    │       └── review-fix-loop     # after a head-changing fix (update_pr)
+    │           └── review-code-change
     ┊
     ┈▷ ready-ticket                 # recommendation only, never invoked
 ```

--- a/skills/implement-ticket/references/review-fix-loop-handoff.md
+++ b/skills/implement-ticket/references/review-fix-loop-handoff.md
@@ -12,9 +12,11 @@ into `implement-ticket`.
 This reference applies only to the initial candidate, before any publication
 path is selected, and always under `publication.policy: local_commit` —
 `review-fix-loop` never pushes on this skill's behalf. `babysit-pr`'s
-post-publication remediation loop and `carve-changesets`'s per-changeset review
-are separate, unmigrated consumers of repository-owned `review-code-change`;
-this handoff does not apply to either.
+post-publication remediation loop (under `update_pr`, per issue #104) and
+`carve-changesets`'s per-changeset review (under `local_commit`, one invocation
+per changeset, per issue #105) are separate, differently-scoped
+`review-fix-loop` consumers with their own handoffs; this handoff does not apply
+to either.
 
 ## Responsibility boundary
 


### PR DESCRIPTION
## Summary

Migrates `carve-changesets`'s per-changeset local review/fix loop to delegate to the repository's standalone `review-fix-loop` skill under its `local_commit` publication policy — one independent invocation per changeset, constructed and resolved in chain order (changeset *i*'s comparison base is changeset *i - 1*'s finalized branch, so *i*'s invocation is not constructed until *i - 1*'s has returned `converged`). This completes the fast-follow migration sequence the `review-fix-loop` design named: `implement-ticket` (#103), `babysit-pr` (#104), and now `carve-changesets` (#105).

## Delegate-or-retain decision per remediation path

- **Per-changeset local review** (during "Materialize and prove equivalence" and again during successor-source recovery): **delegated**. New [`references/review-fix-loop-handoff.md`](skills/carve-changesets/references/review-fix-loop-handoff.md) owns invocation construction, the caller-owned `reviewer`/`decide`/`apply_fix`/validation ports, and the `converged`/`changes_remaining`/`blocked` terminal-result mapping.
- **Published PR post-publication review**: **retained unchanged**. `babysit-pr` already delegates its own post-fix review to `review-fix-loop` under `update_pr` (#104/PR #177) — no second migration needed. This retention is now documented explicitly in `SPEC.md`'s suite-seams section and the narrowed `references/suite-handoffs.md` (now scoped to the PR-lifecycle and successor-recovery handoffs it retains), rather than left implicit.

## Review

Ran the repository's own bounded review/fix loop manually via independent, fresh `review-code-change` cycles (this candidate predates the very delegation it implements, so it could not review itself via `review-fix-loop`):

- Cycle 1: 1 blocking + 1 strong-recommendation finding — the new handoff doc's invocation-construction table put the stacked base branch in the invocation's top-level `repository` field (actually `{identity, git_common_directory}` only), and `implement-epic/SKILL.md`'s dependency-chain sentence was stale (no `review-fix-loop` mention at all). Fixed.
- Cycle 2: 1 strong-recommendation finding — `implement-ticket/references/review-fix-loop-handoff.md`'s disclaimer still called babysit-pr's and carve-changesets's consumption "unmigrated." Fixed.
- Cycle 3: 1 strong-recommendation finding — `scripts/recovery.py`'s terminal message still named `review-code-change` for the evidence category the rewritten recovery step now delegates to `review-fix-loop`. Fixed (by a fresh, differently-scoped implementer, since this consumed the final cycle in the loop's 3-cycle budget).
- Cycle 4 (post-budget deep-check): 1 blocking finding — the same handoff doc's `validation` and `change_contract` bullets had two more schema-mapping errors (commands-vs-results confusion; a nonexistent `pr_notes` invocation field). Fixed directly, since shipping a schema-breaking error in this PR's own primary deliverable doc would be actively harmful regardless of nominal cycle count.
- Cycle 5 (clean): aggregate `clean` across all three lenses, with every invocation-schema field mapping independently re-verified against the real `invocation.schema.json`.

## Non-goals (per ticket)

- Reworking the changeset carving algorithm.
- Making `review-fix-loop` aware of changeset stacks — `carve-changesets` still owns chain ordering and sequences invocations itself.

## Eval evidence

`carve-changesets` has a deterministic forward-eval corpus but no registered real-model executor. Both a `before` and an `after` summary are recorded under `skills/carve-changesets/evals/results/` per `AGENTS.md`'s eval-backed change norm: 12/12 forward cases pass in both, 0 newly failing.

## Validation

- `just format` / `just lint` / `just test` all pass on the final head.
- `just eval-carve-changesets` — integration self-test 3/3, forward corpus 12/12.

Fixes #105
