### PR TITLE
feat: add version-bump tooling, release notes, and a documented release process

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,6 +6,7 @@
   "plugins": [
     {
       "name": "compris",
+      "version": "0.1.1",
       "source": {
         "source": "local",
         "path": "./"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,6 +9,7 @@
   "plugins": [
     {
       "name": "compris",
+      "version": "0.1.1",
       "source": "./",
       "description": "Implementation, code-review, PR-lifecycle, and changeset workflows that install and run together."
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "compris",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "For when the planning is done, and the work begins. Installs the complete compris implementation, review, PR-lifecycle, and changeset skill suite.",
   "author": {
     "name": "shaug"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "compris",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "For when the planning is done, and the work begins. Installs the complete compris implementation, review, PR-lifecycle, and changeset skill suite.",
   "author": {
     "name": "shaug",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,12 @@ said. Neither satisfies the other.
 
 - Changelog: format new entries as `<commit title>`.
 
+- Release process: [`docs/release-process.md`](docs/release-process.md)
+  documents how a tagged release is prepared and cut, including the four version
+  surfaces `scripts/validate_plugins.py` keeps in sync and operator-only tagging
+  authority. `RELEASE-NOTES.md` is the narrative release history — distinct from
+  `CHANGELOG.md`'s daily journal above.
+
 - Avoid shell interpolation in commit and PR messages. Always write the full
   message to a temporary file and use file-based flags instead of inline `-m`
   strings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,37 @@ summary: Chronological history of repository and skill changes.
 
 # Changelog
 
-## 2026-08-08 — Hardened implement-ticket's own worktree isolation mechanics
+## 2026-08-08 — Hardened implement-ticket's own worktree isolation mechanics, then added version-bump tooling, release notes, and a documented release process
+
+- feat: add version-bump tooling, cross-manifest drift detection, narrative
+  release notes, and a documented release process (issue #138, epic #121) —
+  `scripts/bump_version.py` is the only tool that should change any of the four
+  version surfaces (`.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`,
+  `.claude-plugin/marketplace.json`, `.agents/plugins/marketplace.json`; the two
+  marketplace catalogs previously carried no version at all). It reads the
+  current version from the two plugin manifests, computes a
+  `--bump major|minor|patch` or explicit `--to` target, and writes all four in
+  one pass, restoring already-written surfaces if a later write fails so a
+  partial bump never lands. `scripts/validate_plugins.py`'s existing
+  Claude/Codex plugin-version match check (already wired into `just lint`) is
+  extended to require a valid semver on both marketplace catalogs' plugin
+  entries too and to reject drift across all four, not just the original two.
+  `RELEASE-NOTES.md` is new: the narrative history of tagged releases (what
+  changed, why, evidence — distinct from this file's daily commit journal), with
+  its format documented at the top of the file. `docs/release-process.md`
+  documents the version-surface table, the bump-script usage, and that cutting
+  the git tag and GitHub release is reserved for the operator — preparing a
+  release is ordinary PR-completion authority, cutting it is not, and no
+  automation in the repository performs that step. `AGENTS.md`'s Git Workflow
+  section gets a pointer to the new doc. The ticket's own acceptance criterion
+  for a recorded dry run is this change's real diff:
+  `python3 scripts/bump_version.py --bump patch` was run for real on this
+  branch, bumping every surface from `0.1.0` to `0.1.1` (seeding the two
+  marketplace catalogs' version field for the first time in the same pass), with
+  `just lint` and `just test` green at the resulting head and no git tag cut —
+  recorded as the first `RELEASE-NOTES.md` entry. Cutting the first real tagged
+  release stays a separate, explicit operator action; this ticket's non-goals
+  explicitly exclude it.
 
 - feat(implement-ticket): harden worktree isolation mechanics (issue #134, epic
   #119) — implement-ticket's own "Create exclusive implementation state" step
@@ -75,36 +105,6 @@ summary: Chronological history of repository and skill changes.
   Recorded as corpus noise rather than a candidate defect, per the ticket's own
   guidance against chasing single-sample real-model variance.
   (e509ab51491b044be981246985b635a99ff29026)
-
-- feat: add version-bump tooling, cross-manifest drift detection, narrative
-  release notes, and a documented release process (issue #138, epic #121) —
-  `scripts/bump_version.py` is the only tool that should change any of the four
-  version surfaces (`.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`,
-  `.claude-plugin/marketplace.json`, `.agents/plugins/marketplace.json`; the two
-  marketplace catalogs previously carried no version at all). It reads the
-  current version from the two plugin manifests, computes a
-  `--bump major|minor|patch` or explicit `--to` target, and writes all four in
-  one pass, restoring already-written surfaces if a later write fails so a
-  partial bump never lands. `scripts/validate_plugins.py`'s existing
-  Claude/Codex plugin-version match check (already wired into `just lint`) is
-  extended to require a valid semver on both marketplace catalogs' plugin
-  entries too and to reject drift across all four, not just the original two.
-  `RELEASE-NOTES.md` is new: the narrative history of tagged releases (what
-  changed, why, evidence — distinct from this file's daily commit journal), with
-  its format documented at the top of the file. `docs/release-process.md`
-  documents the version-surface table, the bump-script usage, and that cutting
-  the git tag and GitHub release is reserved for the operator — preparing a
-  release is ordinary PR-completion authority, cutting it is not, and no
-  automation in the repository performs that step. `AGENTS.md`'s Git Workflow
-  section gets a pointer to the new doc. The ticket's own acceptance criterion
-  for a recorded dry run is this change's real diff:
-  `python3 scripts/bump_version.py --bump patch` was run for real on this
-  branch, bumping every surface from `0.1.0` to `0.1.1` (seeding the two
-  marketplace catalogs' version field for the first time in the same pass), with
-  `just lint` and `just test` green at the resulting head and no git tag cut —
-  recorded as the first `RELEASE-NOTES.md` entry. Cutting the first real tagged
-  release stays a separate, explicit operator action; this ticket's non-goals
-  explicitly exclude it.
 
 ## 2026-08-07 — Migrated carve-changesets' per-changeset review/fix loop and babysit-pr's post-publication review/fix loop to delegate to review-fix-loop, completing the design's caller-migration sequence, then added rationalization tables to babysit-pr, implement-ticket, and carve-changesets, then added a compaction-resilient ledger and workspace-per-run to implement-epic, carve-changesets, and babysit-pr
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,37 @@ summary: Chronological history of repository and skill changes.
   malformed-result rejection, topically unrelated to this diff's content.
   Recorded as corpus noise rather than a candidate defect, per the ticket's own
   guidance against chasing single-sample real-model variance.
+  (e509ab51491b044be981246985b635a99ff29026)
+
+- feat: add version-bump tooling, cross-manifest drift detection, narrative
+  release notes, and a documented release process (issue #138, epic #121) —
+  `scripts/bump_version.py` is the only tool that should change any of the four
+  version surfaces (`.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`,
+  `.claude-plugin/marketplace.json`, `.agents/plugins/marketplace.json`; the two
+  marketplace catalogs previously carried no version at all). It reads the
+  current version from the two plugin manifests, computes a
+  `--bump major|minor|patch` or explicit `--to` target, and writes all four in
+  one pass, restoring already-written surfaces if a later write fails so a
+  partial bump never lands. `scripts/validate_plugins.py`'s existing
+  Claude/Codex plugin-version match check (already wired into `just lint`) is
+  extended to require a valid semver on both marketplace catalogs' plugin
+  entries too and to reject drift across all four, not just the original two.
+  `RELEASE-NOTES.md` is new: the narrative history of tagged releases (what
+  changed, why, evidence — distinct from this file's daily commit journal), with
+  its format documented at the top of the file. `docs/release-process.md`
+  documents the version-surface table, the bump-script usage, and that cutting
+  the git tag and GitHub release is reserved for the operator — preparing a
+  release is ordinary PR-completion authority, cutting it is not, and no
+  automation in the repository performs that step. `AGENTS.md`'s Git Workflow
+  section gets a pointer to the new doc. The ticket's own acceptance criterion
+  for a recorded dry run is this change's real diff:
+  `python3 scripts/bump_version.py --bump patch` was run for real on this
+  branch, bumping every surface from `0.1.0` to `0.1.1` (seeding the two
+  marketplace catalogs' version field for the first time in the same pass), with
+  `just lint` and `just test` green at the resulting head and no git tag cut —
+  recorded as the first `RELEASE-NOTES.md` entry. Cutting the first real tagged
+  release stays a separate, explicit operator action; this ticket's non-goals
+  explicitly exclude it.
 
 ## 2026-08-07 — Migrated carve-changesets' per-changeset review/fix loop and babysit-pr's post-publication review/fix loop to delegate to review-fix-loop, completing the design's caller-migration sequence, then added rationalization tables to babysit-pr, implement-ticket, and carve-changesets, then added a compaction-resilient ledger and workspace-per-run to implement-epic, carve-changesets, and babysit-pr
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,0 +1,50 @@
+---
+summary: Narrative history of tagged releases, distinct from the daily commit journal in CHANGELOG.md.
+---
+
+# Release Notes
+
+Each entry here describes one **tagged release** in narrative form: what changed
+for someone installing or upgrading the plugin, why it changed, and the evidence
+backing the claim. This is not the daily development journal — see
+`CHANGELOG.md` for that. An entry lands here only when a release is actually
+cut; a merged PR alone does not earn one, except for the dry-run entry below,
+recorded to document the tooling itself before any tag exists.
+
+## Format
+
+Each entry is a level-2 heading naming the version and date
+(`## 0.1.1 — 2026-08-08`), followed by three parts:
+
+- **What changed** — a short narrative summary in plain language, not a
+  commit-log dump.
+- **Why** — the motivating problem or goal.
+- **Evidence** — citations for the claim: linked issues/PRs, the eval-evidence
+  summaries `AGENTS.md`'s norm requires for skill-prose changes (per #135), and
+  any recorded validation output.
+
+Entries are ordered newest first. See `docs/release-process.md` for how a
+release is prepared and who holds tagging authority.
+
+## 0.1.1 — dry run, 2026-08-08
+
+**What changed:** Added `scripts/bump_version.py`, extended
+`scripts/validate_plugins.py`'s existing plugin-version drift check to cover all
+four version surfaces (`.claude-plugin/plugin.json`,
+`.claude-plugin/marketplace.json`, `.agents/plugins/marketplace.json`,
+`.codex-plugin/plugin.json`), and documented the release process in
+`docs/release-process.md`. This entry itself is that tooling's first exercise.
+
+**Why:** #138 — distribution maturity needs a documented, drift-checked release
+path before the first tagged release, as part of #121's outer-loop positioning
+work.
+
+**Evidence:** `python3 scripts/bump_version.py --bump patch` run on this
+ticket's branch, bumping every enumerated surface from `0.1.0` to `0.1.1` in one
+pass (see the diff in this entry's own PR); `just lint` and `just test` both
+green at the resulting head, including the new
+`scripts/tests/test_bump_version.py` and the extended
+`scripts/tests/test_validate_plugins.py`. This is a recorded **dry run**: the
+bump and validation ran end-to-end and no git tag was cut. Cutting the first
+real tagged release remains a separate, explicit operator action — see
+`docs/release-process.md`.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,73 @@
+---
+summary: How a compris release is prepared and cut, and who holds tagging authority.
+---
+
+# Release process
+
+This repository ships as an installable plugin (Claude Code and Codex
+packaging). A release is cutting a git tag and GitHub release from a commit on
+`main` whose version surfaces are in sync. This document is the process; the
+tooling it describes lives in `scripts/bump_version.py` and
+`scripts/validate_plugins.py`.
+
+## Version surfaces
+
+Four files carry the plugin's version. `scripts/validate_plugins.py` (wired into
+`just lint`) rejects any drift among them:
+
+| Surface                            | Where the version lives |
+| ---------------------------------- | ----------------------- |
+| `.claude-plugin/plugin.json`       | top-level `version`     |
+| `.codex-plugin/plugin.json`        | top-level `version`     |
+| `.claude-plugin/marketplace.json`  | `plugins[0].version`    |
+| `.agents/plugins/marketplace.json` | `plugins[0].version`    |
+
+## Preparing a release (bump script)
+
+`scripts/bump_version.py` is the only tool that should change any of the four
+surfaces. It reads the current version from the two plugin manifests, computes
+the target, and writes all four in one pass — restoring any surfaces it already
+wrote if a later write fails, so a partial bump never lands.
+
+```bash
+python3 scripts/bump_version.py --bump patch   # 0.1.0 -> 0.1.1
+python3 scripts/bump_version.py --bump minor   # 0.1.0 -> 0.2.0
+python3 scripts/bump_version.py --bump major   # 0.1.0 -> 1.0.0
+python3 scripts/bump_version.py --to 0.3.0     # explicit target
+python3 scripts/bump_version.py --bump patch --dry-run   # preview only
+```
+
+Run it on a branch, then `just lint` and `just test` to confirm the four
+surfaces agree and nothing else broke. Commit the result as an ordinary PR like
+any other change — preparing a bump carries no special authority.
+
+## Narrative release notes
+
+`RELEASE-NOTES.md` is the narrative history of tagged releases: what changed,
+why, and the evidence behind the claim (see the format documented at the top of
+that file). It is distinct from `CHANGELOG.md`, the daily development journal
+`AGENTS.md`'s Git Workflow section already governs. Add a `RELEASE-NOTES.md`
+entry for every tagged release, not for every merged PR.
+
+## Cutting the release (operator-only)
+
+Preparing a release — bumping versions, updating `RELEASE-NOTES.md`, merging
+that PR to `main` — is ordinary PR completion authority. **Cutting the git tag
+and GitHub release is not.** That step is reserved for the operator:
+
+1. Confirm `main` is at the commit intended for release and that
+   `just lint`/`just test` are green there.
+2. Tag it (`git tag vX.Y.Z` matching the synced version) and push the tag.
+3. Cut the GitHub release from that tag, with notes drawn from the corresponding
+   `RELEASE-NOTES.md` entry.
+
+No automation in this repository creates a tag or a GitHub release on the
+operator's behalf. A PR that prepares a release must never assume tagging
+authority merely because its own acceptance criteria are otherwise satisfied.
+
+## The first real release
+
+This tooling was built ahead of the first tagged release. Cutting the first tag
+is still a separate, explicit operator action — this document does not itself
+authorize it, and no ticket that merely adds tooling, notes, or a dry run should
+be read as having done so.

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Bump the compris plugin version across every enumerated manifest surface.
+
+Four files carry the plugin's version: the two plugin manifests
+(`.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`) at their own
+top level, and the two marketplace catalogs (`.claude-plugin/marketplace.json`,
+`.agents/plugins/marketplace.json`) on their single `compris` plugin entry.
+`scripts/validate_plugins.py` (wired into `just lint`) rejects drift across
+all four; this script is the only tool that should ever change one of them.
+
+Usage:
+    python3 scripts/bump_version.py --bump patch
+    python3 scripts/bump_version.py --bump minor
+    python3 scripts/bump_version.py --bump major
+    python3 scripts/bump_version.py --to 0.3.0
+    python3 scripts/bump_version.py --bump patch --dry-run
+
+Cutting a git tag or GitHub release is a separate, operator-only step outside
+this script's scope — see docs/release-process.md.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+SEMVER = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
+
+# Surfaces where the version lives at the manifest's own top level.
+TOP_LEVEL_VERSION_SURFACES = (
+    Path(".claude-plugin/plugin.json"),
+    Path(".codex-plugin/plugin.json"),
+)
+# Surfaces where the version lives on the catalog's single `compris` plugin
+# entry, not the catalog object itself.
+MARKETPLACE_ENTRY_VERSION_SURFACES = (
+    Path(".claude-plugin/marketplace.json"),
+    Path(".agents/plugins/marketplace.json"),
+)
+
+
+class VersionBumpError(ValueError):
+    """Raised when the current or target version state cannot be bumped safely."""
+
+
+def _parse_semver(version: str) -> tuple[int, int, int]:
+    match = SEMVER.fullmatch(version)
+    if not match:
+        raise VersionBumpError(f"not a valid semver version: {version!r}")
+    major, minor, patch = (int(part) for part in match.groups())
+    return major, minor, patch
+
+
+def _bump(version: tuple[int, int, int], part: str) -> str:
+    major, minor, patch = version
+    if part == "major":
+        return f"{major + 1}.0.0"
+    if part == "minor":
+        return f"{major}.{minor + 1}.0"
+    if part == "patch":
+        return f"{major}.{minor}.{patch + 1}"
+    raise VersionBumpError(f"unknown bump kind: {part!r}")
+
+
+def resolve_current_version(root: Path) -> str:
+    """The version the two plugin manifests currently agree on.
+
+    Only the top-level plugin manifests are consulted here: a marketplace
+    catalog may not carry a version yet on a first run — this script is what
+    seeds it — so it cannot anchor "the current version".
+    """
+    versions: dict[Path, str] = {}
+    for rel in TOP_LEVEL_VERSION_SURFACES:
+        path = root / rel
+        manifest = json.loads(path.read_text(encoding="utf-8"))
+        version = manifest.get("version")
+        if not isinstance(version, str):
+            raise VersionBumpError(f"missing version in {rel}")
+        versions[rel] = version
+    distinct = set(versions.values())
+    if len(distinct) != 1:
+        raise VersionBumpError(
+            "plugin manifests disagree on the current version before bump: "
+            + ", ".join(f"{rel}={version}" for rel, version in versions.items())
+        )
+    return next(iter(distinct))
+
+
+def compute_target_version(root: Path, *, bump: str | None, to: str | None) -> str:
+    if to is not None:
+        _parse_semver(to)
+        return to
+    if bump is None:
+        raise VersionBumpError("either --to or --bump is required")
+    current = resolve_current_version(root)
+    return _bump(_parse_semver(current), bump)
+
+
+def _rendered_top_level(path: Path, version: str) -> str:
+    manifest = json.loads(path.read_text(encoding="utf-8"))
+    manifest["version"] = version
+    return json.dumps(manifest, indent=2) + "\n"
+
+
+def _with_version_after_name(entry: dict, version: str) -> dict:
+    if "version" in entry:
+        entry["version"] = version
+        return entry
+    ordered: dict = {}
+    inserted = False
+    for key, value in entry.items():
+        ordered[key] = value
+        if key == "name" and not inserted:
+            ordered["version"] = version
+            inserted = True
+    if not inserted:
+        ordered = {"version": version, **entry}
+    return ordered
+
+
+def _rendered_marketplace_entry(path: Path, version: str) -> str:
+    catalog = json.loads(path.read_text(encoding="utf-8"))
+    plugins = catalog.get("plugins")
+    if not isinstance(plugins, list) or len(plugins) != 1:
+        raise VersionBumpError(f"{path} must expose exactly one plugin entry")
+    entry = plugins[0]
+    if not isinstance(entry, dict):
+        raise VersionBumpError(f"{path} plugin entry must be an object")
+    plugins[0] = _with_version_after_name(entry, version)
+    return json.dumps(catalog, indent=2) + "\n"
+
+
+def compute_updates(root: Path, version: str) -> dict[Path, str]:
+    """The post-bump text of every enumerated surface, without writing anything."""
+    _parse_semver(version)
+    updates: dict[Path, str] = {}
+    for rel in TOP_LEVEL_VERSION_SURFACES:
+        updates[root / rel] = _rendered_top_level(root / rel, version)
+    for rel in MARKETPLACE_ENTRY_VERSION_SURFACES:
+        updates[root / rel] = _rendered_marketplace_entry(root / rel, version)
+    return updates
+
+
+def write_atomically(updates: dict[Path, str]) -> None:
+    """Write every surface, restoring already-written files if a later write fails.
+
+    All four surfaces are meant to move together; a partial write would leave
+    exactly the drift `validate_plugins.py` exists to catch.
+    """
+    originals: dict[Path, str] = {
+        path: path.read_text(encoding="utf-8") for path in updates
+    }
+    written: list[Path] = []
+    try:
+        for path, content in updates.items():
+            path.write_text(content, encoding="utf-8")
+            written.append(path)
+    except OSError:
+        for path in written:
+            path.write_text(originals[path], encoding="utf-8")
+        raise
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--to", help="exact target version, e.g. 0.3.0")
+    parser.add_argument(
+        "--bump",
+        choices=("major", "minor", "patch"),
+        help="bump kind relative to the version the plugin manifests currently agree on",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print the target version and affected files without writing",
+    )
+    args = parser.parse_args(argv)
+
+    root = Path(__file__).resolve().parents[1]
+    try:
+        version = compute_target_version(root, bump=args.bump, to=args.to)
+        updates = compute_updates(root, version)
+    except VersionBumpError as error:
+        print(f"version bump failed: {error}", file=sys.stderr)
+        return 1
+
+    if args.dry_run:
+        print(f"would bump compris to {version}:")
+        for path in updates:
+            print(f"  {path.relative_to(root)}")
+        return 0
+
+    write_atomically(updates)
+    print(f"bumped compris to {version} across {len(updates)} manifest(s):")
+    for path in updates:
+        print(f"  {path.relative_to(root)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -22,9 +22,12 @@ this script's scope — see docs/release-process.md.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
+import os
 import re
 import sys
+import tempfile
 from pathlib import Path
 
 SEMVER = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
@@ -144,11 +147,41 @@ def compute_updates(root: Path, version: str) -> dict[Path, str]:
     return updates
 
 
+def _replace_atomic(path: Path, content: str) -> None:
+    """Write `content` to `path` via a sibling temp file and `os.replace`.
+
+    Matches this repository's established atomic-write idiom
+    (`skills/review-fix-loop/scripts/local_execution.py`'s
+    `write_checkpoint_atomic`): the real target is only ever touched by the
+    final rename, so a failure while writing the temp file — including one
+    partway through the write itself, not just on open — never truncates or
+    otherwise corrupts the real file.
+    """
+    fd, tmp_name = tempfile.mkstemp(
+        dir=str(path.parent), prefix=f".tmp-{path.name}-", suffix=".json"
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_name, path)
+    except Exception:
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(tmp_name)
+        raise
+
+
 def write_atomically(updates: dict[Path, str]) -> None:
     """Write every surface, restoring already-written files if a later write fails.
 
-    All four surfaces are meant to move together; a partial write would leave
-    exactly the drift `validate_plugins.py` exists to catch.
+    Each surface is written via `_replace_atomic`, so a failure while writing
+    any one surface never touches that surface's own real file. All four
+    surfaces are meant to move together, though: a failure between two
+    separate replaces is still possible, so this also restores every surface
+    this call already replaced, matching the still-published original content
+    — a partial bump never lands and stays exactly the drift
+    `validate_plugins.py` exists to catch.
     """
     originals: dict[Path, str] = {
         path: path.read_text(encoding="utf-8") for path in updates
@@ -156,11 +189,11 @@ def write_atomically(updates: dict[Path, str]) -> None:
     written: list[Path] = []
     try:
         for path, content in updates.items():
-            path.write_text(content, encoding="utf-8")
+            _replace_atomic(path, content)
             written.append(path)
     except OSError:
         for path in written:
-            path.write_text(originals[path], encoding="utf-8")
+            _replace_atomic(path, originals[path])
         raise
 
 

--- a/scripts/tests/helpers.py
+++ b/scripts/tests/helpers.py
@@ -1,0 +1,24 @@
+"""Shared test fixture helpers for the repository-root `scripts/tests/` suite.
+
+Follows the same `helpers.py`-per-test-directory convention already used by
+`skills/carve-changesets/scripts/tests/helpers.py` and
+`skills/review-fix-loop/scripts/tests/helpers.py`.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+
+# The directories that together make up a testable copy of the plugin
+# packaging fixture: the two plugin manifests, the two marketplace catalogs,
+# and the skill suite `validate_plugins.py` inspects.
+PLUGIN_FIXTURE_DIRS = (".agents", ".claude-plugin", ".codex-plugin", "skills")
+
+
+def copy_fixture(destination: Path) -> None:
+    """Copy the plugin packaging fixture directories into `destination`."""
+    for name in PLUGIN_FIXTURE_DIRS:
+        shutil.copytree(REPOSITORY_ROOT / name, destination / name)

--- a/scripts/tests/test_bump_version.py
+++ b/scripts/tests/test_bump_version.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load(name: str, relative: str):
+    spec = importlib.util.spec_from_file_location(name, REPOSITORY_ROOT / relative)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+bump_version = _load("bump_version", "scripts/bump_version.py")
+validate_plugins = _load("validate_plugins", "scripts/validate_plugins.py")
+
+
+class BumpVersionTests(unittest.TestCase):
+    def copy_fixture(self, destination: Path) -> None:
+        import shutil
+
+        for name in (".agents", ".claude-plugin", ".codex-plugin", "skills"):
+            shutil.copytree(REPOSITORY_ROOT / name, destination / name)
+
+    def read_version(self, root: Path, rel: str, *, entry: bool = False) -> str:
+        manifest = json.loads((root / rel).read_text(encoding="utf-8"))
+        if entry:
+            return manifest["plugins"][0]["version"]
+        return manifest["version"]
+
+    def test_resolve_current_version_reads_the_two_plugin_manifests(self) -> None:
+        self.assertEqual(
+            bump_version.resolve_current_version(REPOSITORY_ROOT),
+            self.read_version(REPOSITORY_ROOT, ".claude-plugin/plugin.json"),
+        )
+
+    def test_resolve_current_version_rejects_disagreement(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.copy_fixture(root)
+            codex_path = root / ".codex-plugin" / "plugin.json"
+            manifest = json.loads(codex_path.read_text(encoding="utf-8"))
+            manifest["version"] = "9.9.9"
+            codex_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+            with self.assertRaisesRegex(
+                bump_version.VersionBumpError, "disagree on the current version"
+            ):
+                bump_version.resolve_current_version(root)
+
+    def test_bump_kinds_compute_the_expected_target(self) -> None:
+        self.assertEqual(bump_version._bump((0, 1, 0), "patch"), "0.1.1")
+        self.assertEqual(bump_version._bump((0, 1, 5), "minor"), "0.2.0")
+        self.assertEqual(bump_version._bump((0, 1, 5), "major"), "1.0.0")
+
+    def test_compute_target_version_prefers_explicit_to(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.copy_fixture(root)
+            self.assertEqual(
+                bump_version.compute_target_version(root, bump=None, to="1.2.3"),
+                "1.2.3",
+            )
+
+    def test_compute_target_version_rejects_a_malformed_explicit_target(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.copy_fixture(root)
+            with self.assertRaisesRegex(
+                bump_version.VersionBumpError, "not a valid semver version"
+            ):
+                bump_version.compute_target_version(root, bump=None, to="v1.2")
+
+    def test_compute_target_version_requires_to_or_bump(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.copy_fixture(root)
+            with self.assertRaisesRegex(
+                bump_version.VersionBumpError, "either --to or --bump is required"
+            ):
+                bump_version.compute_target_version(root, bump=None, to=None)
+
+    def test_compute_updates_seeds_a_missing_marketplace_version_after_name(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.copy_fixture(root)
+            marketplace_path = root / ".claude-plugin" / "marketplace.json"
+            catalog = json.loads(marketplace_path.read_text(encoding="utf-8"))
+            catalog["plugins"][0].pop("version", None)
+            marketplace_path.write_text(json.dumps(catalog), encoding="utf-8")
+
+            updates = bump_version.compute_updates(root, "0.2.0")
+            rendered = json.loads(updates[marketplace_path])
+            entry = rendered["plugins"][0]
+            keys = list(entry.keys())
+            self.assertEqual(entry["version"], "0.2.0")
+            self.assertEqual(keys.index("version"), keys.index("name") + 1)
+
+    def test_compute_updates_preserves_position_of_an_existing_version(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.copy_fixture(root)
+            plugin_path = root / ".claude-plugin" / "plugin.json"
+            updates = bump_version.compute_updates(root, "0.9.0")
+            rendered = json.loads(updates[plugin_path])
+            keys = list(rendered.keys())
+            self.assertEqual(rendered["version"], "0.9.0")
+            self.assertEqual(keys.index("version"), keys.index("name") + 1)
+
+    def test_write_atomically_updates_all_four_surfaces_together(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.copy_fixture(root)
+            updates = bump_version.compute_updates(root, "0.5.0")
+            bump_version.write_atomically(updates)
+
+            validate_plugins.validate(root)  # no drift after a real bump
+            for rel, entry in (
+                (".claude-plugin/plugin.json", False),
+                (".codex-plugin/plugin.json", False),
+                (".claude-plugin/marketplace.json", True),
+                (".agents/plugins/marketplace.json", True),
+            ):
+                self.assertEqual(self.read_version(root, rel, entry=entry), "0.5.0")
+
+    def test_write_atomically_restores_originals_when_a_later_write_fails(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.copy_fixture(root)
+            updates = bump_version.compute_updates(root, "0.6.0")
+            claude_path = root / ".claude-plugin" / "plugin.json"
+            codex_path = root / ".codex-plugin" / "plugin.json"
+            original_claude = claude_path.read_text(encoding="utf-8")
+            original_codex = codex_path.read_text(encoding="utf-8")
+
+            real_write_text = Path.write_text
+
+            def flaky_write_text(self: Path, content: str, *args, **kwargs):
+                if self == codex_path:
+                    raise OSError("simulated disk failure")
+                return real_write_text(self, content, *args, **kwargs)
+
+            with patch.object(Path, "write_text", flaky_write_text):
+                with self.assertRaises(OSError):
+                    bump_version.write_atomically(updates)
+
+            self.assertEqual(claude_path.read_text(encoding="utf-8"), original_claude)
+            self.assertEqual(codex_path.read_text(encoding="utf-8"), original_codex)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_bump_version.py
+++ b/scripts/tests/test_bump_version.py
@@ -7,7 +7,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+from helpers import REPOSITORY_ROOT, copy_fixture
 
 
 def _load(name: str, relative: str):
@@ -24,10 +24,7 @@ validate_plugins = _load("validate_plugins", "scripts/validate_plugins.py")
 
 class BumpVersionTests(unittest.TestCase):
     def copy_fixture(self, destination: Path) -> None:
-        import shutil
-
-        for name in (".agents", ".claude-plugin", ".codex-plugin", "skills"):
-            shutil.copytree(REPOSITORY_ROOT / name, destination / name)
+        copy_fixture(destination)
 
     def read_version(self, root: Path, rel: str, *, entry: bool = False) -> str:
         manifest = json.loads((root / rel).read_text(encoding="utf-8"))

--- a/scripts/tests/test_bump_version.py
+++ b/scripts/tests/test_bump_version.py
@@ -129,6 +129,36 @@ class BumpVersionTests(unittest.TestCase):
             ):
                 self.assertEqual(self.read_version(root, rel, entry=entry), "0.5.0")
 
+    def test_replace_atomic_never_touches_the_real_file_when_the_write_itself_fails(
+        self,
+    ) -> None:
+        """A failure partway through the write, not just on open, must never
+        truncate or otherwise corrupt the real target file."""
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            target = root / "surface.json"
+            original = '{"version": "0.1.0"}\n'
+            target.write_text(original, encoding="utf-8")
+
+            real_fdopen = bump_version.os.fdopen
+
+            def flaky_fdopen(fd, *args, **kwargs):
+                handle = real_fdopen(fd, *args, **kwargs)
+
+                def flaky_write(content):
+                    raise OSError("simulated disk failure mid-write")
+
+                handle.write = flaky_write
+                return handle
+
+            with patch.object(bump_version.os, "fdopen", flaky_fdopen):
+                with self.assertRaises(OSError):
+                    bump_version._replace_atomic(target, '{"version": "0.2.0"}\n')
+
+            self.assertEqual(target.read_text(encoding="utf-8"), original)
+            leftover = [entry for entry in root.iterdir() if entry != target]
+            self.assertEqual(leftover, [], "the failed temp file must be cleaned up")
+
     def test_write_atomically_restores_originals_when_a_later_write_fails(
         self,
     ) -> None:
@@ -141,14 +171,14 @@ class BumpVersionTests(unittest.TestCase):
             original_claude = claude_path.read_text(encoding="utf-8")
             original_codex = codex_path.read_text(encoding="utf-8")
 
-            real_write_text = Path.write_text
+            real_replace_atomic = bump_version._replace_atomic
 
-            def flaky_write_text(self: Path, content: str, *args, **kwargs):
-                if self == codex_path:
+            def flaky_replace_atomic(path: Path, content: str) -> None:
+                if path == codex_path:
                     raise OSError("simulated disk failure")
-                return real_write_text(self, content, *args, **kwargs)
+                return real_replace_atomic(path, content)
 
-            with patch.object(Path, "write_text", flaky_write_text):
+            with patch.object(bump_version, "_replace_atomic", flaky_replace_atomic):
                 with self.assertRaises(OSError):
                     bump_version.write_atomically(updates)
 

--- a/scripts/tests/test_release_docs.py
+++ b/scripts/tests/test_release_docs.py
@@ -1,0 +1,81 @@
+"""Structural checks for the release-tooling docs #138 adds.
+
+Checks stable identifiers, not phrasing: the RELEASE-NOTES.md format section
+and its first (dry-run) entry, and release-process.md's version-surface table
+and operator-only tagging authority.
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+RELEASE_NOTES = REPOSITORY_ROOT / "RELEASE-NOTES.md"
+RELEASE_PROCESS = REPOSITORY_ROOT / "docs" / "release-process.md"
+
+
+def compact(value: str) -> str:
+    return re.sub(r"\s+", " ", value).strip()
+
+
+class ReleaseNotesTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.text = RELEASE_NOTES.read_text()
+        cls.compact = compact(cls.text)
+
+    def test_the_file_documents_its_own_format(self) -> None:
+        self.assertIn("## Format", self.text)
+        self.assertIn("What changed", self.compact)
+        self.assertIn("Why", self.compact)
+        self.assertIn("Evidence", self.compact)
+
+    def test_it_is_distinct_from_the_daily_changelog(self) -> None:
+        self.assertIn("CHANGELOG.md", self.compact)
+        self.assertIn("not the daily", self.compact)
+
+    def test_the_first_entry_describes_the_tooling_itself_as_a_dry_run(self) -> None:
+        self.assertIn("bump_version.py", self.compact)
+        self.assertIn("validate_plugins.py", self.compact)
+        self.assertIn("dry run", self.compact.lower())
+        self.assertIn("no git tag was cut", self.compact.lower())
+
+    def test_entries_cite_the_eval_evidence_norm(self) -> None:
+        self.assertIn("#135", self.compact)
+
+    def test_it_points_at_the_release_process_doc(self) -> None:
+        self.assertIn("docs/release-process.md", self.compact)
+
+
+class ReleaseProcessDocTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.text = RELEASE_PROCESS.read_text()
+        cls.compact = compact(cls.text)
+
+    def test_all_four_version_surfaces_are_named(self) -> None:
+        for surface in (
+            ".claude-plugin/plugin.json",
+            ".codex-plugin/plugin.json",
+            ".claude-plugin/marketplace.json",
+            ".agents/plugins/marketplace.json",
+        ):
+            self.assertIn(surface, self.text)
+
+    def test_the_bump_script_usage_is_documented(self) -> None:
+        self.assertIn("scripts/bump_version.py", self.text)
+        self.assertIn("--bump patch", self.text)
+        self.assertIn("--dry-run", self.text)
+
+    def test_operator_only_tagging_authority_is_stated(self) -> None:
+        self.assertIn("Cutting the git tag and GitHub release is not", self.compact)
+        self.assertIn("No automation in this repository creates a tag", self.compact)
+
+    def test_it_references_the_narrative_release_notes_file(self) -> None:
+        self.assertIn("RELEASE-NOTES.md", self.text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_validate_plugins.py
+++ b/scripts/tests/test_validate_plugins.py
@@ -50,6 +50,34 @@ class ValidatePluginsTests(unittest.TestCase):
             ):
                 validate_plugins.validate(root)
 
+    def test_marketplace_entries_require_a_valid_version(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.copy_fixture(root)
+            marketplace_path = root / ".claude-plugin" / "marketplace.json"
+            catalog = json.loads(marketplace_path.read_text(encoding="utf-8"))
+            catalog["plugins"][0].pop("version", None)
+            marketplace_path.write_text(json.dumps(catalog), encoding="utf-8")
+
+            with self.assertRaisesRegex(
+                validate_plugins.PluginValidationError, "invalid version"
+            ):
+                validate_plugins.validate(root)
+
+    def test_marketplace_version_drift_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.copy_fixture(root)
+            marketplace_path = root / ".agents" / "plugins" / "marketplace.json"
+            catalog = json.loads(marketplace_path.read_text(encoding="utf-8"))
+            catalog["plugins"][0]["version"] = "9.9.9"
+            marketplace_path.write_text(json.dumps(catalog), encoding="utf-8")
+
+            with self.assertRaisesRegex(
+                validate_plugins.PluginValidationError, "versions must match"
+            ):
+                validate_plugins.validate(root)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/test_validate_plugins.py
+++ b/scripts/tests/test_validate_plugins.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import importlib.util
 import json
-import shutil
 import tempfile
 import unittest
 from pathlib import Path
 
-REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+from helpers import REPOSITORY_ROOT, copy_fixture
+
 SPEC = importlib.util.spec_from_file_location(
     "validate_plugins", REPOSITORY_ROOT / "scripts" / "validate_plugins.py"
 )
@@ -18,8 +18,7 @@ SPEC.loader.exec_module(validate_plugins)
 
 class ValidatePluginsTests(unittest.TestCase):
     def copy_fixture(self, destination: Path) -> None:
-        for name in (".agents", ".claude-plugin", ".codex-plugin", "skills"):
-            shutil.copytree(REPOSITORY_ROOT / name, destination / name)
+        copy_fixture(destination)
 
     def test_repository_plugin_package_is_complete(self) -> None:
         validate_plugins.validate(REPOSITORY_ROOT)

--- a/scripts/validate_plugins.py
+++ b/scripts/validate_plugins.py
@@ -97,11 +97,6 @@ def validate(root: Path) -> None:
             f"invalid version in {path}",
         )
 
-    _require(
-        claude_manifest["version"] == codex_manifest["version"],
-        "Claude and Codex plugin versions must match",
-    )
-
     claude_marketplace_path = root / ".claude-plugin" / "marketplace.json"
     claude_entry = _single_marketplace_entry(
         _load_object(claude_marketplace_path), claude_marketplace_path
@@ -127,6 +122,28 @@ def validate(root: Path) -> None:
     _require(
         isinstance(codex_entry.get("category"), str),
         "Codex plugin category is required",
+    )
+
+    for path, entry in (
+        (claude_marketplace_path, claude_entry),
+        (codex_marketplace_path, codex_entry),
+    ):
+        version = entry.get("version")
+        _require(
+            isinstance(version, str) and SEMVER.fullmatch(version),
+            f"invalid version in {path}",
+        )
+
+    all_versions = {
+        claude_manifest_path: claude_manifest["version"],
+        codex_manifest_path: codex_manifest["version"],
+        claude_marketplace_path: claude_entry["version"],
+        codex_marketplace_path: codex_entry["version"],
+    }
+    _require(
+        len(set(all_versions.values())) == 1,
+        "plugin and marketplace versions must match across "
+        + ", ".join(str(path) for path in all_versions),
     )
 
     installed_skills = {


### PR DESCRIPTION
## Summary
- New `scripts/bump_version.py`: the only tool that should change any of the
  four version surfaces (`.claude-plugin/plugin.json`,
  `.codex-plugin/plugin.json`, `.claude-plugin/marketplace.json`,
  `.agents/plugins/marketplace.json`; the two marketplace catalogs previously
  carried no version at all). Reads the current version from the two plugin
  manifests, computes a `--bump major|minor|patch` or explicit `--to` target,
  and writes all four via a sibling-temp-file-plus-`os.replace` atomic write
  per surface (matching `review-fix-loop`'s established idiom), restoring
  already-written surfaces if a later one fails.
- Extends `scripts/validate_plugins.py`'s existing Claude/Codex version-match
  check to also require a valid semver on both marketplace catalogs' plugin
  entries and to reject drift across all four surfaces. Already wired into
  `just lint`.
- New `RELEASE-NOTES.md`: narrative release history (what changed, why,
  evidence), distinct from `CHANGELOG.md`'s daily journal, with its format
  documented at the top and a first entry describing this tooling's own dry
  run.
- New `docs/release-process.md`: the version-surface table, bump-script
  usage, and operator-only tagging authority — preparing a release is
  ordinary PR-completion authority, cutting the tag/GitHub release is not.
  `AGENTS.md`'s Git Workflow section now points to it.
- Recorded dry run: `python3 scripts/bump_version.py --bump patch` was run
  for real on this branch, bumping every surface from `0.1.0` to `0.1.1`
  (seeding the two marketplace catalogs' version field for the first time),
  with `just lint`/`just test` green at the resulting head and no git tag
  cut.

## Why
Closes the tooling half of #121 (distribution maturity as the outer-loop
companion to superpowers): a documented, drift-checked release path is
needed ahead of the first tagged release. Cutting that first tag remains a
separate, explicit operator action and stays out of this ticket's scope.

Refs #138

## Test plan
- [x] `just format` — clean
- [x] `just lint` — exit 0 (including the extended `validate_plugins.py`
      drift check)
- [x] `just test` — exit 0, full suite (new `scripts/tests/test_bump_version.py`,
      `scripts/tests/test_release_docs.py`, `scripts/tests/helpers.py`, and the
      extended `scripts/tests/test_validate_plugins.py`, plus every existing
      skill/repo test suite)
- [x] Reviewed with the full repository review suite
      (`review-solution-simplicity`, `review-correctness`,
      `review-code-simplicity`) via `review-code-change`, three fix cycles
      applied (changelog ordering, duplicated test helper, atomic-write
      partial-corruption gap), final verdict clean

🤖 Generated with implement-epic → implement-ticket orchestration
