### PR TITLE
refactor: deduplicate the compact() test helper into scripts/tests/helpers.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ summary: Chronological history of repository and skill changes.
   helper that `test_peer_composition_readme.py`, `test_skill_authoring_doc.py`,
   `test_release_docs.py`, and `test_marketplace_positioning.py` each
   independently defined — moved it into the shared `scripts/tests/helpers.py`
-  (following the same `helpers.py`-per-test-directory convention already used
-  by `skills/carve-changesets/scripts/tests/helpers.py` and
+  (following the same `helpers.py`-per-test-directory convention already used by
+  `skills/carve-changesets/scripts/tests/helpers.py` and
   `skills/review-fix-loop/scripts/tests/helpers.py`) and updated all four
   callers to import it instead. Dropped the now-unused `import re` in the three
   files where `compact()` was the only user of the module; kept it in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,23 @@ summary: Chronological history of repository and skill changes.
 
 # Changelog
 
-## 2026-08-08 — Hardened implement-ticket's own worktree isolation mechanics, added version-bump tooling, release notes, and a documented release process, then repositioned marketplace metadata and the README lead as the outer-loop companion to superpowers
+## 2026-08-08 — Hardened implement-ticket's own worktree isolation mechanics, added version-bump tooling, release notes, and a documented release process, then repositioned marketplace metadata and the README lead as the outer-loop companion to superpowers, then deduplicated the byte-identical `compact()` test helper into `scripts/tests/helpers.py`
+
+- refactor: deduplicate the byte-identical `compact()` whitespace-collapsing
+  helper that `test_peer_composition_readme.py`, `test_skill_authoring_doc.py`,
+  `test_release_docs.py`, and `test_marketplace_positioning.py` each
+  independently defined — moved it into the shared `scripts/tests/helpers.py`
+  (following the same `helpers.py`-per-test-directory convention already used
+  by `skills/carve-changesets/scripts/tests/helpers.py` and
+  `skills/review-fix-loop/scripts/tests/helpers.py`) and updated all four
+  callers to import it instead. Dropped the now-unused `import re` in the three
+  files where `compact()` was the only user of the module; kept it in
+  `test_peer_composition_readme.py`, which still calls `re.search` elsewhere.
+  Flagged as a non-gating `defer`-severity finding by review-code-change's
+  code-simplicity lens while reviewing #139; out of that PR's scope, fixed
+  separately here. Pure deduplication, no behavior change — all four files'
+  existing tests pass unchanged; `just format`/`just lint`/`just test` all
+  green.
 
 - feat: reposition marketplace metadata and the README lead as the outer-loop
   companion to superpowers (issue #139, epic #121) — the "Using beside peer
@@ -29,7 +45,7 @@ summary: Chronological history of repository and skill changes.
   the superpowers mention, and the compose/depend contrast across the README
   lead and all four description surfaces. Docs/config-only change — no
   behavioral test beyond the new structural pins; `just lint`/`just test` both
-  green.
+  green. (b42eda34761fe375f0352bed98c551e905cbf398)
 
 - feat: add version-bump tooling, cross-manifest drift detection, narrative
   release notes, and a documented release process (issue #138, epic #121) —

--- a/scripts/tests/helpers.py
+++ b/scripts/tests/helpers.py
@@ -7,6 +7,7 @@ Follows the same `helpers.py`-per-test-directory convention already used by
 
 from __future__ import annotations
 
+import re
 import shutil
 from pathlib import Path
 
@@ -22,3 +23,8 @@ def copy_fixture(destination: Path) -> None:
     """Copy the plugin packaging fixture directories into `destination`."""
     for name in PLUGIN_FIXTURE_DIRS:
         shutil.copytree(REPOSITORY_ROOT / name, destination / name)
+
+
+def compact(value: str) -> str:
+    """Collapse runs of whitespace to a single space and strip the ends."""
+    return re.sub(r"\s+", " ", value).strip()

--- a/scripts/tests/test_marketplace_positioning.py
+++ b/scripts/tests/test_marketplace_positioning.py
@@ -9,16 +9,13 @@ carries the same "outer loop" / "compose with, not depend on" positioning.
 from __future__ import annotations
 
 import json
-import re
 import unittest
 from pathlib import Path
 
+from helpers import compact
+
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 README = REPOSITORY_ROOT / "README.md"
-
-
-def compact(value: str) -> str:
-    return re.sub(r"\s+", " ", value).strip()
 
 
 class ReadmeLeadPositioningTests(unittest.TestCase):

--- a/scripts/tests/test_peer_composition_readme.py
+++ b/scripts/tests/test_peer_composition_readme.py
@@ -19,6 +19,8 @@ import re
 import unittest
 from pathlib import Path
 
+from helpers import compact
+
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 README = REPOSITORY_ROOT / "README.md"
 
@@ -34,10 +36,6 @@ SEAM_STATUS = {
     **dict.fromkeys(LANDED_SEAM_TICKETS, "Landed"),
     **dict.fromkeys(PLANNED_SEAM_TICKETS, "Planned"),
 }
-
-
-def compact(value: str) -> str:
-    return re.sub(r"\s+", " ", value).strip()
 
 
 def last_cell(row: str) -> str:

--- a/scripts/tests/test_release_docs.py
+++ b/scripts/tests/test_release_docs.py
@@ -7,17 +7,14 @@ and operator-only tagging authority.
 
 from __future__ import annotations
 
-import re
 import unittest
 from pathlib import Path
+
+from helpers import compact
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 RELEASE_NOTES = REPOSITORY_ROOT / "RELEASE-NOTES.md"
 RELEASE_PROCESS = REPOSITORY_ROOT / "docs" / "release-process.md"
-
-
-def compact(value: str) -> str:
-    return re.sub(r"\s+", " ", value).strip()
 
 
 class ReleaseNotesTests(unittest.TestCase):

--- a/scripts/tests/test_skill_authoring_doc.py
+++ b/scripts/tests/test_skill_authoring_doc.py
@@ -7,16 +7,13 @@ own tests live here rather than inside any one skill's test suite.
 
 from __future__ import annotations
 
-import re
 import unittest
 from pathlib import Path
 
+from helpers import compact
+
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 AUTHORING_DOC = REPOSITORY_ROOT / "docs" / "skill-authoring.md"
-
-
-def compact(value: str) -> str:
-    return re.sub(r"\s+", " ", value).strip()
 
 
 class SkillAuthoringDocTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Add `compact(value: str) -> str` to `scripts/tests/helpers.py`
- Update `test_peer_composition_readme.py`, `test_skill_authoring_doc.py`, `test_release_docs.py`, and `test_marketplace_positioning.py` to import it instead of each defining a byte-identical local copy
- Drop the now-unused `import re` in the three files where `compact()` was the only user of the module (kept in `test_peer_composition_readme.py`, which still uses `re.search` elsewhere)

## Why
Flagged as a non-gating `defer`-severity finding by review-code-change's code-simplicity lens while reviewing #139; it was cosmetic and low-risk but out of that PR's scope. Pure deduplication — no behavior change.

## Test plan
- [x] `just format`
- [x] `just lint`
- [x] `just test` (all suites, including the 95 tests under `scripts/tests`)
