### PR TITLE
docs: record the cognitive-driven development direction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ summary: Chronological history of repository and skill changes.
 
 ## 2026-08-09 — Recorded the cognitive-driven development direction: compris takes sole ownership of the cognitive-shaping doctrine from atelier, moves the boundary from "planning is done" to "brainstorming is done", and renames ready-ticket to plan-implementation
 
+- docs: decompose the cognitive-driven development brief into four specs and
+  record the alternatives it never examined — a brainstorming pass over the
+  committed design applied that skill's scope rule and found three dependency
+  roots, three risk profiles and three definitions of done in one document. The
+  tell was not the step count but that every reversal of standing repository
+  doctrine sat in one step: #118's design-approval gate, granular default-off
+  authority, `ready-ticket`'s no-additional-items rule, and the
+  trigger-namespace rule. The brief is now Spec A (compris owns the doctrine —
+  no new skills, no renames, no reversals, complete on its own), Spec B (an
+  executable shaping verdict), Spec C (the planner, carrying every reversal),
+  and Spec D (object model and migration, a live YAGNI candidate because both
+  halves are conceded zero-behavior-change yet the migration triggers the
+  eval-record obligation across three large skills while the brief forfeits the
+  diff it produces). Also records three alternatives a long convergent
+  conversation had left unexamined. The first is serious enough to gate Spec B:
+  the brief argued "a document gets cited; a skill gets called" and concluded
+  only a skill makes doctrine enforceable, but that is a false binary and the
+  counterexample was already in the tree — `review-suite/` distributes canonical
+  normative text, including a ported peer doctrine, via `just sync-contracts`
+  into three consumers' `references/`, drift-checked by `just check-installed`.
+  Spec B is not to be built until that is argued down or adopted. The document
+  reaching this conclusion is the invariant working on itself: it exceeded one
+  reviewable unit and had to become several separately trackable things, decided
+  by the rule it proposes for everything else.
+
 - docs: record that the peer pin is marketplace release 6.2.0, and re-sync the
   published brief — the superpowers plugin turned out to be installed after all,
   just after this session resolved its skill listing, so the pin could finally
@@ -19,7 +44,8 @@ summary: Chronological history of repository and skill changes.
   cross-references pointing at the wrong steps, and a stale "four skills'
   separate corpora" that should have followed the four-judges-to-three
   correction. The published brief is regenerated from the committed markdown
-  rather than patched, so the two no longer drift.
+  rather than patched, so the two no longer drift
+  (1d6322dcfdccdc02199c1f4c85a84becac010b24)
 
 - docs: bolster the cognitive-driven development design against an adversarial
   read — an independent reviewer checked the committed document against the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ summary: Chronological history of repository and skill changes.
 
 ## 2026-08-09 — Recorded the cognitive-driven development direction: compris takes sole ownership of the cognitive-shaping doctrine from atelier, moves the boundary from "planning is done" to "brainstorming is done", and renames ready-ticket to plan-implementation
 
+- docs: commit the presentation copy of the cognitive-driven development design
+  and link it from the Markdown — the rendered brief existed only as a published
+  artifact, outside version control, which had already let the two drift twice
+  in one session: once when several rounds of edits landed in the Markdown
+  alone, and once when the artifact was republished with a description promising
+  content its HTML did not contain. `docs/cognitive-driven-development.html` now
+  sits beside the Markdown and is the file the artifact is published from,
+  wrapped as a standalone document so it also renders when opened directly; the
+  Artifact renderer supplies its own wrapper, so publishing strips this one. The
+  Markdown states which is canonical for review and that both change together.
+  `just format` covers only Python and Markdown, so the HTML is not reformatted
+  and the committed copy stays byte-comparable with what gets published.
+
 - docs: make cognitive shaping a policy-governed default and state the program's
   motive honestly — not every project demands cognitively shaped pull requests.
   A project may legitimately want compris for ticket authoring and delivery
@@ -26,7 +39,7 @@ summary: Chronological history of repository and skill changes.
   metric would reject a small change precisely because the eval norm requires
   its evidence committed; and the retrospective merged-history corpus is
   buildable today against `git log`, which is how the distortion was caught in
-  the first place.
+  the first place (43c83dea578cbfb93ccfa29fab0c8317841d015d)
 
 - docs: decompose the cognitive-driven development brief into four specs and
   record the alternatives it never examined — a brainstorming pass over the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ summary: Chronological history of repository and skill changes.
 
 ## 2026-08-09 — Recorded the cognitive-driven development direction: compris takes sole ownership of the cognitive-shaping doctrine from atelier, moves the boundary from "planning is done" to "brainstorming is done", and renames ready-ticket to plan-implementation
 
+- docs: make cognitive shaping a policy-governed default and state the program's
+  motive honestly — not every project demands cognitively shaped pull requests.
+  A project may legitimately want compris for ticket authoring and delivery
+  automation while declining to be gated on shape, and compris itself is one
+  such project today. The invariant is therefore a default rather than a law:
+  the shaper always judges and the consuming project decides whether an
+  `exceeds` verdict gates anything, which needs no new policy machinery because
+  the shaper's read-only stance already separates judgment from enforcement.
+  That also corrects an overclaim made while gathering failure-first evidence:
+  this repository's merged-PR churn (median 1,253 lines, max 7,829) and the fact
+  that `carve-changesets` has never carved anything here were presented as
+  observed failure, when both are the deliberate exercise of that latitude. The
+  brief now states plainly that the program is capability-driven, not
+  failure-driven. Two findings survive the correction, both from real data
+  rather than principle: recorded machine-generated evidence must be excluded
+  from shape judgment, since PR #179 is 4,715 lines of churn of which 4,538 is
+  committed eval results and the reviewable change is 177 lines — a raw-churn
+  metric would reject a small change precisely because the eval norm requires
+  its evidence committed; and the retrospective merged-history corpus is
+  buildable today against `git log`, which is how the distortion was caught in
+  the first place.
+
 - docs: decompose the cognitive-driven development brief into four specs and
   record the alternatives it never examined — a brainstorming pass over the
   committed design applied that skill's scope rule and found three dependency
@@ -29,7 +51,8 @@ summary: Chronological history of repository and skill changes.
   Spec B is not to be built until that is argued down or adopted. The document
   reaching this conclusion is the invariant working on itself: it exceeded one
   reviewable unit and had to become several separately trackable things, decided
-  by the rule it proposes for everything else.
+  by the rule it proposes for everything else
+  (e7740840ec5b47ade2615d52913092a1a37de8a4)
 
 - docs: record that the peer pin is marketplace release 6.2.0, and re-sync the
   published brief — the superpowers plugin turned out to be installed after all,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ summary: Chronological history of repository and skill changes.
 
 ## 2026-08-09 — Recorded the cognitive-driven development direction: compris takes sole ownership of the cognitive-shaping doctrine from atelier, moves the boundary from "planning is done" to "brainstorming is done", and renames ready-ticket to plan-implementation
 
+- docs: drop the hosted link from the cognitive-driven development design — the
+  Markdown pointed at a claude.ai-hosted rendering of itself, which is an
+  external dependency the repository does not control, cannot version, and
+  cannot guarantee stays reachable or in step. The committed
+  `cognitive-driven-development.html` is the presentation copy, and it travels
+  with the document in the same history and the same review.
+
 - docs: commit the presentation copy of the cognitive-driven development design
   and link it from the Markdown — the rendered brief existed only as a published
   artifact, outside version control, which had already let the two drift twice
@@ -17,7 +24,8 @@ summary: Chronological history of repository and skill changes.
   Artifact renderer supplies its own wrapper, so publishing strips this one. The
   Markdown states which is canonical for review and that both change together.
   `just format` covers only Python and Markdown, so the HTML is not reformatted
-  and the committed copy stays byte-comparable with what gets published.
+  and the committed copy stays byte-comparable with what gets published
+  (c2e363470d024fbaa1cd446f48b2946a7abb2674)
 
 - docs: make cognitive shaping a policy-governed default and state the program's
   motive honestly — not every project demands cognitively shaped pull requests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ summary: Chronological history of repository and skill changes.
 
 # Changelog
 
+## 2026-08-09 — Recorded the cognitive-driven development direction: compris takes sole ownership of the cognitive-shaping doctrine from atelier, moves the boundary from "planning is done" to "brainstorming is done", and renames ready-ticket to plan-implementation
+
+- docs: record the cognitive-driven development design — compris is
+  ticket-driven because work spanning more than one pull request has exceeded a
+  local plan's grasp and needs durable, public representation. The document
+  establishes the invariant that every leaf ticket is scoped to exactly one
+  cognitively shaped changeset, ports atelier's human-shaped-changeset test
+  verbatim ("whether a reviewer can construct an accurate mental model of the
+  change and evaluate it independently") along with its eight breakdown rules,
+  and takes sole ownership of both from `shaug/atelier`, which is moving toward
+  multi-agent process management and model routing — a doctrine with two homes
+  has no home. Half the vocabulary comes with it: `changeset` and `initiative`,
+  which atelier's own layer diagram already places on the compris side, while
+  `assignment`, `claim`, `receipt` and `worker` stay in its process layer.
+  Records eight decisions with their reasoning, eight verified findings against
+  `obra/superpowers` at pin `44c9b2d6`, and two open questions. Load-bearing
+  verification falsified three assumptions during authoring: `writing-plans`
+  reads no spec from disk, supplies no pull-request sizing verdict, and ships a
+  dangling plan reviewer — so sizing is house-owned outright and the house
+  reviewer is required rather than optional. Nothing is implemented; the
+  doctrine document and the object model document are the first two steps of the
+  recorded six-step program.
+
 ## 2026-08-08 — Hardened implement-ticket's own worktree isolation mechanics, added version-bump tooling, release notes, and a documented release process, then repositioned marketplace metadata and the README lead as the outer-loop companion to superpowers, then deduplicated the byte-identical `compact()` test helper into `scripts/tests/helpers.py`
 
 - refactor: deduplicate the byte-identical `compact()` whitespace-collapsing
@@ -490,7 +513,8 @@ summary: Chronological history of repository and skill changes.
   plus three in `docs/skill-authoring.md`'s own new test file pinning the
   admissible-evidence rule's wording, placement, and reconciliation with the
   baseline exemplar — each independently observed failing when run against the
-  unmodified base `20d05b0` and passing at head.
+  unmodified base `20d05b0` and passing at head
+  (2d5fa6041825cc5161d4300f9b3056b948bd8029)
 
   Eval evidence: the deterministic tier for `carve-changesets` is unchanged
   before and after (12/12, empty per-case diff) — the corpus reads only the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ summary: Chronological history of repository and skill changes.
 
 ## 2026-08-09 — Recorded the cognitive-driven development direction: compris takes sole ownership of the cognitive-shaping doctrine from atelier, moves the boundary from "planning is done" to "brainstorming is done", and renames ready-ticket to plan-implementation
 
+- docs: settle the shaping rubric and reframe the altitude question as an
+  experiment — the shaping corpus grades seams rather than partitions, because
+  two good decompositions of the same work agree on where the seams are and
+  disagree on how they group, so partition equality rejects correct answers and
+  accepts cuts through the middle of a concern. The eight breakdown rules sort
+  by kind: three are mechanically checkable and need no judge (one-child count
+  plus a stated reason, re-split trigger presence, the fits-as-one case),
+  halving the judge surface and keeping most of the corpus deterministic. Each
+  case is built around a specific trap, since a corpus that only rewards good
+  answers measures little; the merged-PR history supplies free labeled data,
+  where work whose shape held is a positive and work that had to be carved is a
+  negative already annotated by the carving; judges are perspective-diverse
+  rather than redundant; and no numeric score is emitted, because the doctrine
+  retired numeric heuristics and per-rule pass/fail with recorded observations
+  is what `AGENTS.md` already asks for. Separately, the `writing-plans` altitude
+  question moves from an open question to a recorded experiment with a named run
+  and success criterion — nobody owes an answer there, someone owes a run — with
+  the three-way contingency deliberately left un-pre-decided until it reports.
+
 - docs: record the cognitive-driven development design — compris is
   ticket-driven because work spanning more than one pull request has exceeded a
   local plan's grasp and needs durable, public representation. The document
@@ -25,7 +44,7 @@ summary: Chronological history of repository and skill changes.
   dangling plan reviewer — so sizing is house-owned outright and the house
   reviewer is required rather than optional. Nothing is implemented; the
   doctrine document and the object model document are the first two steps of the
-  recorded six-step program.
+  recorded six-step program (53cb800756fcaaec57a080ed58ab2552145eecdc)
 
 ## 2026-08-08 — Hardened implement-ticket's own worktree isolation mechanics, added version-bump tooling, release notes, and a documented release process, then repositioned marketplace metadata and the README lead as the outer-loop companion to superpowers, then deduplicated the byte-identical `compact()` test helper into `scripts/tests/helpers.py`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ summary: Chronological history of repository and skill changes.
 
 ## 2026-08-09 — Recorded the cognitive-driven development direction: compris takes sole ownership of the cognitive-shaping doctrine from atelier, moves the boundary from "planning is done" to "brainstorming is done", and renames ready-ticket to plan-implementation
 
+- docs: record that the peer pin is marketplace release 6.2.0, and re-sync the
+  published brief — the superpowers plugin turned out to be installed after all,
+  just after this session resolved its skill listing, so the pin could finally
+  be checked against what a user actually receives. It matches: the installed
+  plugin and the pinned checkout carry the same fourteen skills, and
+  `writing-plans` and `brainstorming` — the two every finding in the design
+  rests on — are byte-identical between them. Recording the release alongside
+  the SHA makes the pin resolvable by a reader who cannot run `git`, and it
+  retires the document's last unverified assumption about its own evidence. Also
+  fixes three defects the eight-step renumbering introduced: two internal
+  cross-references pointing at the wrong steps, and a stale "four skills'
+  separate corpora" that should have followed the four-judges-to-three
+  correction. The published brief is regenerated from the committed markdown
+  rather than patched, so the two no longer drift.
+
 - docs: bolster the cognitive-driven development design against an adversarial
   read — an independent reviewer checked the committed document against the
   repository's own contracts and found seventeen problems, all verified before
@@ -39,7 +54,8 @@ summary: Chronological history of repository and skill changes.
   correct when written and rotted in the rebase, while the triggering-corpus row
   cited a refuted observation rather than `triggering/expectations.json:130`,
   where the case is a *negative* owned by `review-code-change` that cannot
-  simply be flipped without destroying that skill's coverage.
+  simply be flipped without destroying that skill's coverage
+  (99877814bd3c1f2be2378160d0fa9aae0c280c8e)
 
 - docs: settle the shaping rubric and reframe the altitude question as an
   experiment — the shaping corpus grades seams rather than partitions, because

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,41 @@ summary: Chronological history of repository and skill changes.
 
 ## 2026-08-09 — Recorded the cognitive-driven development direction: compris takes sole ownership of the cognitive-shaping doctrine from atelier, moves the boundary from "planning is done" to "brainstorming is done", and renames ready-ticket to plan-implementation
 
+- docs: bolster the cognitive-driven development design against an adversarial
+  read — an independent reviewer checked the committed document against the
+  repository's own contracts and found seventeen problems, all verified before
+  acting. Four needed decisions and are now recorded. `initiative` and `epic`
+  are kept as a mapped pair rather than one replacing the other: an initiative
+  is the logical grouping the breakdown derives, an epic is its tracker
+  realization, and compris keeps `implement-epic`'s authoritative parent (its
+  own acceptance ledger and closeout gate) instead of overwriting it with
+  atelier's lighter non-authoritative grouping. The invariant is restated as a
+  prediction rather than an identity, because `implement-ticket` ships
+  `ready_prs` — one ticket, an authorized carved stack, several pull requests —
+  so a carved stack is a recorded falsification, not a violation. The breakdown
+  becomes house-owned and complete without a peer, since
+  `docs/skill-authoring.md:598` forbids depending on one; `writing-plans`
+  supplies the richer method when present, and the cost of maintaining both
+  paths is named. Ticket-graph creation stays an approval gate that may be
+  pre-approved at invocation, at which point the presentation becomes disclosure
+  — which is also what makes autonomous graph creation possible, since an
+  autonomous run has nobody to ask. Thirteen further corrections: the extraction
+  premise dropped from four independent judges to three, because
+  `implement-ticket:632-635` already reads `carve-changesets`' live guardrails
+  and is forbidden to substitute local heuristics — it is the pattern's
+  precedent, not an instance of the problem; a new program step wires the
+  doctrine in and retires `carve-changesets/references/SPEC.md`'s own guardrails
+  so the doctrine replaces codifications rather than becoming a fifth; another
+  revises `docs/skill-authoring.md` and `README.md`, whose composition rule 1
+  asserts a mechanism that stops being true; the shaper contract gains a closed
+  terminal-state set with `blocked` as its honest fallback; the rubric now
+  accounts for all eight breakdown rules, recording that rule 8 is not gradeable
+  at plan time; and two citations of mine were wrong — `implement-epic:186` was
+  correct when written and rotted in the rebase, while the triggering-corpus row
+  cited a refuted observation rather than `triggering/expectations.json:130`,
+  where the case is a *negative* owned by `review-code-change` that cannot
+  simply be flipped without destroying that skill's coverage.
+
 - docs: settle the shaping rubric and reframe the altitude question as an
   experiment — the shaping corpus grades seams rather than partitions, because
   two good decompositions of the same work agree on where the seams are and
@@ -23,7 +58,8 @@ summary: Chronological history of repository and skill changes.
   is what `AGENTS.md` already asks for. Separately, the `writing-plans` altitude
   question moves from an open question to a recorded experiment with a named run
   and success criterion — nobody owes an answer there, someone owes a run — with
-  the three-way contingency deliberately left un-pre-decided until it reports.
+  the three-way contingency deliberately left un-pre-decided until it reports
+  (eab76ecab2e4fe400c00c00622e0adda49a3ea7c)
 
 - docs: record the cognitive-driven development design — compris is
   ticket-driven because work spanning more than one pull request has exceeded a

--- a/docs/cognitive-driven-development.html
+++ b/docs/cognitive-driven-development.html
@@ -1,0 +1,1154 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<!--
+  Presentation copy of docs/cognitive-driven-development.md.
+  The Markdown is canonical for review; this renders the same content.
+  Published as a Claude Artifact by stripping this document wrapper; the
+  Artifact renderer supplies its own. Keep this file and the Markdown in
+  step when either changes.
+-->
+<title>compris: cognitive-driven development</title>
+
+<style>
+  :root {
+    --paper:      #EDEEF0;
+    --surface:    #FFFFFF;
+    --surface-2:  #E4E6EA;
+    --ink:        #181F2B;
+    --ink-soft:   #3A4557;
+    --muted:      #5C6B82;
+    --rule:       #C9CFD9;
+    --accent:     #2D4B8E;
+    --accent-soft:#DDE4F2;
+    --warn:       #8A5A2B;
+    --warn-soft:  #F0E5D6;
+    --good:       #2F6B4F;
+    --good-soft:  #DCEAE1;
+
+    --serif: "Iowan Old Style", "Palatino Linotype", Palatino, "Book Antiqua", Georgia, serif;
+    --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+
+    --measure: 68ch;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --paper:      #12161D;
+      --surface:    #181D26;
+      --surface-2:  #1F2530;
+      --ink:        #E4E8EF;
+      --ink-soft:   #B9C2D0;
+      --muted:      #8A97AC;
+      --rule:       #2C3442;
+      --accent:     #7FA3E8;
+      --accent-soft:#1C2941;
+      --warn:       #C89B62;
+      --warn-soft:  #2E2517;
+      --good:       #6FAE8C;
+      --good-soft:  #17281F;
+    }
+  }
+
+  :root[data-theme="dark"] {
+    --paper:      #12161D;
+    --surface:    #181D26;
+    --surface-2:  #1F2530;
+    --ink:        #E4E8EF;
+    --ink-soft:   #B9C2D0;
+    --muted:      #8A97AC;
+    --rule:       #2C3442;
+    --accent:     #7FA3E8;
+    --accent-soft:#1C2941;
+    --warn:       #C89B62;
+    --warn-soft:  #2E2517;
+    --good:       #6FAE8C;
+    --good-soft:  #17281F;
+  }
+
+  :root[data-theme="light"] {
+    --paper:      #EDEEF0;
+    --surface:    #FFFFFF;
+    --surface-2:  #E4E6EA;
+    --ink:        #181F2B;
+    --ink-soft:   #3A4557;
+    --muted:      #5C6B82;
+    --rule:       #C9CFD9;
+    --accent:     #2D4B8E;
+    --accent-soft:#DDE4F2;
+    --warn:       #8A5A2B;
+    --warn-soft:  #F0E5D6;
+    --good:       #2F6B4F;
+    --good-soft:  #DCEAE1;
+  }
+
+  * { box-sizing: border-box; }
+
+  body {
+    margin: 0;
+    background: var(--paper);
+    color: var(--ink);
+    font-family: var(--serif);
+    font-size: 17px;
+    line-height: 1.62;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .shell {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 0;
+    max-width: 1180px;
+    margin: 0 auto;
+    padding: 0 24px 96px;
+  }
+
+  @media (min-width: 1000px) {
+    .shell {
+      grid-template-columns: 210px minmax(0, var(--measure));
+      column-gap: 64px;
+      justify-content: center;
+      padding-left: 40px;
+      padding-right: 40px;
+    }
+  }
+
+  /* ---------- masthead ---------- */
+
+  .masthead {
+    grid-column: 1 / -1;
+    padding: 72px 0 40px;
+    border-bottom: 1px solid var(--rule);
+    margin-bottom: 48px;
+  }
+
+  .eyebrow {
+    font-family: var(--sans);
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--muted);
+    margin: 0 0 20px;
+  }
+
+  h1 {
+    font-family: var(--serif);
+    font-size: clamp(38px, 6vw, 61px);
+    line-height: 1.04;
+    font-weight: 600;
+    letter-spacing: -0.02em;
+    text-wrap: balance;
+    margin: 0 0 24px;
+    max-width: 18ch;
+  }
+
+  .standfirst {
+    font-size: clamp(19px, 2.4vw, 23px);
+    line-height: 1.5;
+    color: var(--ink-soft);
+    max-width: 54ch;
+    margin: 0 0 36px;
+    text-wrap: pretty;
+  }
+
+  .meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px 28px;
+    font-family: var(--sans);
+    font-size: 12.5px;
+    color: var(--muted);
+  }
+
+  .meta b {
+    font-weight: 600;
+    color: var(--ink-soft);
+  }
+
+  /* ---------- contents rail ---------- */
+
+  .rail { display: none; }
+
+  @media (min-width: 1000px) {
+    .rail {
+      display: block;
+      grid-column: 1;
+      align-self: start;
+      position: sticky;
+      top: 40px;
+      font-family: var(--sans);
+      font-size: 13px;
+      line-height: 1.45;
+    }
+    .rail p {
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--muted);
+      margin: 0 0 14px;
+    }
+    .rail ol {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 11px;
+    }
+    .rail a {
+      color: var(--ink-soft);
+      text-decoration: none;
+      border-left: 2px solid var(--rule);
+      padding-left: 12px;
+      display: block;
+    }
+    .rail a:hover,
+    .rail a:focus-visible {
+      color: var(--accent);
+      border-left-color: var(--accent);
+    }
+  }
+
+  /* ---------- main column ---------- */
+
+  main {
+    grid-column: 1;
+    min-width: 0;
+    max-width: var(--measure);
+  }
+
+  @media (min-width: 1000px) {
+    main { grid-column: 2; }
+  }
+
+  section { margin: 0 0 68px; scroll-margin-top: 28px; }
+
+  h2 {
+    font-family: var(--serif);
+    font-size: 30px;
+    line-height: 1.2;
+    font-weight: 600;
+    letter-spacing: -0.012em;
+    text-wrap: balance;
+    margin: 0 0 8px;
+  }
+
+  .kicker {
+    font-family: var(--sans);
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--accent);
+    margin: 0 0 12px;
+  }
+
+  h3 {
+    font-family: var(--sans);
+    font-size: 15px;
+    font-weight: 650;
+    letter-spacing: -0.005em;
+    margin: 34px 0 10px;
+  }
+
+  p { margin: 0 0 18px; text-wrap: pretty; }
+
+  main > section > p:first-of-type { margin-top: 18px; }
+
+  a { color: var(--accent); text-underline-offset: 2px; }
+
+  code {
+    font-family: var(--mono);
+    font-size: 0.86em;
+    background: var(--surface-2);
+    padding: 0.12em 0.36em;
+    border-radius: 3px;
+  }
+
+  ul, ol { margin: 0 0 18px; padding-left: 1.3em; }
+  li { margin-bottom: 9px; }
+  li::marker { color: var(--muted); }
+
+  strong { font-weight: 650; }
+
+  blockquote {
+    margin: 22px 0;
+    padding: 2px 0 2px 22px;
+    border-left: 3px solid var(--accent);
+    color: var(--ink-soft);
+    font-style: italic;
+  }
+  blockquote p:last-child { margin-bottom: 0; }
+  blockquote cite {
+    display: block;
+    margin-top: 10px;
+    font-family: var(--mono);
+    font-size: 12px;
+    font-style: normal;
+    color: var(--muted);
+  }
+
+  /* ---------- diagram ---------- */
+
+  .figure {
+    margin: 30px 0 34px;
+    overflow-x: auto;
+  }
+  .figure svg { display: block; min-width: 580px; width: 100%; height: auto; }
+  figcaption {
+    font-family: var(--sans);
+    font-size: 12.5px;
+    color: var(--muted);
+    margin-top: 12px;
+    line-height: 1.5;
+  }
+
+  /* ---------- program steps ---------- */
+
+  .program {
+    list-style: none;
+    padding: 0;
+    margin: 26px 0 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    counter-reset: step;
+  }
+  .program li {
+    counter-increment: step;
+    display: grid;
+    grid-template-columns: 42px minmax(0, 1fr);
+    gap: 18px;
+    padding: 20px 0;
+    margin: 0;
+    border-top: 1px solid var(--rule);
+  }
+  .program li:last-child { border-bottom: 1px solid var(--rule); }
+  .program li::before {
+    content: counter(step, decimal-leading-zero);
+    font-family: var(--mono);
+    font-size: 13px;
+    font-variant-numeric: tabular-nums;
+    color: var(--accent);
+    padding-top: 3px;
+  }
+  .program h3 { margin: 0 0 6px; font-size: 16px; }
+  .program p { margin: 0; font-size: 16px; color: var(--ink-soft); }
+  .program p + p { margin-top: 10px; }
+  .program .tag {
+    display: inline-block;
+    font-family: var(--sans);
+    font-size: 10.5px;
+    font-weight: 650;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    padding: 2px 7px;
+    border-radius: 3px;
+    margin-left: 8px;
+    vertical-align: 2px;
+    background: var(--good-soft);
+    color: var(--good);
+  }
+  .program .tag.later { background: var(--surface-2); color: var(--muted); }
+
+  /* ---------- record blocks ---------- */
+
+  .record {
+    border: 1px solid var(--rule);
+    border-radius: 4px;
+    background: var(--surface);
+    padding: 22px 24px;
+    margin: 0 0 14px;
+  }
+  .record.open { border-left: 3px solid var(--warn); }
+  .record.settled { border-left: 3px solid var(--good); }
+  .record h3 { margin: 0 0 8px; font-size: 16px; }
+  .record p { margin: 0 0 12px; font-size: 16px; }
+  .record p:last-child { margin-bottom: 0; }
+  .record .why {
+    font-family: var(--sans);
+    font-size: 13.5px;
+    line-height: 1.55;
+    color: var(--muted);
+  }
+  .record .why b {
+    color: var(--ink-soft);
+    font-weight: 650;
+  }
+
+  /* ---------- evidence table ---------- */
+
+  .tablewrap { overflow-x: auto; margin: 24px 0 8px; }
+  table {
+    border-collapse: collapse;
+    width: 100%;
+    min-width: 520px;
+    font-size: 15px;
+  }
+  th, td {
+    text-align: left;
+    vertical-align: top;
+    padding: 12px 16px 12px 0;
+    border-bottom: 1px solid var(--rule);
+  }
+  th {
+    font-family: var(--sans);
+    font-size: 11px;
+    font-weight: 650;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--muted);
+    border-bottom-color: var(--ink-soft);
+    white-space: nowrap;
+  }
+  td:last-child { padding-right: 0; }
+  td.src { font-family: var(--mono); font-size: 12.5px; color: var(--muted); white-space: nowrap; }
+
+  /* ---------- contract ---------- */
+
+  .contract {
+    background: var(--surface);
+    border: 1px solid var(--rule);
+    border-radius: 4px;
+    padding: 4px 24px;
+    margin: 26px 0;
+  }
+  .contract dl { margin: 0; padding: 20px 0; }
+  .contract div + div { border-top: 1px solid var(--rule); }
+  .contract dt {
+    font-family: var(--sans);
+    font-size: 11px;
+    font-weight: 650;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--accent);
+    margin-bottom: 7px;
+  }
+  .contract dd { margin: 0; font-size: 16px; color: var(--ink-soft); }
+  .contract dd ul { margin: 8px 0 0; }
+
+  .note {
+    font-family: var(--sans);
+    font-size: 14px;
+    line-height: 1.6;
+    color: var(--ink-soft);
+    background: var(--accent-soft);
+    border-radius: 4px;
+    padding: 16px 20px;
+    margin: 24px 0;
+  }
+  .note b { font-weight: 650; color: var(--ink); }
+
+  hr.end {
+    border: 0;
+    border-top: 1px solid var(--rule);
+    margin: 0 0 24px;
+  }
+
+  .colophon {
+    font-family: var(--sans);
+    font-size: 12.5px;
+    line-height: 1.6;
+    color: var(--muted);
+  }
+
+  :focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 3px;
+    border-radius: 2px;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    * { animation: none !important; transition: none !important; }
+  }
+</style>
+</head>
+<body>
+<div class="shell">
+
+  <header class="masthead">
+    <p class="eyebrow">Program brief · compris</p>
+    <h1>Cognitive-driven development</h1>
+    <p class="standfirst">
+      Test-driven development lets the test drive the design. Cognitive-driven development lets
+      a reviewer's capacity to hold the change drive how the work is broken apart — and compris
+      takes ownership of the doctrine, the vocabulary, and the judgment that enforces it.
+    </p>
+    <div class="meta">
+      <span><b>Status</b> Direction agreed, nothing built</span>
+      <span><b>Ceded by</b> shaug/atelier</span>
+      <span><b>Renames</b> ready-ticket → plan-implementation</span>
+      <span><b>Decomposes into</b> four specs</span>
+      <span><b>Next</b> Spec A</span>
+    </div>
+  </header>
+
+  <nav class="rail" aria-label="Contents">
+    <p>Contents</p>
+    <ol>
+      <li><a href="#practice">The practice</a></li>
+      <li><a href="#thesis">The thesis</a></li>
+      <li><a href="#boundary">Where the line falls</a></li>
+      <li><a href="#invariant">The invariant</a></li>
+      <li><a href="#custody">Ending shared custody</a></li>
+      <li><a href="#shaper">The shaping skill</a></li>
+      <li><a href="#program">Four specs</a></li>
+      <li><a href="#alts">Alternatives open</a></li>
+      <li><a href="#decisions">Decisions on record</a></li>
+      <li><a href="#status">What the evidence shows</a></li>
+      <li><a href="#evidence">Verified evidence</a></li>
+      <li><a href="#open">Experiment</a></li>
+    </ol>
+  </nav>
+
+  <main>
+
+    <section id="practice">
+      <p class="kicker">The practice</p>
+      <h2>Comprehension drives decomposition</h2>
+      <p>
+        Work is normally broken apart by feature area, team ownership, or sprint capacity.
+        Cognitive-driven development breaks it apart by what a reviewer can understand in one
+        sitting, and treats that as the binding constraint rather than a nicety observed when
+        there is time.
+      </p>
+      <p>
+        Two consequences follow, and both are load-bearing. The tracker hierarchy stops being an
+        organizational choice and becomes a <strong>derived artifact of the implementation
+        breakdown</strong> — which is why the breakdown has to happen before the tickets exist,
+        and why nobody can know whether something is one ticket or twelve until it has been
+        broken down. And the skill that performs it becomes the highest-leverage and highest-risk
+        in the suite: everything downstream inherits its decomposition, and no amount of good
+        implementation repairs a bad one.
+      </p>
+    </section>
+
+    <section id="thesis">
+      <p class="kicker">Why this exists</p>
+      <h2>Work that spans pull requests has outgrown a local plan</h2>
+      <p>
+        compris is ticket-driven, and that is what separates it from a methodology library.
+        Capturing a design, reviewing it, breaking it into an implementation plan, and building
+        it are all necessary — but they have to happen <em>in public</em>, at whatever scope the
+        organization draws. A plan file is local, ephemeral, single-agent, and dies with the
+        context that produced it.
+      </p>
+      <p>
+        So the test is simple: <strong>if an implementation plan spans more than one pull
+        request, it has exceeded its grasp</strong> and should have been represented by something
+        more permanent. Durable identity, real dependency edges, visibility to the org, survival
+        across handoffs and context loss. That is a tracker, not a markdown file.
+      </p>
+    </section>
+
+    <section id="boundary">
+      <p class="kicker">Retiring the old tagline</p>
+      <h2>For when the brainstorming is done</h2>
+      <p>
+        The README currently says compris is <em>for when the planning is done, and the work
+        begins</em>. That is wrong, and it has already misled a reader into inverting this design
+        once. compris plans constantly — it builds an implementation plan, shapes it into tickets,
+        and revises it when reality disagrees. Planning is not the thing it starts after.
+      </p>
+      <p>
+        Brainstorming is. It names an activity with a definite output, so the boundary can be
+        checked rather than interpreted. <strong>Brainstorming is done when the requirements and
+        acceptance criteria are captured, the goals and non-goals are known, and the stakeholders
+        and deadlines are identified — each at the scale the work warrants.</strong> For a
+        one-line bugfix, the sentence is the design.
+      </p>
+      <p>
+        Everything after that is compris: turn it into a ticket-based implementation plan, and
+        drive it to completion, adjusting the plan against conditions on the ground. A bugfix in
+        one sentence and a design document representing months of work are both legal inputs —
+        the difference surfaces in the breakdown, not at the door.
+      </p>
+
+      <figure class="figure">
+        <svg viewBox="0 0 900 230" role="img" aria-label="Pipeline diagram. Left of the boundary, brainstorming turns input of any size into captured requirements, acceptance criteria, goals and non-goals, stakeholders and deadlines. Right of the boundary, compris shapes that into an epic and leaf tickets, each realized as one changeset and one pull request, with a re-split loop feeding back into shaping.">
+          <defs>
+            <marker id="ar" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+              <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--muted)"></path>
+            </marker>
+            <marker id="ar-a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+              <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--accent)"></path>
+            </marker>
+          </defs>
+
+          <text x="8" y="20" font-family="var(--sans)" font-size="11" font-weight="650" letter-spacing="1.4" fill="var(--muted)">BRAINSTORMING · PEERS</text>
+          <text x="418" y="20" font-family="var(--sans)" font-size="11" font-weight="650" letter-spacing="1.4" fill="var(--accent)">COMPRIS</text>
+
+          <line x1="400" y1="32" x2="400" y2="212" stroke="var(--accent)" stroke-width="1.5" stroke-dasharray="5 5"></line>
+
+          <rect x="8" y="56" width="150" height="52" rx="4" fill="var(--surface)" stroke="var(--rule)"></rect>
+          <text x="83" y="79" text-anchor="middle" font-family="var(--sans)" font-size="13.5" font-weight="600" fill="var(--ink)">one sentence</text>
+          <text x="83" y="97" text-anchor="middle" font-family="var(--sans)" font-size="12" fill="var(--muted)">…or months of work</text>
+
+          <line x1="166" y1="82" x2="204" y2="82" stroke="var(--muted)" stroke-width="1.4" marker-end="url(#ar)"></line>
+
+          <rect x="212" y="46" width="172" height="72" rx="4" fill="var(--surface)" stroke="var(--rule)"></rect>
+          <text x="298" y="68" text-anchor="middle" font-family="var(--sans)" font-size="12.5" fill="var(--ink)">requirements · criteria</text>
+          <text x="298" y="87" text-anchor="middle" font-family="var(--sans)" font-size="12.5" fill="var(--ink)">goals · non-goals</text>
+          <text x="298" y="106" text-anchor="middle" font-family="var(--sans)" font-size="12.5" fill="var(--ink)">stakeholders · dates</text>
+
+          <line x1="392" y1="82" x2="428" y2="82" stroke="var(--muted)" stroke-width="1.4" marker-end="url(#ar)"></line>
+
+          <rect x="436" y="56" width="132" height="52" rx="4" fill="var(--accent-soft)" stroke="var(--accent)"></rect>
+          <text x="502" y="79" text-anchor="middle" font-family="var(--sans)" font-size="13.5" font-weight="600" fill="var(--ink)">shape</text>
+          <text x="502" y="97" text-anchor="middle" font-family="var(--sans)" font-size="12" fill="var(--muted)">seams · breakdown</text>
+
+          <line x1="576" y1="82" x2="612" y2="82" stroke="var(--muted)" stroke-width="1.4" marker-end="url(#ar)"></line>
+
+          <rect x="620" y="46" width="120" height="34" rx="4" fill="var(--surface)" stroke="var(--rule)"></rect>
+          <text x="680" y="68" text-anchor="middle" font-family="var(--sans)" font-size="12.5" fill="var(--ink)">epic</text>
+
+          <rect x="620" y="88" width="120" height="34" rx="4" fill="var(--surface)" stroke="var(--rule)"></rect>
+          <text x="680" y="110" text-anchor="middle" font-family="var(--sans)" font-size="12.5" fill="var(--ink)">leaf ticket</text>
+
+          <line x1="748" y1="105" x2="784" y2="105" stroke="var(--muted)" stroke-width="1.4" marker-end="url(#ar)"></line>
+
+          <rect x="792" y="88" width="100" height="34" rx="4" fill="var(--accent-soft)" stroke="var(--accent)"></rect>
+          <text x="842" y="104" text-anchor="middle" font-family="var(--sans)" font-size="12.5" fill="var(--ink)">changeset</text>
+          <text x="842" y="118" text-anchor="middle" font-family="var(--sans)" font-size="11" fill="var(--muted)">one PR</text>
+
+          <path d="M 842 130 L 842 176 L 502 176 L 502 118" fill="none" stroke="var(--accent)" stroke-width="1.4" stroke-dasharray="4 4" marker-end="url(#ar-a)"></path>
+          <text x="672" y="194" text-anchor="middle" font-family="var(--sans)" font-size="12" fill="var(--accent)">re-split trigger fires · the plan adjusts</text>
+        </svg>
+        <figcaption>
+          Left of the line, a human decides what the work is. Right of it, compris decides how it
+          is cut, delivers it, and re-cuts when the ground moves. The loop is core behavior, not
+          error recovery.
+        </figcaption>
+      </figure>
+    </section>
+
+    <section id="invariant">
+      <p class="kicker">The one thing everything serves</p>
+      <h2>Every leaf ticket is scoped to one predicted changeset</h2>
+      <p>
+        <strong>The invariant is a default, not a law.</strong> Not every project demands
+        cognitively shaped pull requests. A project may legitimately want compris for ticket
+        authoring and delivery automation while declining to be gated on shape — compris itself
+        is one such project today. So the shaper always <em>judges</em>, and the consuming
+        project decides whether an <code>exceeds</code> verdict gates anything. No new policy
+        machinery is needed: the shaper is already read-only, which separates judgment from
+        enforcement by construction.
+      </p>
+      <p>
+        <strong>And the prediction is the invariant, not the identity.</strong>
+        <code>implement-ticket</code> ships <code>ready_prs</code> — one ticket, an authorized
+        carved stack, several pull requests — and that path stays. A carved stack is the
+        <em>recorded falsification</em> of a shaping prediction, not a violation of the rule.
+        Developers are bad at estimating; the answer is measurement, not accuracy.
+      </p>
+      <p>The standard comes from atelier and travels intact:</p>
+      <blockquote>
+        <p>
+          Line counts may inform judgment but are not universal correctness gates. The test is
+          whether a reviewer can construct an accurate mental model of the change and evaluate it
+          independently.
+        </p>
+        <cite>atelier · docs/atelier-skill-design.md:480</cite>
+      </blockquote>
+      <p>
+        This is not a threshold check. atelier dropped its predecessor's fixed implementation and
+        <em>some</em> of its numeric heuristics, subordinating line count to the mental-model
+        test, and states outright that lines of code are not a success measure. Any
+        implementation that reduces this to a number has failed to port it.
+      </p>
+
+      <h3>The breakdown rules, ported whole</h3>
+      <ul>
+        <li>Keep an initiative executable as one ticket when it is already reviewable.</li>
+        <li>Avoid one-child decomposition without a real reason.</li>
+        <li>Separate unrelated concern domains.</li>
+        <li>Prefer additive foundations before disruptive transitions.</li>
+        <li>Separate mechanical restructuring from behavioral change when that helps review.</li>
+        <li>Keep validation with the behavior it proves.</li>
+        <li>Identify re-split triggers before implementation.</li>
+        <li>Create follow-up work when implementation or review reveals new scope.</li>
+      </ul>
+      <p>
+        The first two matter most for tone: one ticket is a legal outcome. Ceremonial
+        decomposition is a failure, not diligence.
+      </p>
+    </section>
+
+    <section id="custody">
+      <p class="kicker">Ownership</p>
+      <h2>Ending shared custody</h2>
+      <p>
+        atelier used to own the breakdown. It is moving toward multi-agent process management and
+        model selection and routing, and it is mid-rebuild. Leaving the doctrine in the project
+        that no longer applies it guarantees the drift this program exists to stop. A doctrine
+        with two homes has no home.
+      </p>
+      <p>
+        The name already fits the job. <em>compris</em> is French for <em>understood</em> — what
+        the suite claims at the moment work changes hands. The shaping test asks whether a
+        reviewer can build an accurate mental model. That is understanding, operationalized.
+      </p>
+      <div class="note">
+        <b>Port at a pinned commit.</b> atelier's text is still moving. compris already solved
+        this for superpowers — the registry pins <code>obra/superpowers</code> at
+        <code>44c9b2d6</code>, which corresponds to marketplace release 6.2.0, because an
+        unpinned reference describes a moving target. Recording the release alongside the SHA
+        makes the pin resolvable by a reader who cannot run <code>git</code>.
+      </div>
+
+      <h3>Vocabulary comes too — but only our half of it</h3>
+      <p>
+        atelier's layer diagram already split the nouns, and it put ours on our side. The mailbox
+        layer holds "assignments, messages, claims, receipts"; the compris layer holds
+        "implementation, review, <strong>changeset carving</strong>, PR lifecycle." So
+        <strong>changeset comes home</strong> — already the noun in
+        <code>carve-changesets</code> and in the doctrine's own title.
+      </p>
+      <p>
+        <strong>Assignment, claim, receipt and worker stay with atelier.</strong> They are the
+        process-management layer it is moving into. An assignment is a claimable unit of approved
+        work, which is not the shaped unit of code a reviewer reads; atelier's own wording keeps
+        them distinct. Receipt resolves the same way, since it and compris's evidence-binding are
+        one idea under two names.
+      </p>
+      <p>
+        <strong>Initiative comes, but mapped rather than substituted.</strong> An initiative is
+        the logical grouping the breakdown derives; an <strong>epic</strong> is its tracker
+        realization — and compris keeps its own richer semantics there, since
+        <code>implement-epic</code> gives the parent an acceptance ledger and holds closeout to
+        explicit authority, which atelier's lighter notion would have overwritten.
+      </p>
+
+      <div class="tablewrap">
+        <table>
+          <thead>
+            <tr><th>Logical — internal currency</th><th>Realized — what users say</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>initiative</td><td>epic</td></tr>
+            <tr><td>changeset</td><td>pull request</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <p>
+        A <strong>leaf ticket</strong> is a child of an epic and is scoped to one changeset.
+        Keeping <code>ticket</code> as the leaf noun is what makes this safe: descriptions are the
+        routing surface, people say "implement this GitHub issue," and a description answering
+        only to "execute this assignment" would quietly stop matching them.
+      </p>
+    </section>
+
+    <section id="shaper">
+      <p class="kicker">The new shared skill</p>
+      <h2>One executable home for the judgment</h2>
+      <p>
+        Three skills judge shape independently today and none cites the others:
+        <code>carve-changesets</code> decides changeset boundaries,
+        <code>review-solution-simplicity</code> judges whole-solution complexity, and
+        <code>plan-implementation</code> will decide the decomposition. Same two-codifications
+        problem, already inside one repo.
+      </p>
+      <p>
+        <strong>The fourth is the precedent, not the problem.</strong>
+        <code>implement-ticket</code> carries no heuristic of its own — it loads
+        <code>carve-changesets</code> by stable name, reads its live guardrails, and is forbidden
+        to "copy their thresholds or substitute local heuristics," which
+        <code>docs/skill-authoring.md:198</code> records as the repository's worked example. One
+        caller already delegates shape judgment to an external authority, so extracting the
+        shaper generalizes something that works rather than inventing something new.
+      </p>
+      <p>
+        A document gets cited; a skill gets called. Extracting the judgment is what makes the
+        doctrine enforceable rather than aspirational, and compris has the exact precedent —
+        <code>review-code-change</code> does not implement its three lenses, it invokes them and
+        reconciles typed verdicts.
+      </p>
+
+      <div class="contract">
+        <dl>
+          <div>
+            <dt>Input</dt>
+            <dd>A candidate in any of its forms — source material, design document, ticket, implementation plan, branch, pull request — plus repository context. Heterogeneous evidence is expected.</dd>
+          </div>
+          <div>
+            <dt>Output</dt>
+            <dd>Typed. The verdict; the seam-aligned breakdown whenever the verdict is <em>exceeds</em>; a rationale per seam; and the re-split triggers the doctrine requires.</dd>
+          </div>
+          <div>
+            <dt>Terminal states</dt>
+            <dd>Exactly three: <code>fits</code>, <code>exceeds</code>, <code>blocked</code>. <code>blocked</code> is the honest fallback, claimed when the evidence needed to judge shape cannot be recovered. A <code>fits</code> verdict still emits a one-element breakdown, so the mechanical checks always have an object.</dd>
+          </div>
+          <div>
+            <dt>Stance</dt>
+            <dd>Read-only. It never creates a ticket, carves a branch, or mutates the candidate. Callers act on the proposal.</dd>
+          </div>
+          <div>
+            <dt>Callers</dt>
+            <dd>
+              <ul>
+                <li><code>plan-implementation</code> — source material to tickets</li>
+                <li><code>carve-changesets</code> — branch to stacked changesets</li>
+                <li><code>implement-ticket</code> — verdict at the publication size gate</li>
+              </ul>
+            </dd>
+          </div>
+        </dl>
+      </div>
+
+      <h3>Verdict and breakdown are one skill, not two</h3>
+      <p>
+        Splitting them is tempting, since the size gate only wants the verdict. Resist it. You
+        cannot credibly return <em>too big</em> without naming the seams — the seam-aligned
+        breakdown <strong>is</strong> the evidence for the verdict. A skill that says too big with
+        no proposed decomposition is asserting, not judging.
+      </p>
+
+      <h3>Two things this quietly fixes</h3>
+      <p>
+        It dissolves a question that looked hard: what should <code>plan-implementation</code>
+        return for work that is one coherent subsystem but too large for a single PR? There is no
+        terminal-state puzzle once the skill calls the shaper and receives a two-ticket
+        breakdown. Oversized-coherent is not an outcome, it is an input to decomposition.
+      </p>
+      <p>
+        And it closes the feedback loop. The shaper predicts where a re-split would become
+        necessary; when one fires downstream, that is a falsified prediction recorded against a
+        specific named trigger. You learn <em>which</em> seam judgment was wrong, not merely that
+        one was.
+      </p>
+    </section>
+
+    <section id="program">
+      <p class="kicker">Scope</p>
+      <h2>Four specs, not one design</h2>
+      <p>
+        Brainstorming's scope rule fired on this brief. The tell was not the step count — it was
+        that <strong>every reversal of standing repository doctrine sat in one place.</strong>
+        Spec C alone reverses #118's design-approval gate, granular default-off authority,
+        <code>ready-ticket</code>'s no-additional-items rule, and the trigger-namespace rule. Four
+        doctrine reversals is not a step, and bundling them lets the riskiest work gate the
+        safest.
+      </p>
+      <div class="note">
+        <b>The brief hit its own invariant.</b> It exceeded one reviewable unit and had to be
+        represented as several separately trackable things — decided by exactly the rule it
+        proposes for everything else.
+      </div>
+
+      <ol class="program">
+        <li><div>
+          <h3>Spec A — compris owns the doctrine <span class="tag">next</span></h3>
+          <p>The doctrine document at a pinned atelier commit; retire <code>carve-changesets</code>' own guardrails in its favor so it replaces a codification rather than becoming a fifth; <code>review-solution-simplicity</code> cites it; atelier points here. <strong>No new skills, no renames, no reversals</strong> — and it ends shared custody on its own.</p>
+        </div></li>
+        <li><div>
+          <h3>Spec B — an executable shaping verdict</h3>
+          <p>The shaping skill, its corpus, and re-split telemetry. Two callers exist on day one. Depends on A for the standard; does not depend on C. <strong>Gated</strong> on the bundled-contract alternative below.</p>
+        </div></li>
+        <li><div>
+          <h3>Spec C — the planner</h3>
+          <p><code>plan-implementation</code>: the rename, endpoint-scoped authority, the boundary move, <code>requires_brainstorming</code>, the <code>writing-plans</code> relationship, and the README and registry edits that follow. A product repositioning of the repository — and it carries every doctrine reversal in the brief.</p>
+        </div></li>
+        <li><div>
+          <h3>Spec D — object model and migration <span class="tag later">YAGNI candidate</span></h3>
+          <p>Deferrable until B and C prove the vocabulary is load-bearing. Both halves are conceded zero-behavior-change, yet the migration triggers the <code>just eval-record</code> obligation across three large skills — while the brief forfeits the diff that obligation produces. Full price, discarded output.</p>
+        </div></li>
+      </ol>
+
+      <div class="note">
+        <b>On renaming.</b> Rename only where the name misleads. <code>ready-ticket</code> did — it
+        promised one ticket and will produce a graph. <code>implement-ticket</code> does not, and
+        <code>implement-epic</code> keeps a noun users say out loud.
+      </div>
+    </section>
+
+    <section id="alts">
+      <p class="kicker">Not yet ruled out</p>
+      <h2>Alternatives the conversation never examined</h2>
+      <p>
+        This shape was reached by convergence over one long conversation, which is exactly the
+        condition under which unexamined alternatives survive. The first is the most serious,
+        because it attacks Spec B's premise rather than varying it.
+      </p>
+
+      <div class="record open">
+        <h3>A bundled synced contract, with no new skill</h3>
+        <p>
+          This brief argues "a document gets cited; a skill gets called," and concludes only a
+          skill makes doctrine enforceable. <strong>That is a false binary, and the counterexample
+          was already in the tree.</strong> <code>review-suite/</code> holds canonical normative
+          text — including <code>consumption-disciplines.md</code>, itself a ported peer doctrine —
+          which <code>just sync-contracts</code> bundles verbatim into three consumers'
+          <code>references/</code> and <code>just check-installed</code> drift-checks.
+        </p>
+        <p class="why">
+          <b>Trades away:</b> nothing measures whether a breakdown obeyed the doctrine, so no typed
+          verdict at the size gate and no prediction-feedback loop. <b>Buys:</b> the smallest change
+          that ends shared custody, on infrastructure already built and tested, with no new
+          contract, terminal states, or corpus. Spec B should not be built until this is argued
+          down or adopted.
+        </p>
+      </div>
+
+      <div class="record open">
+        <h3>Shape as a fourth review lens</h3>
+        <p>
+          <code>review-code-change</code> already invokes three read-only lenses against a shared
+          schema. A shape lens inherits the packet, the result contract, the validator, and the
+          replay evaluator — all built.
+        </p>
+        <p class="why">
+          <b>Trades away:</b> lenses run on committed candidates and return findings, not
+          decompositions, so this cannot serve plan-time input. It covers two of three callers —
+          which isolates the real question: does the third alone justify a new contract shape,
+          three terminal states, and a new corpus?
+        </p>
+      </div>
+
+      <div class="record open">
+        <h3>Build only the missing edge</h3>
+        <p>
+          Keep <code>ready-ticket</code> under its name and per-item authority, and build the one
+          thing it cannot do: turning <code>decomposition_recommended</code> into a parent plus
+          children plus dependency edges. No rename, no planning-language claim, no house breakdown
+          procedure, no reversals.
+        </p>
+        <p class="why">
+          <b>Trades away:</b> a thin breakdown method, so weaker shape prediction and no design
+          document as input. But it separates what Spec C bundles — is the value the <em>graph
+          output</em> or the <em>breakdown method</em>? This buys the first without the second, and
+          the answer says whether Spec C needs to exist as written.
+        </p>
+      </div>
+
+      <div class="record open">
+        <h3>An ordering variant: telemetry first</h3>
+        <p>
+          The brief calls re-split telemetry "the real measure," and it appears nowhere in the
+          program. Shipping it first — leaf tickets record a predicted shape, which
+          <code>implement-ticket</code> and <code>babysit-pr</code> already observe the outcome of —
+          plus the retrospective merged-history corpus, buildable today against
+          <code>git log</code> with zero prose changes, would produce the labeled data this whole
+          program is justified by <em>before</em> the program is built.
+        </p>
+      </div>
+    </section>
+
+    <section id="decisions">
+      <p class="kicker">Settled, with reasons</p>
+      <h2>Decisions on record</h2>
+
+      <div class="record settled">
+        <h3><code>plan-implementation</code> consumes an approved design; it does not produce one</h3>
+        <p>Elicitation narrows to the tracker-shaped residue a design cannot answer — surface-observable criteria, verification commands, pre- and post-merge classification.</p>
+        <p class="why"><b>Note this reverses a recorded decision.</b> Epic #118 established that "a ready ticket satisfies brainstorming's design-approval gate (elicitation happened at authoring time)."</p>
+      </div>
+
+      <div class="record settled">
+        <h3>The composition rules stand; the boundary is hard</h3>
+        <p>The <em>ordering</em> rule survives — brainstorming applies pre-ticket, never mid-pipeline. But README's first composition rule is not merely re-justified: its mechanism sentence asserts the gate is satisfied <em>because <code>ready-ticket</code> ran elicitation</em>, which stops being true. It is rewritten, not re-argued.</p>
+        <p class="why"><b>And the boundary fails closed.</b> When a compris step wants something brainstorming should have settled, exit with <code>requires_brainstorming</code> naming what is missing. Never gather it — that is what keeps the planner from drifting back into being a design prompt.</p>
+      </div>
+
+      <div class="record settled">
+        <h3>A design document is required for every ticket, scaled to the work</h3>
+        <p>No threshold to adjudicate and no second door for bug reports.</p>
+        <p class="why"><b>Verified.</b> brainstorming already owns the scaling problem: "Every project goes through this process. A todo list, a single-function utility, a config change — all of them. The design can be short (a few sentences for truly simple projects), but you MUST present it and get approval."</p>
+      </div>
+
+      <div class="record settled">
+        <h3>compris owns the breakdown; the peer is the richer path, never a dependency</h3>
+        <p>The breakdown is how the ticket structure is <em>discovered</em>, which moves <code>writing-plans</code> from House territory to a genuine referenced peer.</p>
+        <p class="why"><b>But house-owned and complete without it.</b> <code>docs/skill-authoring.md:598</code> forbids depending on a peer and <code>:619</code> forbids conditioning a quality outcome on its availability. compris writes its own breakdown procedure; the peer supplies a deeper method when present. The cost is real and accepted: two paths to maintain, and a corpus that grades both.</p>
+      </div>
+
+      <div class="record settled">
+        <h3>Ticket authority is endpoint-scoped; the graph gate is approval</h3>
+        <p>Granting ticket management grants the whole graph. In for a penny, in for a pound.</p>
+        <p class="why"><b>This reverses two recorded decisions</b> — granular default-off authority, and <code>ready-ticket</code>'s rule that authoring never implies creating additional items. What remains is an <em>approval</em> gate, not a disclosure: presenting the graph before creating it. <b>Approval may be given at invocation</b>, and then the presentation becomes disclosure — which is also what makes autonomous graph creation possible, since an autonomous run has nobody to ask.</p>
+      </div>
+
+      <div class="record settled">
+        <h3>Prediction is best-effort, and instrumented</h3>
+        <p>Developers are bad at estimating; the answer is measurement, not accuracy.</p>
+        <p class="why"><b>Cheapest version.</b> The ticket records its predicted shape; <code>implement-ticket</code> and <code>babysit-pr</code> already observe the outcome. atelier's own evaluation criteria — whether changes remain cognitively reviewable, and how much operator effort acceptance costs — beat grading prose compliance.</p>
+      </div>
+
+      <div class="record settled">
+        <h3>Three eval surfaces, not one stretched corpus</h3>
+        <p>The <strong>forward corpus</strong> keeps asking whether the prose governs once loaded. The <strong>shaping corpus</strong> belongs to the shaping skill and asks what nothing here asks today — was the breakdown good. <strong>Re-split telemetry</strong> is the real measure.</p>
+        <p class="why"><b>Two non-goals.</b> The eval does not observe artifact lifecycle — "reason from artifacts alone" is the right constraint, and unit tests plus one manual run cover the filesystem more cheaply. And diff continuity is not claimed across the vocabulary change: record a fresh baseline and say so.</p>
+      </div>
+
+      <div class="record settled">
+        <h3>The shaping rubric grades seams, not partitions</h3>
+        <p>Two good decompositions agree on <em>where the seams are</em> and disagree on <em>how they group</em>. Score those separately: did each cut land on a boundary the reference also recognized, and was the grouping defensible? Partition equality gets this backwards.</p>
+        <p class="why"><b>All eight rules accounted for.</b> Three are mechanically checkable and need no judge; four need judgment; the eighth — follow-up work when new scope appears — is not gradeable at plan time at all and belongs to the telemetry surface. Each case is built around a specific trap. Merged history supplies free labels: work whose shape held is a positive, work that had to be carved is a negative already annotated by the carving. Diverse judges, and no numeric score.</p>
+      </div>
+
+      <div class="record settled">
+        <h3><code>ready-ticket</code> becomes <code>plan-implementation</code></h3>
+        <p>It names the activity rather than the artifact, and it is verb-first like every other skill in the suite.</p>
+        <p class="why"><b>It forces a doctrine revision.</b> The trigger-namespace rule forbids compris descriptions from claiming planning language. That rule assumed planning lived upstream; this program moves it in-house.</p>
+      </div>
+    </section>
+
+    <section id="status">
+      <p class="kicker">Honest accounting</p>
+      <h2>What the evidence does and does not show</h2>
+      <p>
+        This program is <strong>capability-driven, not failure-driven</strong>, and the brief
+        should say so rather than imply otherwise. <code>docs/skill-authoring.md:24</code> asks a
+        change to trace to an observed failure. Measured against compris's own history, no such
+        failure is established.
+      </p>
+      <p>
+        Merged-PR churn here runs to a median of 1,253 lines and a maximum of 7,829, which the
+        shaping test would reject outright — but that is not evidence of anything breaking. This
+        project deliberately declines shape gating, which is exactly the policy latitude the
+        invariant now allows. <code>carve-changesets</code> has never carved anything in this
+        repository for the same reason: the mechanism has not failed, it has not been asked.
+      </p>
+      <p>Two findings survive the correction, both from real data rather than principle:</p>
+      <div class="record settled">
+        <h3>Recorded machine-generated evidence must be excluded from shape judgment</h3>
+        <p>
+          PR #179 is 4,715 lines of churn, of which 4,538 is committed eval results — the
+          reviewable change is <strong>177 lines</strong>. A metric counting raw churn would reject
+          a small change precisely because the eval norm requires its evidence committed. Any
+          implementation that misses this is measuring the wrong thing.
+        </p>
+      </div>
+      <div class="record settled">
+        <h3>The retrospective corpus is buildable today</h3>
+        <p>
+          The distribution above came from <code>git log</code> and the GitHub API with no prose
+          changes — the "anchor on merged history" idea already recorded — and it caught the
+          eval-results distortion on first contact.
+        </p>
+      </div>
+      <p>
+        The honest statement of motive is therefore: build the capability for projects that want
+        it, governed by policy, rather than fix an observed break here.
+      </p>
+    </section>
+
+    <section id="evidence">
+      <p class="kicker">Load-bearing verification</p>
+      <h2>Verified evidence</h2>
+      <p>
+        Established against <code>obra/superpowers</code> at pin <code>44c9b2d6</code> and the
+        compris tree. Three assumptions were falsified in the process; all are reflected above.
+        The pin is <strong>marketplace release 6.2.0</strong>, verified rather than assumed —
+        same fourteen skills, and <code>writing-plans</code> and <code>brainstorming</code> are
+        byte-identical between the installed plugin and the pinned checkout. These citations hold
+        against the version a user actually receives.
+      </p>
+
+      <div class="tablewrap">
+        <table>
+          <thead>
+            <tr><th>Finding</th><th>Consequence</th><th>Source</th></tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>implement-ticket</code> already reads <code>carve-changesets</code>' live guardrails and may not substitute local heuristics</td>
+              <td>Only three skills judge shape independently. The fourth is the pattern's precedent, which strengthens the extraction argument</td>
+              <td class="src">implement-ticket:632-635</td>
+            </tr>
+            <tr>
+              <td><code>carve-changesets</code> already carries normative cognitive-load guardrails</td>
+              <td>Without retiring them the doctrine becomes a fifth codification rather than replacing four</td>
+              <td class="src">SPEC.md:73</td>
+            </tr>
+            <tr>
+              <td><code>writing-plans</code> never reads a spec from disk — no path parameter, no file read</td>
+              <td>The design is handed over inline; no document has to exist for the handoff</td>
+              <td class="src">SKILL.md:23,71,140</td>
+            </tr>
+            <tr>
+              <td>It supplies no pull-request sizing verdict; the concept appears nowhere in it</td>
+              <td>Sizing is house-owned outright. Its only whole-plan check duplicates a trigger we already have</td>
+              <td class="src">skills/writing-plans/</td>
+            </tr>
+            <tr>
+              <td>Its plan review is an inline checklist; the typed subagent reviewer it replaced is referenced nowhere</td>
+              <td>The peer ships no typed, evidence-bound review, so the house reviewer is required rather than optional</td>
+              <td class="src">plan-document-reviewer-prompt.md</td>
+            </tr>
+            <tr>
+              <td><code>brainstorming</code> writes <em>and commits</em> its design document to git</td>
+              <td>It stays a borrow, never invoked. Borrow a peer that mutates the user's repo; invoke one whose output is disposable</td>
+              <td class="src">SKILL.md:107,110</td>
+            </tr>
+            <tr>
+              <td>Its step-7 Spec Self-Review is <code>ready-ticket</code>'s four scans, same order</td>
+              <td>The skill already ports the peer further than the registry declares</td>
+              <td class="src">SKILL.md:112–118</td>
+            </tr>
+            <tr>
+              <td>Planning language is a <strong>negative</strong> case owned by <code>review-code-change</code>, expecting no compris skill</td>
+              <td>The expectation inverts, but flipping the case destroys that skill's negative coverage. Add a positive <code>plan-implementation</code> case and re-scope the negative</td>
+              <td class="src">expectations.json:130</td>
+            </tr>
+            <tr>
+              <td>Skill-invokes-skill is established practice across five compris skills</td>
+              <td>Three anti-cycle pairings plus one layering rule — a read-only shaper closes no cycle, because it invokes nothing</td>
+              <td class="src">implement-ticket:301-303</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section id="open">
+      <p class="kicker">Owed: a run, not an answer</p>
+      <h2>Recorded experiment</h2>
+
+      <div class="record open">
+        <h3>Can <code>writing-plans</code> be steered to behavioral altitude?</h3>
+        <p>
+          Depth is not the worry — sample code, schemas and protocol design are welcome, because
+          the rough shape of an implementation is what makes a sizing estimate credible. The worry
+          is altitude. The peer produces unit-level TDD bound to internals, while compris requires
+          acceptance criteria observable at the public surface.
+        </p>
+        <p class="why">
+          <b>The run.</b> Hand <code>writing-plans</code> a spec written as surface-observable
+          acceptance criteria and inspect what returns. <b>Success:</b> its Interfaces block names
+          no internal function signatures, and its test steps assert against behavior rather than
+          functions. <b>The hypothesis:</b> the peer's own coverage check — "skim each requirement
+          in the spec, can you point to a task that implements it?" — maps behavior onto
+          implementation tasks for us. Now unblocked: the plugin is installed and matches the pin.
+        </p>
+      </div>
+
+      <div class="record open">
+        <h3>The fork if steering fails — deliberately not pre-decided</h3>
+        <p>
+          <b>Take it as-is</b> — use the output only for sizing, derive the behavioral criteria
+          independently. Cheapest; nothing binds plan coverage to ticket criteria.
+          <b>Post-process</b> — compris lifts internal-altitude tests to the surface as a house
+          step. Preserves the binding; a translation step can lose or invent.
+          <b>Structure only</b> — take the file map, task boundaries and sequencing; compris owns
+          everything test-shaped. Cleanest boundary, least peer value.
+        </p>
+      </div>
+    </section>
+
+    <hr class="end">
+    <p class="colophon">
+      Captured from a working session and hardened by an adversarial read that found seventeen
+      problems, each verified against the source before it was acted on. Nothing in this brief has
+      been built, filed, or committed — no ticket, no tracker write, no behavior change. The
+      doctrine document is the next artifact.
+    </p>
+
+  </main>
+</div>
+</body>
+</html>

--- a/docs/cognitive-driven-development.md
+++ b/docs/cognitive-driven-development.md
@@ -1,0 +1,374 @@
+# Cognitive-driven development
+
+This is the design document for compris taking sole ownership of cognitive
+shaping — the doctrine that decides whether a unit of work is comprehensible —
+together with the vocabulary that carries it and the skill that enforces it.
+
+Nothing described here is built. This document records the direction, the
+decisions behind it, the evidence they rest on, and what remains open. A
+presentation copy is published at
+<https://claude.ai/code/artifact/71ba7b43-e1fc-432f-b094-a72ce38852f1>.
+
+## The practice
+
+Work is normally broken apart by feature area, team ownership, or sprint
+capacity. Cognitive-driven development breaks it apart by what a reviewer can
+understand in one sitting, and treats that as the binding constraint rather than
+a nicety observed when there is time.
+
+Two consequences follow, and both are load-bearing.
+
+The tracker hierarchy stops being an organizational choice and becomes a
+**derived artifact of the implementation breakdown** — which is why the
+breakdown has to happen before the tickets exist, and why nobody can know
+whether something is one ticket or twelve until it has been done.
+
+And the skill that performs it becomes the highest-leverage and highest-risk in
+the suite: everything downstream inherits its decomposition, and no amount of
+good implementation repairs a bad one.
+
+## Why this exists
+
+compris is ticket-driven, and that is what separates it from a methodology
+library. Capturing a design, reviewing it, breaking it into an implementation
+plan, and building it are all necessary — but they have to happen *in public*,
+at whatever scope the organization draws. A plan file is local, ephemeral,
+single-agent, and dies with the context that produced it.
+
+So the test is simple: **if an implementation plan spans more than one pull
+request, it has exceeded its grasp** and should have been represented by
+something more permanent. Durable identity, real dependency edges, visibility to
+the org, survival across handoffs and context loss. That is a tracker, not a
+markdown file.
+
+## The boundary: for when the brainstorming is done
+
+`README.md` currently says compris is *for when the planning is done, and the
+work begins*. That is wrong, and it has already misled a reader into inverting
+this design once. compris plans constantly — it builds an implementation plan,
+shapes it into tickets, and revises it when reality disagrees. Planning is not
+the thing it starts after.
+
+Brainstorming is. It names an activity with a definite output, so the boundary
+can be checked rather than interpreted.
+
+> Brainstorming is done when the requirements and acceptance criteria are
+> captured, the goals and non-goals are known, and the stakeholders and
+> deadlines are identified.
+
+Everything after that is compris: turn it into a ticket-based implementation
+plan, and drive it to completion, adjusting the plan against conditions on the
+ground.
+
+The entry point does not care how much of that there is. A bugfix described in
+one sentence and a design document representing months of work are both legal
+inputs — the difference surfaces in the breakdown, not at the door.
+
+The boundary is hard in both directions. Left of it, a human decides what the
+work is. Right of it, compris decides how it is cut, delivers it, and re-cuts
+when the ground moves. That re-cutting loop is core behavior, not error
+recovery.
+
+## The invariant
+
+Every leaf ticket is scoped to exactly one cognitively shaped changeset, which
+becomes one pull request.
+
+The standard comes from atelier and travels intact, because inventing a second
+wording is how two codifications start drifting:
+
+> Line counts may inform judgment but are not universal correctness gates. The
+> test is whether a reviewer can construct an accurate mental model of the
+> change and evaluate it independently.
+>
+> — atelier, `docs/atelier-skill-design.md:480`
+
+Note what that rules out. This is not a threshold check. Line count is an input
+to judgment and nothing more — atelier explicitly retired the numeric
+heuristics, and states that lines of code are not a success measure. Any
+implementation that reduces this to a number has failed to port it.
+
+### The breakdown rules, ported whole
+
+- Keep an initiative executable as one ticket when it is already reviewable.
+- Avoid one-child decomposition without a real reason.
+- Separate unrelated concern domains.
+- Prefer additive foundations before disruptive transitions.
+- Separate mechanical restructuring from behavioral change when that helps
+  review.
+- Keep validation with the behavior it proves.
+- Identify re-split triggers before implementation.
+- Create follow-up work when implementation or review reveals new scope.
+
+The first two matter most for tone: one ticket is a legal outcome. Ceremonial
+decomposition is a failure, not diligence.
+
+## Ending shared custody
+
+atelier used to own the breakdown. It is moving toward multi-agent process
+management and model selection and routing, and it is mid-rebuild. Leaving the
+doctrine in the project that no longer applies it guarantees the drift this
+program exists to stop. A doctrine with two homes has no home.
+
+The name already fits the job. *compris* is French for *understood* — what the
+suite claims at the moment work changes hands. The shaping test asks whether a
+reviewer can build an accurate mental model. That is understanding,
+operationalized.
+
+**Port at a pinned commit.** atelier's text is still moving. compris already
+solved this for superpowers: the named-peer registry pins `obra/superpowers` at
+`44c9b2d6` because an unpinned reference describes a moving target. Record
+atelier's doctrine the same way, or the first thing the new owner inherits is
+the drift it was created to end.
+
+### Vocabulary comes too, but only our half of it
+
+atelier's layer diagram already split the nouns, and it put ours on our side.
+The mailbox layer holds "assignments, messages, claims, receipts"; the compris
+layer holds "implementation, review, changeset carving, PR lifecycle."
+
+So **changeset comes home** — it was always ours, it is already the noun in
+`carve-changesets`, and it is the noun in the doctrine's own title. **Initiative
+comes too**, as optional, non-authoritative grouping: authority, dependencies,
+readiness and acceptance live at the leaf, and grouping is derived from it.
+
+**Assignment, claim, receipt and worker stay with atelier.** They are the
+process-management layer it is moving into, and importing them would duplicate
+concepts compris already has — an assignment is a claimable unit of approved
+work, which is not the same thing as the shaped unit of code a reviewer reads.
+atelier's own wording keeps them distinct: an initiative that "fits one project
+and one reviewable changeset may consist of a single assignment." One maps to
+the other; neither replaces it. Receipt resolves the same way, since it and
+compris's evidence-binding are one idea under two names.
+
+That leaves three layers and no borrowed noun duplicating something we have: an
+**initiative** groups, the **leaf ticket** is the tracker object, and it is
+scoped to exactly one **changeset**, which becomes one pull request.
+
+Keeping `ticket` as the leaf noun is what makes this safe. Descriptions are the
+routing surface and description-based routing is winner-takes-attention: people
+say "implement this GitHub issue," and a description answering only to "execute
+this assignment" would quietly stop matching them. Because the leaf keeps the
+word users already say, only `initiative` and `changeset` are new internal
+currency — and `changeset` is already in a skill name, so it is not new at all.
+
+## The shaping skill
+
+Four skills already make shape judgments independently and none cites the
+others: `carve-changesets` decides changeset boundaries, `implement-ticket`'s
+publication size gate decides what counts as oversized,
+`review-solution-simplicity` judges whole-solution complexity, and
+`plan-implementation` will decide the decomposition. That is the same
+two-codifications problem, already present inside one repo.
+
+A document gets cited; a skill gets called. Extracting the judgment is what
+makes the doctrine enforceable rather than aspirational, and compris has the
+exact precedent — `review-code-change` does not implement its three lenses, it
+invokes them and reconciles typed verdicts.
+
+| Facet       | Contract                                                                                                                                                                             |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Input**   | A candidate in any of its forms — source material, design document, ticket, implementation plan, branch, pull request — plus repository context. Heterogeneous evidence is expected. |
+| **Output**  | Typed. The verdict; the seam-aligned breakdown whenever the verdict is *exceeds*; a rationale per seam; and the re-split triggers the doctrine requires.                             |
+| **Stance**  | Read-only. It never creates a ticket, carves a branch, or mutates the candidate. Callers act on the proposal.                                                                        |
+| **Callers** | `plan-implementation` (source material to tickets), `carve-changesets` (branch to stacked changesets), `implement-ticket` (verdict at the publication size gate).                    |
+
+### Verdict and breakdown are one skill, not two
+
+Splitting them is tempting, since the size gate only wants the verdict. Resist
+it. You cannot credibly return *too big* without naming the seams — the
+seam-aligned breakdown **is** the evidence for the verdict. A skill that says
+too big with no proposed decomposition is asserting, not judging. Callers ignore
+the part they do not need.
+
+### Two things this quietly fixes
+
+It dissolves a question that looked hard: what should `plan-implementation`
+return for work that is one coherent subsystem but too large for a single PR?
+There is no terminal-state puzzle once the skill calls the shaper and receives a
+two-ticket breakdown. Oversized-coherent is not an outcome, it is an input to
+decomposition.
+
+And it closes the feedback loop. The shaper predicts where a re-split would
+become necessary; when one fires downstream, that is a falsified prediction
+recorded against a specific named trigger. You learn *which* seam judgment was
+wrong, not merely that one was. `carve-changesets` stops being a repair
+mechanism that implies guilt and becomes the instrument that measures the
+prediction.
+
+## The program
+
+Ordered so that each step is independently valuable and every later step cites
+an earlier one. The first two are pure documentation.
+
+1. **The doctrine document.** Human-shaped changesets, ported at a pinned
+   atelier commit, owned by compris. Cited by the four skills that already judge
+   shape independently. Zero behavior change, and it unifies four implicit
+   standards on day one. Carries the new tagline: `README.md` stops promising
+   *for when the planning is done* and starts promising *for when the
+   brainstorming is done*, with the done-condition spelled out. The line at
+   `README.md:15` about peers owning the thinking-it-through phase goes with it.
+
+2. **The object model document.** Initiative, leaf ticket, changeset, dependency
+   — and the mapping onto GitHub and Linear stated once. Still zero behavior
+   change. Deliberately narrow: it does *not* import assignment, claim, receipt
+   or worker, which stay in atelier's process layer. Receipt in particular would
+   duplicate compris's evidence-binding, which is the same idea and already ours
+   — and is where the prediction-feedback loop gets its home for free.
+
+3. **The shaping skill.** The contract above. One executable home for the
+   judgment, with its own eval corpus, rather than shape judgments buried in
+   four skills' separate corpora where none is really testing the doctrine.
+
+4. **`plan-implementation`** (was `ready-ticket`). Source material to an
+   initiative plus tickets: shaped by step 1, expressed via step 2, discovered
+   through the `writing-plans` breakdown, judged by step 3. Input ranges from a
+   stacktrace to a full design document; output ranges from one ticket to a
+   multi-tier dependency graph.
+
+5. **Migrate the downstream skills.** `implement-ticket`, `implement-epic` and
+   `babysit-pr` move to the object model internally. Trigger surfaces unchanged.
+
+6. **atelier cites compris.** atelier drops its section and points here — which
+   also repairs its orphaned reference to numeric heuristics that would
+   otherwise live nowhere.
+
+**On renaming.** Rename only where the name misleads about behavior.
+`ready-ticket` did — it promised one ticket and will produce a graph — so it
+becomes `plan-implementation`. `implement-ticket` does not mislead; it really
+does take one ticket, and `implement-epic` keeps a noun users say out loud. A
+big-bang rename buys nothing and costs routing.
+
+## Decisions on record
+
+### `plan-implementation` consumes an approved design; it does not produce one
+
+It stops approximating brainstorming's questioning. Elicitation narrows to the
+tracker-shaped residue a design cannot answer — surface-observable criteria,
+verification commands, pre- and post-merge classification.
+
+*Note this reverses a recorded decision.* Epic #118 established that "a ready
+ticket satisfies brainstorming's design-approval gate (elicitation happened at
+authoring time)."
+
+### The composition rules stand; the boundary is hard
+
+#118's rule survives intact — brainstorming applies pre-ticket, never
+mid-pipeline. Only its justification changes, from *the skill absorbed the
+design-approval gate* to *brainstorming actually ran*.
+
+And the boundary fails closed. When a compris step finds itself wanting
+something brainstorming should have settled, that is a compris failure case:
+exit with *needs more information*, naming what is missing. Never gather it. A
+distinct typed result — `requires_brainstorming`, parallel to
+`implement-ticket`'s `requires_epic` — makes it machine-routable and keeps the
+planner from drifting back into being a design prompt.
+
+### A design document is required for every ticket, scaled to the work
+
+No threshold to adjudicate and no second door for bug reports. Trivial work gets
+a trivial design.
+
+*Verified.* brainstorming already owns the scaling problem: "Every project goes
+through this process. A todo list, a single-function utility, a config change —
+all of them. The design can be short (a few sentences for truly simple
+projects), but you MUST present it and get approval."
+
+### compris owns the implementation breakdown, using writing-plans to do it
+
+The breakdown is how the ticket structure is *discovered* — nobody can know
+whether something is one ticket or twelve until it has been broken down. That
+makes `writing-plans` structurally load-bearing rather than a quality
+enhancement, and moves it in the registry from House territory to a genuine
+referenced peer.
+
+### Ticket authority is endpoint-scoped, not per-item
+
+Granting the skill ticket management grants it the whole graph. In for a penny,
+in for a pound.
+
+*What remains is disclosure, not permission.* The existing body-approval step
+scales up to presenting the graph — shape, leaves, dependency edges — before
+anything is created.
+
+### Prediction is best-effort, and instrumented
+
+Developers are bad at estimating; the answer is measurement, not accuracy.
+Paying for the full plan now is acceptable provided the approach's usefulness
+can be reflected on later and adjusted.
+
+*Cheapest version.* The ticket records its predicted shape; `implement-ticket`
+and `babysit-pr` already observe the actual outcome. atelier's evaluation
+criteria — whether changes remain cognitively reviewable, and how much operator
+effort acceptance costs — are a better forward-eval target than grading prose
+compliance.
+
+### Three eval surfaces, not one stretched corpus
+
+The **forward corpus** keeps asking whether the prose governs once loaded,
+extended with peer-present cases and new vocabulary terms. The **shaping
+corpus** belongs to the shaping skill and asks a question nothing here asks
+today — was the breakdown good — graded by judge panel against the eight
+doctrine rules. **Re-split telemetry** is the real measure: every shipped leaf
+records whether its prediction held.
+
+*Why the shaping corpus lives on the shaping skill.* One corpus then tests the
+doctrine for all four call sites — the extraction argument carried through to
+verification. Two non-goals: the eval does not observe artifact lifecycle, since
+"reason from artifacts alone" is the right constraint and unit tests plus one
+manual run cover the filesystem more cheaply; and diff continuity is not claimed
+across the vocabulary change — record a fresh baseline and say so.
+
+### `ready-ticket` becomes `plan-implementation`
+
+It names the activity rather than the artifact, so it no longer promises one
+ticket while producing a graph — and it is verb-first, like every other skill in
+the suite.
+
+*It forces a doctrine revision.* The trigger-namespace rule forbids compris
+descriptions from claiming planning language, because that is what peer skills
+trigger on. That rule assumed planning lived upstream; this program moves it
+in-house. The namespace list has to say compris now claims
+implementation-planning language deliberately, and the collision audit needs a
+`plan-implementation` × `writing-plans` row recording the overlap as structural
+and cooperative.
+
+## Verified evidence
+
+Established against `obra/superpowers` at pin `44c9b2d6` and the compris tree.
+Three assumptions were falsified in the process; all are reflected above.
+
+| Finding                                                                                                          | Consequence                                                                                                                                   | Source                             |
+| ---------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
+| `writing-plans` never reads a spec from disk — no path parameter, no file read                                   | The design can be handed over inline; no document has to exist for the handoff                                                                | `SKILL.md:23,71,140`               |
+| It supplies no pull-request sizing verdict; the PR concept appears nowhere in it                                 | Sizing is house-owned outright. Its only whole-plan check duplicates a trigger we already have                                                | `skills/writing-plans/`            |
+| Its own plan reviewer is dangling — referenced nowhere since an inline checklist replaced it                     | The peer ships no review, so the house reviewer is required rather than optional                                                              | `plan-document-reviewer-prompt.md` |
+| Committed peer plans run 143–1649 lines, placeholders forbidden, complete code required                          | A material context expenditure — accepted, pending instrumentation                                                                            | 13 committed plans                 |
+| `brainstorming` writes *and commits* its design document to git                                                  | It stays a borrow, never invoked. Borrow a peer that mutates the user's repo; invoke one whose output is disposable                           | `SKILL.md:107,110`                 |
+| Its step-7 Spec Self-Review is `ready-ticket`'s four scans, same order                                           | The skill already ports the peer further than the registry declares                                                                           | `SKILL.md:112–118`                 |
+| The triggering corpus records planning language as expecting "no compris skill; planning language is peer-owned" | That expectation inverts — planning language should now route to `plan-implementation`. A recorded case flips sign and seeds the new baseline | `triggering/known-overlaps.json`   |
+| Skill-invokes-skill is established practice across five compris skills                                           | Dispatch is not novel. The anti-invoke rule in `implement-ticket` is an anti-cycle rule for one pairing                                       | `implement-epic:186`               |
+
+## Still open
+
+### Can `writing-plans` be steered to behavioral altitude?
+
+Depth is not the worry — sample code, schemas and protocol design are welcome,
+because the rough shape of an implementation is what makes a sizing estimate
+credible. The worry is altitude. The peer produces unit-level TDD bound to
+internals, while compris requires acceptance criteria observable at the public
+surface.
+
+*The resolution, if it holds.* Hand the peer the behavioral criteria as its
+spec. Its own coverage check — "skim each requirement in the spec, can you point
+to a task that implements it?" — then maps behavior onto implementation tasks
+for us. The plan's unit detail sharpens sizing and dies with the scratch
+artifact; the ticket keeps the surface-observable contract. Unverified: whether
+prose alone steers the peer to that altitude.
+
+### Grading a breakdown, not a compliance
+
+The shaping corpus asks whether a decomposition was *good*, which no existing
+compris corpus asks of anything. Reference decompositions plus a judge panel is
+the plan, but the grading rubric is unwritten and exact-match is known to be
+wrong, since many valid decompositions exist for one input.

--- a/docs/cognitive-driven-development.md
+++ b/docs/cognitive-driven-development.md
@@ -5,8 +5,9 @@ shaping — the doctrine that decides whether a unit of work is comprehensible �
 together with the vocabulary that carries it and the skill that enforces it.
 
 Nothing described here is built. This document records the direction, the
-decisions behind it, the evidence they rest on, and the one experiment still
-owed. A presentation copy is published at
+decisions behind it, the evidence they rest on, the four specs it decomposes
+into, the alternatives not yet ruled out, and the one experiment still owed. A
+presentation copy is published at
 <https://claude.ai/code/artifact/71ba7b43-e1fc-432f-b094-a72ce38852f1>.
 
 ## The practice
@@ -195,6 +196,12 @@ makes the doctrine enforceable rather than aspirational, and compris has the
 exact precedent — `review-code-change` does not implement its three lenses, it
 invokes them and reconciles typed verdicts.
 
+**That framing is contested, and the contest is unresolved.**
+Cited-versus-called is a false binary: `review-suite/` distributes canonical
+normative text by mechanical sync and drift check, with no skill involved. See
+[Alternatives not yet ruled out](#alternatives-not-yet-ruled-out). Spec B should
+not be built until that alternative is argued down or adopted.
+
 | Facet               | Contract                                                                                                                                                                                                                                                  |
 | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Input**           | A candidate in any of its forms — source material, design document, ticket, implementation plan, branch, pull request — plus repository context. Heterogeneous evidence is expected.                                                                      |
@@ -228,55 +235,128 @@ prediction.
 
 ## The program
 
-Ordered so that each step is independently valuable and every later step cites
-an earlier one. The first two are pure documentation.
+Brainstorming's scope rule fired on this document: it describes work with three
+different dependency roots, three risk profiles, and three definitions of done.
+The tell is not the step count — it is that **every reversal of standing
+repository doctrine sits in one place.** Spec C alone reverses #118's
+design-approval gate, `docs/skill-authoring.md:366`'s granular default-off
+authority, `ready-ticket:82-84`'s no-additional-items rule, and the
+trigger-namespace rule. Four doctrine reversals is not a step.
 
-1. **The doctrine document.** Human-shaped changesets, ported at a pinned
-   atelier commit, owned by compris. Genuinely zero behavior change: a new
-   document that nothing yet cites.
+So this brief is a program of four specs, not one design. Bundling them would
+let the riskiest gate the safest.
 
-2. **Wire the doctrine in.** Add citations from the skills that judge shape, and
-   retire `carve-changesets/references/SPEC.md`'s own cognitive-load guardrails
-   and decomposition-order sections in favor of one — otherwise the doctrine
-   becomes a *fifth* codification rather than replacing the existing ones. This
-   step edits normative skill prose, so it carries the `just eval-record`
-   before/after obligation; step 1 does not.
+The document reaching this conclusion is itself the invariant working. It
+exceeded one reviewable unit and had to be represented as several separately
+trackable things — decided by exactly the rule it proposes for everything else.
 
-3. **Revise the governing documents.** `docs/skill-authoring.md`: the
-   trigger-namespace list claims implementation-planning language; the
-   `writing-plans` registry entry moves from House territory to referenced peer;
-   the `ready-ticket` collision-audit row is renamed and a `plan-implementation`
-   × `writing-plans` row is added. `README.md`: the new tagline, the line at
-   `:15` about peers owning the thinking-it-through phase, and the first
-   composition rule.
+### Spec A — compris owns the shaping doctrine
 
-4. **The object model document.** Initiative, leaf ticket, changeset, dependency
-   — and the mapping onto GitHub and Linear stated once. Still zero behavior
-   change. Deliberately narrow: it does *not* import assignment, claim, receipt
-   or worker, which stay in atelier's process layer. Receipt in particular would
-   duplicate compris's evidence-binding, which is the same idea and already ours
-   — and is where the prediction-feedback loop gets its home for free.
+The doctrine document, ported at a pinned atelier commit; retire
+`carve-changesets/references/SPEC.md`'s cognitive-load guardrails and
+decomposition-order sections in its favor so the doctrine replaces a
+codification rather than becoming a fifth; `review-solution-simplicity` cites
+it; atelier drops its section and points here.
 
-5. **The shaping skill.** The contract above. One executable home for the
-   judgment, with its own eval corpus, rather than shape judgments buried in
-   three skills' separate corpora where none is really testing the doctrine.
+*No new skills, no renames, no doctrine reversals.* This is the piece that
+actually ends shared custody, and it is complete on its own. Ships on
+infrastructure that already exists.
 
-6. **`plan-implementation`** (was `ready-ticket`). Source material to an
-   initiative plus tickets: shaped by step 1, expressed via step 4, discovered
-   through the breakdown, judged by step 5. Input ranges from a stacktrace to a
-   full design document; output ranges from one ticket to a multi-tier
-   dependency graph.
+### Spec B — an executable shaping verdict
 
-7. **Migrate the downstream skills.** `implement-ticket`, `implement-epic` and
-   `babysit-pr` move to the object model internally. Trigger surfaces unchanged.
+The shaping skill and its contract, the shaping corpus, and the re-split
+telemetry. Two real callers exist on day one: `carve-changesets`, and
+`implement-ticket`'s size gate, which already loads a shape authority by stable
+name and is forbidden to substitute local heuristics.
 
-8. **atelier cites compris.** atelier drops its section and points here.
+*Depends on A for the standard it enforces.* Does not depend on C.
+
+### Spec C — the planner
+
+`ready-ticket` becomes `plan-implementation`: the rename, the endpoint-scoped
+authority model, the boundary move to *for when the brainstorming is done*,
+`requires_brainstorming`, the `writing-plans` relationship change, and the
+README, registry and collision-audit edits that follow from all of it.
+
+*This is a product repositioning of the repository, not a step in another spec's
+program.* It carries every doctrine reversal in the brief.
+
+### Spec D — object model and downstream migration
+
+The object model document, and migrating `implement-ticket`, `implement-epic`
+and `babysit-pr` to it internally.
+
+*Deferrable until B and C prove the vocabulary is load-bearing*, and a live
+YAGNI candidate: both halves are conceded zero-behavior-change, yet the
+migration edits normative prose in three large skills and so triggers the
+`just eval-record` obligation three times — while this brief simultaneously
+forfeits the diff that obligation produces, by not claiming continuity across
+the vocabulary change. That is paying the full price of the eval norm and
+discarding its output.
 
 **On renaming.** Rename only where the name misleads about behavior.
 `ready-ticket` did — it promised one ticket and will produce a graph — so it
-becomes `plan-implementation`. `implement-ticket` does not mislead; it really
-does take one ticket, and `implement-epic` keeps a noun users say out loud. A
-big-bang rename buys nothing and costs routing.
+becomes `plan-implementation` under Spec C. `implement-ticket` does not mislead;
+it really does take one ticket, and `implement-epic` keeps a noun users say out
+loud. A big-bang rename buys nothing and costs routing.
+
+## Alternatives not yet ruled out
+
+The shape above was reached by convergence over one long conversation, which is
+exactly the condition under which unexamined alternatives survive. Three were
+never put on the table. The first is the most serious, because it attacks Spec
+B's premise rather than offering a variation on it.
+
+### A bundled synced contract, with no new skill
+
+This brief argues that "a document gets cited; a skill gets called," and
+concludes that only a skill makes the doctrine enforceable. **That is a false
+binary, and the counterexample is already in the tree.** `review-suite/` holds
+canonical normative text — including `consumption-disciplines.md`, itself a
+ported peer doctrine — which `just sync-contracts` bundles verbatim into each
+consumer's `references/`, and `just check-installed` drift-checks. Three skills
+consume it that way today.
+
+So there is a proven third mechanism: text loaded by stable name and
+mechanically verified against drift, with no new contract, terminal states, or
+corpus.
+
+*Trades away:* nothing measures whether a given breakdown obeyed the doctrine,
+so there is no typed verdict at the size gate and no prediction-feedback loop.
+
+### Shape as a fourth review lens
+
+`review-code-change` already invokes three read-only lenses and reconciles typed
+verdicts against a shared schema. A shape lens would inherit the shared packet,
+the result contract, the validator, and the replay evaluator — all built and
+tested.
+
+*Trades away:* lenses run on a committed candidate and return findings, not
+decompositions, so this cannot serve plan-time input. It covers two of the three
+named callers, which isolates the real question — whether the third caller alone
+justifies a new contract shape, three terminal states, and a new corpus.
+
+### Build only the missing edge
+
+Keep `ready-ticket` under its name and its per-item authority, and build the one
+thing it demonstrably cannot do: turning `decomposition_recommended` into a
+parent plus children plus dependency edges. No rename, no claim on planning
+language, no house breakdown procedure, no reversals.
+
+*Trades away:* the breakdown method stays thin, so shape prediction is weaker
+and compris still cannot take a design document as input. But it separates what
+Spec C bundles — is the value in the *graph output* or in the *breakdown
+method*? This delivers the first without buying the second, and the answer says
+whether Spec C needs to exist as written.
+
+### An ordering variant worth naming
+
+This brief calls re-split telemetry "the real measure," and it appears nowhere
+in the program. Shipping it first — leaf tickets record a predicted shape, which
+`implement-ticket` and `babysit-pr` already observe the outcome of — plus the
+retrospective merged-history corpus, which is buildable today against `git log`
+with zero prose changes, would produce the labeled data this whole program is
+justified by *before* the program is built.
 
 ## Decisions on record
 
@@ -484,7 +564,7 @@ written as surface-observable acceptance criteria, and inspect what returns.
 
 **Success criterion.** Its Interfaces block does not name internal function
 signatures, and its test steps assert against observable behavior rather than
-against functions. One session; blocks neither step 1 nor step 2.
+against functions. One session, and it blocks no spec — it informs Spec C.
 
 **The hypothesis, if it holds.** The peer's own coverage check — "skim each
 requirement in the spec, can you point to a task that implements it?" — maps

--- a/docs/cognitive-driven-development.md
+++ b/docs/cognitive-driven-development.md
@@ -76,7 +76,15 @@ recovery.
 Every leaf ticket is scoped to what is predicted to be one cognitively shaped
 changeset, realized as one pull request.
 
-The prediction is the invariant, not the identity. `implement-ticket` ships
+**The invariant is a default, not a law.** Not every project demands cognitively
+shaped pull requests. A personal project may legitimately want compris for
+ticket authoring and delivery automation while declining to be gated on shape —
+compris itself is one such project today. So the shaper always *judges*, and the
+consuming project decides whether an `exceeds` verdict gates anything. No new
+policy machinery is needed: the shaper is already read-only, which separates
+judgment from enforcement by construction.
+
+And the prediction is the invariant, not the identity. `implement-ticket` ships
 `ready_prs` — one ticket, an authorized carved stack, several pull requests —
 and that path stays. A carved stack is the *recorded falsification* of a shaping
 prediction, not a violation of the rule. Developers are bad at estimating; the
@@ -524,6 +532,36 @@ in-house. The namespace list has to say compris now claims
 implementation-planning language deliberately, and the collision audit needs a
 `plan-implementation` × `writing-plans` row recording the overlap as structural
 and cooperative.
+
+## What the evidence does and does not show
+
+This program is **capability-driven, not failure-driven**, and the brief should
+say so rather than imply otherwise. `docs/skill-authoring.md:24` asks a change
+to trace to an observed failure. Measured against compris's own history, no such
+failure is established.
+
+Merged-PR churn here runs to a median of 1,253 lines and a maximum of 7,829,
+which the shaping test would reject outright — but that is not evidence of
+anything breaking. This project deliberately declines shape gating, which is
+exactly the policy latitude recorded above. `carve-changesets` has never carved
+anything in this repository for the same reason: the mechanism has not failed,
+it has not been asked.
+
+Two findings survive the correction, and both came from looking at real data
+rather than reasoning from principle:
+
+- **Recorded machine-generated evidence must be excluded from shape judgment.**
+  PR #179 is 4,715 lines of churn, of which 4,538 is committed eval results; the
+  reviewable change is 177 lines. A metric counting raw churn would reject a
+  small change because the eval norm requires its evidence to be committed. Any
+  implementation that misses this is measuring the wrong thing.
+- **The retrospective corpus is buildable today.** The distribution above came
+  from `git log` and the GitHub API with no prose changes — the "anchor on
+  merged history" idea already recorded — and it caught the eval-results
+  distortion on first contact.
+
+The honest statement of motive is therefore: build the capability for projects
+that want it, governed by policy, rather than fix an observed break here.
 
 ## Verified evidence
 

--- a/docs/cognitive-driven-development.md
+++ b/docs/cognitive-driven-development.md
@@ -6,9 +6,13 @@ together with the vocabulary that carries it and the skill that enforces it.
 
 Nothing described here is built. This document records the direction, the
 decisions behind it, the evidence they rest on, the four specs it decomposes
-into, the alternatives not yet ruled out, and the one experiment still owed. A
-presentation copy is published at
-<https://claude.ai/code/artifact/71ba7b43-e1fc-432f-b094-a72ce38852f1>.
+into, the alternatives not yet ruled out, and the one experiment still owed.
+
+This Markdown is canonical for review.
+[`cognitive-driven-development.html`](cognitive-driven-development.html) is a
+presentation copy of the same content, committed alongside it and also published
+at <https://claude.ai/code/artifact/71ba7b43-e1fc-432f-b094-a72ce38852f1>. When
+one changes, change both.
 
 ## The practice
 

--- a/docs/cognitive-driven-development.md
+++ b/docs/cognitive-driven-development.md
@@ -21,7 +21,7 @@ Two consequences follow, and both are load-bearing.
 The tracker hierarchy stops being an organizational choice and becomes a
 **derived artifact of the implementation breakdown** — which is why the
 breakdown has to happen before the tickets exist, and why nobody can know
-whether something is one ticket or twelve until it has been done.
+whether something is one ticket or twelve until it has been broken down.
 
 And the skill that performs it becomes the highest-leverage and highest-risk in
 the suite: everything downstream inherits its decomposition, and no amount of
@@ -54,7 +54,8 @@ can be checked rather than interpreted.
 
 > Brainstorming is done when the requirements and acceptance criteria are
 > captured, the goals and non-goals are known, and the stakeholders and
-> deadlines are identified.
+> deadlines are identified — each at the scale the work warrants. For a one-line
+> bugfix, the sentence is the design.
 
 Everything after that is compris: turn it into a ticket-based implementation
 plan, and drive it to completion, adjusting the plan against conditions on the
@@ -71,8 +72,14 @@ recovery.
 
 ## The invariant
 
-Every leaf ticket is scoped to exactly one cognitively shaped changeset, which
-becomes one pull request.
+Every leaf ticket is scoped to what is predicted to be one cognitively shaped
+changeset, realized as one pull request.
+
+The prediction is the invariant, not the identity. `implement-ticket` ships
+`ready_prs` — one ticket, an authorized carved stack, several pull requests —
+and that path stays. A carved stack is the *recorded falsification* of a shaping
+prediction, not a violation of the rule. Developers are bad at estimating; the
+answer is measurement, not accuracy.
 
 The standard comes from atelier and travels intact, because inventing a second
 wording is how two codifications start drifting:
@@ -84,9 +91,10 @@ wording is how two codifications start drifting:
 > — atelier, `docs/atelier-skill-design.md:480`
 
 Note what that rules out. This is not a threshold check. Line count is an input
-to judgment and nothing more — atelier explicitly retired the numeric
-heuristics, and states that lines of code are not a success measure. Any
-implementation that reduces this to a number has failed to port it.
+to judgment and nothing more — atelier dropped its predecessor's fixed
+implementation and *some* of its numeric heuristics, subordinating line count to
+the mental-model test, and states outright that lines of code are not a success
+measure. Any implementation that reduces this to a number has failed to port it.
 
 ### The breakdown rules, ported whole
 
@@ -129,8 +137,12 @@ layer holds "implementation, review, changeset carving, PR lifecycle."
 
 So **changeset comes home** — it was always ours, it is already the noun in
 `carve-changesets`, and it is the noun in the doctrine's own title. **Initiative
-comes too**, as optional, non-authoritative grouping: authority, dependencies,
-readiness and acceptance live at the leaf, and grouping is derived from it.
+comes too**, but mapped rather than substituted. An initiative is the *logical*
+grouping the breakdown derives; an **epic** is its tracker realization, and
+compris keeps its own richer semantics there — `implement-epic:340` gives the
+parent its own acceptance ledger and holds parent closeout to explicit
+authority, which atelier's lighter "non-authoritative grouping" would have
+overwritten.
 
 **Assignment, claim, receipt and worker stay with atelier.** They are the
 process-management layer it is moving into, and importing them would duplicate
@@ -141,9 +153,16 @@ and one reviewable changeset may consist of a single assignment." One maps to
 the other; neither replaces it. Receipt resolves the same way, since it and
 compris's evidence-binding are one idea under two names.
 
-That leaves three layers and no borrowed noun duplicating something we have: an
-**initiative** groups, the **leaf ticket** is the tracker object, and it is
-scoped to exactly one **changeset**, which becomes one pull request.
+That leaves two logical-to-realized mappings, with the leaf ticket binding them:
+
+| Logical (internal currency) | Realized (what users say) |
+| --------------------------- | ------------------------- |
+| initiative                  | epic                      |
+| changeset                   | pull request              |
+
+A **leaf ticket** is a child of an epic and is scoped to one changeset. The
+logical nouns are how contracts, handoffs and doctrine talk; the realized ones
+are what descriptions claim, because that is what people type.
 
 Keeping `ticket` as the leaf noun is what makes this safe. Descriptions are the
 routing surface and description-based routing is winner-takes-attention: people
@@ -154,24 +173,33 @@ currency — and `changeset` is already in a skill name, so it is not new at all
 
 ## The shaping skill
 
-Four skills already make shape judgments independently and none cites the
-others: `carve-changesets` decides changeset boundaries, `implement-ticket`'s
-publication size gate decides what counts as oversized,
-`review-solution-simplicity` judges whole-solution complexity, and
-`plan-implementation` will decide the decomposition. That is the same
-two-codifications problem, already present inside one repo.
+Three skills judge shape independently today and none cites the others:
+`carve-changesets` decides changeset boundaries, `review-solution-simplicity`
+judges whole-solution complexity, and `plan-implementation` will decide the
+decomposition. That is the same two-codifications problem, already inside one
+repo.
+
+The fourth is the precedent rather than the problem. `implement-ticket` does
+*not* carry its own heuristic — at `SKILL.md:632-635` it loads
+`carve-changesets` by stable name and reads its live guardrails, and is
+explicitly forbidden to "copy their thresholds or substitute local heuristics."
+`docs/skill-authoring.md:198` records that as the repository's worked example of
+the pattern. So one caller already delegates shape judgment to an external
+authority; extracting the shaper generalizes something that works rather than
+inventing something new.
 
 A document gets cited; a skill gets called. Extracting the judgment is what
 makes the doctrine enforceable rather than aspirational, and compris has the
 exact precedent — `review-code-change` does not implement its three lenses, it
 invokes them and reconciles typed verdicts.
 
-| Facet       | Contract                                                                                                                                                                             |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Input**   | A candidate in any of its forms — source material, design document, ticket, implementation plan, branch, pull request — plus repository context. Heterogeneous evidence is expected. |
-| **Output**  | Typed. The verdict; the seam-aligned breakdown whenever the verdict is *exceeds*; a rationale per seam; and the re-split triggers the doctrine requires.                             |
-| **Stance**  | Read-only. It never creates a ticket, carves a branch, or mutates the candidate. Callers act on the proposal.                                                                        |
-| **Callers** | `plan-implementation` (source material to tickets), `carve-changesets` (branch to stacked changesets), `implement-ticket` (verdict at the publication size gate).                    |
+| Facet               | Contract                                                                                                                                                                                                                                                  |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Input**           | A candidate in any of its forms — source material, design document, ticket, implementation plan, branch, pull request — plus repository context. Heterogeneous evidence is expected.                                                                      |
+| **Output**          | Typed. The verdict; the seam-aligned breakdown whenever the verdict is *exceeds*; a rationale per seam; and the re-split triggers the doctrine requires.                                                                                                  |
+| **Terminal states** | Exactly three: `fits`, `exceeds`, `blocked`. `blocked` is the honest fallback, claimed when the evidence needed to judge shape cannot be recovered. A `fits` verdict still emits a one-element breakdown, so the mechanical checks always have an object. |
+| **Stance**          | Read-only. It never creates a ticket, carves a branch, or mutates the candidate. Callers act on the proposal.                                                                                                                                             |
+| **Callers**         | `plan-implementation` (source material to tickets), `carve-changesets` (branch to stacked changesets), `implement-ticket` (verdict at the publication size gate).                                                                                         |
 
 ### Verdict and breakdown are one skill, not two
 
@@ -202,36 +230,45 @@ Ordered so that each step is independently valuable and every later step cites
 an earlier one. The first two are pure documentation.
 
 1. **The doctrine document.** Human-shaped changesets, ported at a pinned
-   atelier commit, owned by compris. Cited by the four skills that already judge
-   shape independently. Zero behavior change, and it unifies four implicit
-   standards on day one. Carries the new tagline: `README.md` stops promising
-   *for when the planning is done* and starts promising *for when the
-   brainstorming is done*, with the done-condition spelled out. The line at
-   `README.md:15` about peers owning the thinking-it-through phase goes with it.
+   atelier commit, owned by compris. Genuinely zero behavior change: a new
+   document that nothing yet cites.
 
-2. **The object model document.** Initiative, leaf ticket, changeset, dependency
+2. **Wire the doctrine in.** Add citations from the skills that judge shape, and
+   retire `carve-changesets/references/SPEC.md`'s own cognitive-load guardrails
+   and decomposition-order sections in favor of one — otherwise the doctrine
+   becomes a *fifth* codification rather than replacing the existing ones. This
+   step edits normative skill prose, so it carries the `just eval-record`
+   before/after obligation; step 1 does not.
+
+3. **Revise the governing documents.** `docs/skill-authoring.md`: the
+   trigger-namespace list claims implementation-planning language; the
+   `writing-plans` registry entry moves from House territory to referenced peer;
+   the `ready-ticket` collision-audit row is renamed and a `plan-implementation`
+   × `writing-plans` row is added. `README.md`: the new tagline, the line at
+   `:15` about peers owning the thinking-it-through phase, and composition rule
+   1\.
+
+4. **The object model document.** Initiative, leaf ticket, changeset, dependency
    — and the mapping onto GitHub and Linear stated once. Still zero behavior
    change. Deliberately narrow: it does *not* import assignment, claim, receipt
    or worker, which stay in atelier's process layer. Receipt in particular would
    duplicate compris's evidence-binding, which is the same idea and already ours
    — and is where the prediction-feedback loop gets its home for free.
 
-3. **The shaping skill.** The contract above. One executable home for the
+5. **The shaping skill.** The contract above. One executable home for the
    judgment, with its own eval corpus, rather than shape judgments buried in
    four skills' separate corpora where none is really testing the doctrine.
 
-4. **`plan-implementation`** (was `ready-ticket`). Source material to an
+6. **`plan-implementation`** (was `ready-ticket`). Source material to an
    initiative plus tickets: shaped by step 1, expressed via step 2, discovered
    through the `writing-plans` breakdown, judged by step 3. Input ranges from a
    stacktrace to a full design document; output ranges from one ticket to a
    multi-tier dependency graph.
 
-5. **Migrate the downstream skills.** `implement-ticket`, `implement-epic` and
+7. **Migrate the downstream skills.** `implement-ticket`, `implement-epic` and
    `babysit-pr` move to the object model internally. Trigger surfaces unchanged.
 
-6. **atelier cites compris.** atelier drops its section and points here — which
-   also repairs its orphaned reference to numeric heuristics that would
-   otherwise live nowhere.
+8. **atelier cites compris.** atelier drops its section and points here.
 
 **On renaming.** Rename only where the name misleads about behavior.
 `ready-ticket` did — it promised one ticket and will produce a graph — so it
@@ -253,9 +290,12 @@ authoring time)."
 
 ### The composition rules stand; the boundary is hard
 
-#118's rule survives intact — brainstorming applies pre-ticket, never
-mid-pipeline. Only its justification changes, from *the skill absorbed the
-design-approval gate* to *brainstorming actually ran*.
+The *ordering* rule survives — brainstorming applies pre-ticket, never
+mid-pipeline. But README composition rule 1 is not merely re-justified: its
+title and mechanism sentence assert a ready ticket satisfies the gate *because
+`ready-ticket` ran elicitation and obtained approval of the body*. Once
+elicitation narrows to the tracker-shaped residue, that sentence is false. The
+rule is rewritten to say the gate is satisfied by brainstorming having run.
 
 And the boundary fails closed. When a compris step finds itself wanting
 something brainstorming should have settled, that is a compris failure case:
@@ -278,18 +318,42 @@ projects), but you MUST present it and get approval."
 
 The breakdown is how the ticket structure is *discovered* — nobody can know
 whether something is one ticket or twelve until it has been broken down. That
-makes `writing-plans` structurally load-bearing rather than a quality
-enhancement, and moves it in the registry from House territory to a genuine
-referenced peer.
+moves `writing-plans` in the registry from House territory to a genuine
+referenced peer: compris owns the implementation-breakdown phase and points at
+the peer by name as the recommended method for it.
+
+**The breakdown is house-owned and complete without a peer.**
+`docs/skill-authoring.md:598` is unambiguous — a skill "may never depend on" a
+peer — and `:619` forbids conditioning a quality outcome on peer availability.
+So compris writes its own breakdown procedure: file map, task boundaries,
+sequencing, enough to judge shape. `writing-plans` supplies a deeper and
+better-tested method when it is present. Outcome house-owned, method delegated,
+exactly as the convention requires.
+
+*The cost is real and accepted.* A house procedure that mostly duplicates the
+peer's has to be written and maintained, and the two paths can produce different
+shapes for the same input — which the shaping corpus then has to grade on both
+paths rather than one.
 
 ### Ticket authority is endpoint-scoped, not per-item
 
 Granting the skill ticket management grants it the whole graph. In for a penny,
 in for a pound.
 
-*What remains is disclosure, not permission.* The existing body-approval step
-scales up to presenting the graph — shape, leaves, dependency edges — before
-anything is created.
+*Note this reverses two recorded decisions.* `docs/skill-authoring.md:366` makes
+authority "granular, separately granted, and never inferred… Each defaults to
+off," and `ready-ticket:82-84` states that authoring authority "never implies
+authority to… create additional tracker items." Endpoint-scoped authority
+supersedes both for this skill, and the reversal is recorded here rather than
+left for a reader to find.
+
+*What remains is an approval gate, not a disclosure.* `ready-ticket:220-223`
+already requires explicit approval of the body before `ticket_ready`; scaling
+that to the graph — shape, leaves, dependency edges — is continuity, not a new
+gate. **Approval may be given at invocation**, and when it is the presentation
+becomes a disclosure: the run reports the graph and proceeds. That is also what
+makes autonomous operation possible at all, since an autonomous run has nobody
+to ask.
 
 ### Prediction is best-effort, and instrumented
 
@@ -313,7 +377,7 @@ doctrine rules. **Re-split telemetry** is the real measure: every shipped leaf
 records whether its prediction held.
 
 *Why the shaping corpus lives on the shaping skill.* One corpus then tests the
-doctrine for all four call sites — the extraction argument carried through to
+doctrine for all three call sites — the extraction argument carried through to
 verification. Two non-goals: the eval does not observe artifact lifecycle, since
 "reason from artifacts alone" is the right constraint and unit tests plus one
 manual run cover the filesystem more cheaply; and diff continuity is not claimed
@@ -321,14 +385,18 @@ across the vocabulary change — record a fresh baseline and say so.
 
 ### The shaping rubric grades seams, not partitions
 
-**Sort the eight rules by kind first.** Three are mechanically checkable and
-need no judge: one-child decomposition (count children; if one, require a stated
-reason), re-split triggers (a presence check), and the fits-as-one-ticket case
-(if the verdict was *fits*, did it produce exactly one?). Making those
-deterministic assertions halves the judge surface and keeps most of the corpus
-stable and cheap. Only concern separation, ordering,
-mechanical-versus-behavioral separation, validation placement, and the
-mental-model test need judgment.
+**Sort all eight rules by kind first, and account for every one.** Three are
+mechanically checkable and need no judge: one-child decomposition (count
+children; if one, require a stated reason), re-split triggers (a presence
+check), and the fits-as-one-ticket case (a `fits` verdict must emit exactly one
+element). Four need judgment: concern separation, ordering of additive
+foundations before disruptive transitions, mechanical-versus-behavioral
+separation, and validation placement. The eighth — create follow-up work when
+implementation or review reveals new scope — **is not gradeable at plan time at
+all**: it describes a downstream event, so it belongs to the re-split telemetry
+surface rather than to this corpus. The mental-model test is not one of the
+eight; it is the standard the four judgment rules serve, and is judged alongside
+them.
 
 **Grade seams, not partitions.** Two good decompositions of the same work
 typically agree on *where the seams are* and disagree on *how they group*. Score
@@ -380,16 +448,16 @@ and cooperative.
 Established against `obra/superpowers` at pin `44c9b2d6` and the compris tree.
 Three assumptions were falsified in the process; all are reflected above.
 
-| Finding                                                                                                          | Consequence                                                                                                                                   | Source                             |
-| ---------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
-| `writing-plans` never reads a spec from disk — no path parameter, no file read                                   | The design can be handed over inline; no document has to exist for the handoff                                                                | `SKILL.md:23,71,140`               |
-| It supplies no pull-request sizing verdict; the PR concept appears nowhere in it                                 | Sizing is house-owned outright. Its only whole-plan check duplicates a trigger we already have                                                | `skills/writing-plans/`            |
-| Its own plan reviewer is dangling — referenced nowhere since an inline checklist replaced it                     | The peer ships no review, so the house reviewer is required rather than optional                                                              | `plan-document-reviewer-prompt.md` |
-| Committed peer plans run 143–1649 lines, placeholders forbidden, complete code required                          | A material context expenditure — accepted, pending instrumentation                                                                            | 13 committed plans                 |
-| `brainstorming` writes *and commits* its design document to git                                                  | It stays a borrow, never invoked. Borrow a peer that mutates the user's repo; invoke one whose output is disposable                           | `SKILL.md:107,110`                 |
-| Its step-7 Spec Self-Review is `ready-ticket`'s four scans, same order                                           | The skill already ports the peer further than the registry declares                                                                           | `SKILL.md:112–118`                 |
-| The triggering corpus records planning language as expecting "no compris skill; planning language is peer-owned" | That expectation inverts — planning language should now route to `plan-implementation`. A recorded case flips sign and seeds the new baseline | `triggering/known-overlaps.json`   |
-| Skill-invokes-skill is established practice across five compris skills                                           | Dispatch is not novel. The anti-invoke rule in `implement-ticket` is an anti-cycle rule for one pairing                                       | `implement-epic:186`               |
+| Finding                                                                                                   | Consequence                                                                                                                                                                                                             | Source                             |
+| --------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
+| `writing-plans` never reads a spec from disk — no path parameter, no file read                            | The design can be handed over inline; no document has to exist for the handoff                                                                                                                                          | `SKILL.md:23,71,140`               |
+| It supplies no pull-request sizing verdict; the PR concept appears nowhere in it                          | Sizing is house-owned outright. Its only whole-plan check duplicates a trigger we already have                                                                                                                          | `skills/writing-plans/`            |
+| Its plan review is an inline checklist; the typed subagent reviewer it replaced is now referenced nowhere | The peer ships no typed, evidence-bound review, so the house reviewer is required rather than optional                                                                                                                  | `plan-document-reviewer-prompt.md` |
+| Committed peer plans run 143–1649 lines, placeholders forbidden, complete code required                   | A material context expenditure — accepted, pending instrumentation                                                                                                                                                      | 13 committed plans                 |
+| `brainstorming` writes *and commits* its design document to git                                           | It stays a borrow, never invoked. Borrow a peer that mutates the user's repo; invoke one whose output is disposable                                                                                                     | `SKILL.md:107,110`                 |
+| Its step-7 Spec Self-Review is `ready-ticket`'s four scans, same order                                    | The skill already ports the peer further than the registry declares                                                                                                                                                     | `SKILL.md:112–118`                 |
+| Planning language is a **negative** case owned by `review-code-change`, expecting no compris skill        | The expectation inverts, but the case cannot simply be flipped: doing so destroys that skill's negative coverage. Add a positive `plan-implementation` case and re-scope the negative                                   | `triggering/expectations.json:130` |
+| Skill-invokes-skill is established practice across five compris skills                                    | Dispatch is not novel. `implement-ticket`'s anti-invoke rule covers three pairings plus a self-re-entry bar, and `implement-epic` adds a layering rule — a read-only shaper closes no cycle, because it invokes nothing | `implement-ticket:301-303`         |
 
 ## Recorded experiments
 

--- a/docs/cognitive-driven-development.md
+++ b/docs/cognitive-driven-development.md
@@ -125,7 +125,9 @@ operationalized.
 
 **Port at a pinned commit.** atelier's text is still moving. compris already
 solved this for superpowers: the named-peer registry pins `obra/superpowers` at
-`44c9b2d6` because an unpinned reference describes a moving target. Record
+`44c9b2d6` — which corresponds to marketplace release 6.2.0 — because an
+unpinned reference describes a moving target. Recording the release alongside
+the SHA makes the pin resolvable by a reader who cannot run `git`. Record
 atelier's doctrine the same way, or the first thing the new owner inherits is
 the drift it was created to end.
 
@@ -245,8 +247,8 @@ an earlier one. The first two are pure documentation.
    `writing-plans` registry entry moves from House territory to referenced peer;
    the `ready-ticket` collision-audit row is renamed and a `plan-implementation`
    × `writing-plans` row is added. `README.md`: the new tagline, the line at
-   `:15` about peers owning the thinking-it-through phase, and composition rule
-   1\.
+   `:15` about peers owning the thinking-it-through phase, and the first
+   composition rule.
 
 4. **The object model document.** Initiative, leaf ticket, changeset, dependency
    — and the mapping onto GitHub and Linear stated once. Still zero behavior
@@ -257,13 +259,13 @@ an earlier one. The first two are pure documentation.
 
 5. **The shaping skill.** The contract above. One executable home for the
    judgment, with its own eval corpus, rather than shape judgments buried in
-   four skills' separate corpora where none is really testing the doctrine.
+   three skills' separate corpora where none is really testing the doctrine.
 
 6. **`plan-implementation`** (was `ready-ticket`). Source material to an
-   initiative plus tickets: shaped by step 1, expressed via step 2, discovered
-   through the `writing-plans` breakdown, judged by step 3. Input ranges from a
-   stacktrace to a full design document; output ranges from one ticket to a
-   multi-tier dependency graph.
+   initiative plus tickets: shaped by step 1, expressed via step 4, discovered
+   through the breakdown, judged by step 5. Input ranges from a stacktrace to a
+   full design document; output ranges from one ticket to a multi-tier
+   dependency graph.
 
 7. **Migrate the downstream skills.** `implement-ticket`, `implement-epic` and
    `babysit-pr` move to the object model internally. Trigger surfaces unchanged.
@@ -447,6 +449,12 @@ and cooperative.
 
 Established against `obra/superpowers` at pin `44c9b2d6` and the compris tree.
 Three assumptions were falsified in the process; all are reflected above.
+
+The pin is **marketplace release 6.2.0**, verified rather than assumed: the
+installed plugin's `skills/` tree and the pinned checkout carry the same
+fourteen skills, and `writing-plans` and `brainstorming` — the two every finding
+below rests on — are byte-identical between them. So these citations hold
+against the version a user actually receives, not only against a commit.
 
 | Finding                                                                                                   | Consequence                                                                                                                                                                                                             | Source                             |
 | --------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |

--- a/docs/cognitive-driven-development.md
+++ b/docs/cognitive-driven-development.md
@@ -10,9 +10,8 @@ into, the alternatives not yet ruled out, and the one experiment still owed.
 
 This Markdown is canonical for review.
 [`cognitive-driven-development.html`](cognitive-driven-development.html) is a
-presentation copy of the same content, committed alongside it and also published
-at <https://claude.ai/code/artifact/71ba7b43-e1fc-432f-b094-a72ce38852f1>. When
-one changes, change both.
+presentation copy of the same content, committed alongside it. When one changes,
+change both.
 
 ## The practice
 

--- a/docs/cognitive-driven-development.md
+++ b/docs/cognitive-driven-development.md
@@ -5,8 +5,8 @@ shaping — the doctrine that decides whether a unit of work is comprehensible �
 together with the vocabulary that carries it and the skill that enforces it.
 
 Nothing described here is built. This document records the direction, the
-decisions behind it, the evidence they rest on, and what remains open. A
-presentation copy is published at
+decisions behind it, the evidence they rest on, and the one experiment still
+owed. A presentation copy is published at
 <https://claude.ai/code/artifact/71ba7b43-e1fc-432f-b094-a72ce38852f1>.
 
 ## The practice
@@ -319,6 +319,48 @@ verification. Two non-goals: the eval does not observe artifact lifecycle, since
 manual run cover the filesystem more cheaply; and diff continuity is not claimed
 across the vocabulary change — record a fresh baseline and say so.
 
+### The shaping rubric grades seams, not partitions
+
+**Sort the eight rules by kind first.** Three are mechanically checkable and
+need no judge: one-child decomposition (count children; if one, require a stated
+reason), re-split triggers (a presence check), and the fits-as-one-ticket case
+(if the verdict was *fits*, did it produce exactly one?). Making those
+deterministic assertions halves the judge surface and keeps most of the corpus
+stable and cheap. Only concern separation, ordering,
+mechanical-versus-behavioral separation, validation placement, and the
+mental-model test need judgment.
+
+**Grade seams, not partitions.** Two good decompositions of the same work
+typically agree on *where the seams are* and disagree on *how they group*. Score
+those separately: did each proposed cut land on a boundary the reference also
+recognized, and was the grouping defensible? A decomposition that cuts at real
+seams but bundles differently is fine; one that cuts through the middle of a
+concern is wrong regardless of how many pieces it made. Partition equality gets
+this backwards, and seam-level scoring maps onto the skill's own output
+vocabulary.
+
+**Build each case around a specific trap.** The eight rules imply eight ways to
+be wrong — an input that tempts ceremonial one-child decomposition, one that
+invites mixing a rename with a behavior change, one where validation naturally
+drifts from the behavior it proves. A corpus that only rewards good answers
+measures very little; one where every case has a known bait measures whether the
+doctrine governs.
+
+**Anchor on merged history.** Shipped work whose shape held is a labeled
+positive; work that had to be carved is a labeled negative, already annotated by
+the fact that it was carved. Reconstruct the input, ask the shaper what it would
+have proposed, compare. Free labeled data, and it grounds the standard in the
+team's real review culture rather than a synthetic one — the retrospective twin
+of the re-split telemetry.
+
+**Diverse judges, not redundant ones.** A concern-coherence judge, an ordering
+judge, and a mental-model judge, matching the review-suite pattern. Three
+identical judges mostly measure sampling temperature.
+
+**No numeric score.** The doctrine retired numeric heuristics; a rubric emitting
+7.2 out of 10 reintroduces what atelier removed. Per-rule pass/fail with
+recorded observations matches what `AGENTS.md` already asks for.
+
 ### `ready-ticket` becomes `plan-implementation`
 
 It names the activity rather than the artifact, so it no longer promises one
@@ -349,7 +391,9 @@ Three assumptions were falsified in the process; all are reflected above.
 | The triggering corpus records planning language as expecting "no compris skill; planning language is peer-owned" | That expectation inverts — planning language should now route to `plan-implementation`. A recorded case flips sign and seeds the new baseline | `triggering/known-overlaps.json`   |
 | Skill-invokes-skill is established practice across five compris skills                                           | Dispatch is not novel. The anti-invoke rule in `implement-ticket` is an anti-cycle rule for one pairing                                       | `implement-epic:186`               |
 
-## Still open
+## Recorded experiments
+
+Not open questions. Nobody owes an answer here; someone owes a run.
 
 ### Can `writing-plans` be steered to behavioral altitude?
 
@@ -359,16 +403,25 @@ credible. The worry is altitude. The peer produces unit-level TDD bound to
 internals, while compris requires acceptance criteria observable at the public
 surface.
 
-*The resolution, if it holds.* Hand the peer the behavioral criteria as its
-spec. Its own coverage check — "skim each requirement in the spec, can you point
-to a task that implements it?" — then maps behavior onto implementation tasks
-for us. The plan's unit detail sharpens sizing and dies with the scratch
-artifact; the ticket keeps the surface-observable contract. Unverified: whether
-prose alone steers the peer to that altitude.
+**The run.** Install superpowers at pin `44c9b2d6`, hand `writing-plans` a spec
+written as surface-observable acceptance criteria, and inspect what returns.
 
-### Grading a breakdown, not a compliance
+**Success criterion.** Its Interfaces block does not name internal function
+signatures, and its test steps assert against observable behavior rather than
+against functions. One session; blocks neither step 1 nor step 2.
 
-The shaping corpus asks whether a decomposition was *good*, which no existing
-compris corpus asks of anything. Reference decompositions plus a judge panel is
-the plan, but the grading rubric is unwritten and exact-match is known to be
-wrong, since many valid decompositions exist for one input.
+**The hypothesis, if it holds.** The peer's own coverage check — "skim each
+requirement in the spec, can you point to a task that implements it?" — maps
+behavior onto implementation tasks for us. The plan's unit detail sharpens
+sizing and dies with the scratch artifact; the ticket keeps the
+surface-observable contract.
+
+**The fork if it fails**, deliberately not pre-decided:
+
+- _Take it as-is_ — use the output only for sizing and derive the behavioral
+  criteria independently. Cheapest; nothing binds plan coverage to ticket
+  criteria.
+- _Post-process_ — compris lifts internal-altitude tests to the surface as a
+  house step. Preserves the binding; a translation step can lose or invent.
+- _Structure only_ — take the file map, task boundaries and sequencing; compris
+  owns everything test-shaped. Cleanest boundary, least peer value.


### PR DESCRIPTION
## Summary

Adds `docs/cognitive-driven-development.md`, the design document for compris
taking sole ownership of cognitive shaping — the doctrine that decides whether a
unit of work is comprehensible — along with the vocabulary that carries it and
the skill that will enforce it.

Documentation only. Nothing is implemented, no skill prose changes, and no
existing behavior moves.

## Why

**compris is ticket-driven, and that is the differentiator.** Capturing a
design, reviewing it, breaking it into an implementation plan, and building it
all have to happen *in public*, at whatever scope the organization draws. A plan
file is local, ephemeral, single-agent, and dies with the context that produced
it. So: if an implementation plan spans more than one pull request, it has
exceeded its grasp and should have been represented by something more permanent.

**The invariant** that falls out: every leaf ticket is scoped to exactly one
cognitively shaped changeset, which becomes one pull request. The standard is
ported verbatim from atelier — "whether a reviewer can construct an accurate
mental model of the change and evaluate it independently" — along with its eight
breakdown rules.

**Why compris owns it now.** The doctrine currently lives in `shaug/atelier`,
which is moving toward multi-agent process management and model routing. A
doctrine with two homes has no home. Four compris skills already make shape
judgments independently — `carve-changesets`, `implement-ticket`'s publication
size gate, `review-solution-simplicity`, and the planner — and none cites the
others, so the same drift is already present inside this repo.

**Half the vocabulary comes with it.** atelier's own layer diagram places
`changeset` on the compris side, alongside "changeset carving", so `changeset`
and `initiative` come home while `assignment`, `claim`, `receipt` and `worker`
stay in atelier's process layer. Keeping `ticket` as the leaf noun preserves the
tracker-native trigger surface that description-based routing depends on.

**The tagline is wrong and gets replaced.** *For when the planning is done* is
not merely vague — it misled a reader into inverting this design during
authoring. compris plans constantly. What it starts after is **brainstorming**,
which names an activity with a definite output, so the boundary can be checked
rather than interpreted.

## What the document contains

- The practice, the thesis, and the boundary with its done-condition
- The invariant and the eight breakdown rules
- The custody transfer, with the requirement to port at a pinned commit
- The shaping skill's contract (input, output, stance, callers)
- A six-step program, the first two steps of which are pure documentation
- Nine decisions with their reasoning
- Eight verified findings
- One recorded experiment, with its run and success criterion

## Evidence

Load-bearing verification ran against `obra/superpowers` at pin `44c9b2d6` and
falsified three assumptions, all reflected in the document:

- `writing-plans` reads no spec from disk and exposes no caller-facing path, so
  the approved design is handed over inline
- it supplies no pull-request sizing verdict — the concept appears nowhere in
  the skill — so sizing is house-owned outright
- its own plan reviewer is dangling, referenced nowhere since an inline
  checklist replaced it, so the house reviewer is required rather than optional

Also recorded: `brainstorming` writes *and commits* its design document, which is
why it stays a borrow rather than an invocation; its step-7 Spec Self-Review is
`ready-ticket`'s four scans in the same order; and the triggering corpus records
planning language as expecting "no compris skill", an assertion this direction
inverts.

## Reviewer notes

- **This reverses a recorded decision.** Epic #118 established that "a ready
  ticket satisfies brainstorming's design-approval gate (elicitation happened at
  authoring time)." The composition rule itself survives — brainstorming still
  applies pre-ticket, never mid-pipeline — but its justification changes, and the
  boundary now fails closed via a `requires_brainstorming` result rather than the
  skill improvising the missing input.
- **No eval evidence is included, and none is owed.** The eval-backed change norm
  applies to skill prose; this PR changes none. It will apply from step 3 onward,
  and the document records how — three eval surfaces rather than one stretched
  corpus.
- **The branch name is stale.** It says `ready-ticket-create-plan`, which was the
  original question in the session that produced this, not what the branch ended
  up carrying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
