### PR TITLE
feat: reposition marketplace metadata and the README lead as the outer-loop companion to superpowers

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,14 +4,14 @@
     "name": "shaug"
   },
   "metadata": {
-    "description": "For when the planning is done, and the work begins. Installs the complete compris skill suite as one dependency-closed plugin."
+    "description": "For when the planning is done, and the work begins. compris is the ticket-to-merge outer loop — readiness gates, contract-driven review, and the post-publication PR lifecycle — designed to compose with, not depend on, inner-loop methodology libraries such as superpowers. Installs the complete skill suite as one dependency-closed plugin."
   },
   "plugins": [
     {
       "name": "compris",
       "version": "0.1.1",
       "source": "./",
-      "description": "Implementation, code-review, PR-lifecycle, and changeset workflows that install and run together."
+      "description": "The ticket-to-merge outer loop — readiness gates, contract-driven review, PR lifecycle, and epic orchestration — that composes with, not depends on, inner-loop methodology libraries such as superpowers."
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "compris",
   "version": "0.1.1",
-  "description": "For when the planning is done, and the work begins. Installs the complete compris implementation, review, PR-lifecycle, and changeset skill suite.",
+  "description": "For when the planning is done, and the work begins. compris is the ticket-to-merge outer loop — readiness gates, contract-driven review, the post-publication PR lifecycle, and epic orchestration — designed to compose with, not depend on, inner-loop methodology libraries such as superpowers. Installs the complete implementation, review, PR-lifecycle, and changeset skill suite.",
   "author": {
     "name": "shaug"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "compris",
   "version": "0.1.1",
-  "description": "For when the planning is done, and the work begins. Installs the complete compris implementation, review, PR-lifecycle, and changeset skill suite.",
+  "description": "For when the planning is done, and the work begins. compris is the ticket-to-merge outer loop — readiness gates, contract-driven review, the post-publication PR lifecycle, and epic orchestration — designed to compose with, not depend on, inner-loop methodology libraries such as superpowers. Installs the complete implementation, review, PR-lifecycle, and changeset skill suite.",
   "author": {
     "name": "shaug",
     "url": "https://github.com/shaug"
@@ -18,7 +18,7 @@
   "interface": {
     "displayName": "Compris",
     "shortDescription": "For when the planning is done, and the work begins",
-    "longDescription": "Install the dependency-closed suite for ticket and epic implementation, code review, PR babysitting, and changeset carving.",
+    "longDescription": "Install the dependency-closed suite for the ticket-to-merge outer loop — readiness gates, contract-driven review, PR lifecycle, and epic orchestration — that composes with, not depends on, inner-loop methodology libraries such as superpowers.",
     "developerName": "shaug",
     "category": "Developer Tools",
     "capabilities": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,32 @@ summary: Chronological history of repository and skill changes.
 
 # Changelog
 
-## 2026-08-08 — Hardened implement-ticket's own worktree isolation mechanics, then added version-bump tooling, release notes, and a documented release process
+## 2026-08-08 — Hardened implement-ticket's own worktree isolation mechanics, added version-bump tooling, release notes, and a documented release process, then repositioned marketplace metadata and the README lead as the outer-loop companion to superpowers
+
+- feat: reposition marketplace metadata and the README lead as the outer-loop
+  companion to superpowers (issue #139, epic #121) — the "Using beside peer
+  skills" README section already stated the outer-loop/inner-loop division of
+  labor, but nothing surfaced that framing where a prospective user first looks:
+  the README lead and the four plugin/marketplace description surfaces. Adds a
+  "Where it composes" lead paragraph naming superpowers explicitly, stating the
+  "fully functional without a peer installed" guarantee, and linking
+  `#using-beside-peer-skills`. Updates `.claude-plugin/plugin.json`,
+  `.codex-plugin/plugin.json` (both its top-level `description` and its
+  `interface.longDescription`), and `.claude-plugin/marketplace.json` (both
+  `metadata.description` and the `compris` plugin entry's `description`) to the
+  same "ticket-to-merge outer loop... composes with, not depends on, inner-loop
+  methodology libraries such as superpowers" positioning; ticket body referred
+  to the project by its pre-rename name `agent-scripts`, so the copy uses the
+  current name `compris` throughout, verified against the actual repository
+  identity rather than copied verbatim. `.agents/plugins/marketplace.json`
+  carries no description-shaped field in its current schema, so it is unchanged
+  — its plugin entry gained a `version` field under #138, and the other three
+  surfaces already carry this ticket's positioning. New
+  `scripts/tests/test_marketplace_positioning.py` pins the outer-loop framing,
+  the superpowers mention, and the compose/depend contrast across the README
+  lead and all four description surfaces. Docs/config-only change — no
+  behavioral test beyond the new structural pins; `just lint`/`just test` both
+  green.
 
 - feat: add version-bump tooling, cross-manifest drift detection, narrative
   release notes, and a documented release process (issue #138, epic #121) —
@@ -34,7 +59,7 @@ summary: Chronological history of repository and skill changes.
   `just lint` and `just test` green at the resulting head and no git tag cut —
   recorded as the first `RELEASE-NOTES.md` entry. Cutting the first real tagged
   release stays a separate, explicit operator action; this ticket's non-goals
-  explicitly exclude it.
+  explicitly exclude it. (a55c2cc425335470962a846c3b4d252877d089e8)
 
 - feat(implement-ticket): harden worktree isolation mechanics (issue #134, epic
   #119) — implement-ticket's own "Create exclusive implementation state" step

--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ its caller can validate. They fail closed: a review that cannot bind its
 evidence to the candidate says so rather than returning a clean verdict it did
 not earn.
 
+**Where it composes.** `compris` is the outer-loop companion to peer methodology
+libraries such as [superpowers](https://github.com/obra/superpowers): it owns
+ticket readiness, review production, and the post-publication pull-request
+lifecycle, while peers own in-phase methodology — how to brainstorm, how to run
+a red–green loop, how to debug a failure hypothesis-first. Install both for the
+complete cycle from idea to merged pull request; `compris` is fully functional
+without a peer installed. See
+[Using beside peer skills](#using-beside-peer-skills) for the full division of
+labor and composition rules.
+
 ## Installation
 
 Install the plugin when you need any composed workflow. It packages every skill

--- a/scripts/tests/test_marketplace_positioning.py
+++ b/scripts/tests/test_marketplace_positioning.py
@@ -1,0 +1,71 @@
+"""Contract invariants for the outer-loop-companion positioning #139 adds.
+
+Checks stable identifiers, not phrasing: that the README lead names the
+"outer loop" framing, names superpowers, and links to the "Using beside peer
+skills" section; and that every marketplace/plugin description surface
+carries the same "outer loop" / "compose with, not depend on" positioning.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import unittest
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+README = REPOSITORY_ROOT / "README.md"
+
+
+def compact(value: str) -> str:
+    return re.sub(r"\s+", " ", value).strip()
+
+
+class ReadmeLeadPositioningTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        text = README.read_text()
+        # The lead is everything before the first "## " heading.
+        cls.lead = compact(text.split("\n## ", 1)[0])
+
+    def test_the_lead_names_the_outer_loop_framing(self) -> None:
+        self.assertIn("outer-loop companion", self.lead)
+        self.assertIn("superpowers", self.lead)
+
+    def test_the_lead_links_the_peer_composition_section(self) -> None:
+        self.assertIn("Using beside peer skills", self.lead)
+        self.assertIn("#using-beside-peer-skills", self.lead)
+
+    def test_the_lead_states_standalone_function(self) -> None:
+        self.assertIn("fully functional without a peer installed", self.lead)
+
+
+class MarketplacePositioningTests(unittest.TestCase):
+    def test_every_description_surface_carries_the_outer_loop_positioning(
+        self,
+    ) -> None:
+        surfaces = {
+            ".claude-plugin/plugin.json": lambda m: m["description"],
+            ".codex-plugin/plugin.json": lambda m: m["description"],
+            ".codex-plugin/plugin.json#longDescription": lambda m: m["interface"][
+                "longDescription"
+            ],
+            ".claude-plugin/marketplace.json#metadata": lambda m: m["metadata"][
+                "description"
+            ],
+            ".claude-plugin/marketplace.json#plugin-entry": lambda m: m["plugins"][0][
+                "description"
+            ],
+        }
+        for label, extract in surfaces.items():
+            rel = label.split("#", 1)[0]
+            manifest = json.loads((REPOSITORY_ROOT / rel).read_text())
+            with self.subTest(surface=label):
+                text = extract(manifest)
+                self.assertIn("outer loop", text)
+                self.assertIn("superpowers", text)
+                self.assertRegex(text, r"compose(?:s)? with, not depend(?:s)? on")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- New "Where it composes" README lead paragraph: names superpowers
  explicitly, states the "fully functional without a peer installed"
  guarantee, and links `#using-beside-peer-skills` for the full division of
  labor and composition rules already documented there.
- Updated description text on `.claude-plugin/plugin.json`,
  `.codex-plugin/plugin.json` (top-level `description` and
  `interface.longDescription`), and `.claude-plugin/marketplace.json`
  (`metadata.description` and the `compris` plugin entry's `description`) to
  the same "ticket-to-merge outer loop ... composes with, not depends on,
  inner-loop methodology libraries such as superpowers" positioning.
- `.agents/plugins/marketplace.json` is unchanged: its current schema carries
  no description-shaped field to update.
- New `scripts/tests/test_marketplace_positioning.py` pins the outer-loop
  framing, the superpowers mention, and the compose/depend contrast across
  the README lead and all four description surfaces.

## Why
Closes the positioning half of #121 (distribution maturity as the
outer-loop companion to superpowers). The outer-loop/inner-loop division of
labor was already true and documented in the "Using beside peer skills"
section, but nothing surfaced it where a prospective user first looks — the
README lead and the marketplace/plugin metadata. The ticket body referred to
the project by its pre-rename name `agent-scripts`; this copy uses the
current name `compris` throughout, verified against the actual repository
identity rather than copied verbatim.

Refs #139

## Test plan
- [x] `just format` — clean
- [x] `just lint` — exit 0 (`validate_plugins.py` passes with the updated
      descriptions)
- [x] `just test` — exit 0, full suite including the new
      `test_marketplace_positioning.py` and the pre-existing
      `test_peer_composition_readme.py` (unaffected)
- [x] Reviewed with the full repository review suite
      (`review-solution-simplicity`, `review-correctness`,
      `review-code-simplicity`) via `review-code-change` — clean on first
      pass, one non-gating `defer` finding (pre-existing `compact()` helper
      duplication across 4 test files, out of scope, flagged separately)

🤖 Generated with implement-epic → implement-ticket orchestration
