### PR TITLE
fix: record the eval candidate's tree hash and pinned model in every summary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,19 @@ commit a later reader can resolve, and commit the summaries on top. A run
 recorded from a dirty tree — or from a commit later amended away — names a tree
 nobody else can retrieve, which is the one thing the record exists to supply.
 
+Each summary also carries `candidate.tree`, the committed content's
+`git rev-parse HEAD^{tree}`, and — for a real-model run — `model`, the exact
+`--model` the recorded command passed. `sha` names the commit, which rebase
+rewrites and squash-merge discards outright; `tree` names the content, which is
+identical under both, so it is `tree`, not `sha`, that a reader should expect to
+still resolve once a change has landed on `main`. `model` exists because a
+before/after pair taken across a model update compares two different subjects
+wearing the same tier name; a diff is drawn only when the compared runs' tier,
+suite, and model all match. A deterministic run records no model — there is none
+to name. Summaries recorded before this field existed carry no `model` at all
+and are branch-local and unattributed: no model can be recovered for them after
+the fact, and they are not backfilled.
+
 Summaries already written under `evals/results/` are the one exemption, and it
 is narrow by construction. Recording several skills in sequence writes a summary
 per skill, so without the exemption only the first run of a batch could report a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ summary: Chronological history of repository and skill changes.
 
 # Changelog
 
+## 2026-08-11 — Named the tree and the model an eval summary measured, so both survive rebase and squash-merge
+
+- fix: record the candidate's git tree hash and, for real-model runs, the pinned
+  model name in every recorded eval summary — `candidate.sha` names a branch
+  commit that rebase rewrites and squash-merge discards outright, so no summary
+  merged so far names a SHA a fresh clone can resolve, and the recorder never
+  named which model actually produced a real-model run, so a before/after diff
+  taken across a model update silently compared two different subjects wearing
+  the same tier name. `candidate.tree` resolves under both rewrites, every
+  real-model executor invocation now passes an explicit `--model claude-opus-5`
+  instead of relying on an environment default, and a diff is drawn only between
+  runs whose tier, suite, and model all match. Summaries recorded before this
+  change carry no model at all and are documented as branch-local and
+  unattributed rather than backfilled.
+
 ## 2026-08-09 — Recorded the cognitive-driven development direction: compris takes sole ownership of the cognitive-shaping doctrine from atelier, moves the boundary from "planning is done" to "brainstorming is done", and renames ready-ticket to plan-implementation
 
 - docs: drop the hosted link from the cognitive-driven development design — the
@@ -12,6 +27,7 @@ summary: Chronological history of repository and skill changes.
   cannot guarantee stays reachable or in step. The committed
   `cognitive-driven-development.html` is the presentation copy, and it travels
   with the document in the same history and the same review.
+  (308b6212f5bf6b23854da340b25ee1d63320dad2)
 
 - docs: commit the presentation copy of the cognitive-driven development design
   and link it from the Markdown — the rendered brief existed only as a published

--- a/scripts/record_eval_run.py
+++ b/scripts/record_eval_run.py
@@ -47,6 +47,13 @@ STAGES = ("baseline", "before", "after")
 REAL_MODEL = "real-model"
 DETERMINISTIC = "deterministic"
 
+# The real-model subject is pinned rather than left to whatever `claude -p`
+# defaults to in a given environment on a given day: a before/after diff taken
+# across a model update must compare two runs of the same model, not two
+# different subjects wearing the same tier name. Changing the pin is a
+# one-line edit plus a re-baseline, not a schema change.
+RECORDED_MODEL = "claude-opus-5"
+
 _RUN_FORWARD = "skills/implement-ticket/scripts/evals/run_forward.py"
 _CLAUDE_EXECUTOR = "skills/implement-ticket/scripts/evals/claude_executor.py"
 
@@ -64,14 +71,18 @@ _CLAUDE_EXECUTOR = "skills/implement-ticket/scripts/evals/claude_executor.py"
 # skill directory.
 EVAL_TARGETS = {
     "implement-ticket": {
-        "real_model": [_RUN_FORWARD, "--executor", f"{{python}} {_CLAUDE_EXECUTOR}"],
+        "real_model": [
+            _RUN_FORWARD,
+            "--executor",
+            f"{{python}} {_CLAUDE_EXECUTOR} --model {RECORDED_MODEL}",
+        ],
         "deterministic": [_RUN_FORWARD],
     },
     "implement-epic": {
         "real_model": [
             _RUN_FORWARD,
             "--executor",
-            f"{{python}} {_CLAUDE_EXECUTOR}",
+            f"{{python}} {_CLAUDE_EXECUTOR} --model {RECORDED_MODEL}",
             "--target-skill",
             "implement-epic",
         ],
@@ -84,7 +95,8 @@ EVAL_TARGETS = {
         "real_model": [
             "skills/ready-ticket/scripts/evals/run_forward.py",
             "--executor",
-            "{python} skills/ready-ticket/scripts/evals/claude_executor.py",
+            f"{{python}} skills/ready-ticket/scripts/evals/claude_executor.py "
+            f"--model {RECORDED_MODEL}",
         ],
         "deterministic": ["skills/ready-ticket/scripts/evals/run_forward.py"],
     },
@@ -107,7 +119,7 @@ TRIGGERING_TARGETS = {
             "--skill",
             skill,
             "--executor",
-            f"{{python}} {_DESCRIPTION_EXECUTOR}",
+            f"{{python}} {_DESCRIPTION_EXECUTOR} --model {RECORDED_MODEL}",
         ],
         "deterministic": [_TRIGGERING_RUNNER, "--skill", skill],
     }
@@ -199,6 +211,31 @@ def resolve_command(
     return command, resolved_tier, gap_for(resolved_tier), True
 
 
+def model_for(command: list[str], tier: str) -> str | None:
+    """The model a real-model run's own command explicitly selects, if any.
+
+    Read from the resolved command rather than a separate parameter, so a
+    registered target and a `--command` override are named the same way: both
+    are trusted only insofar as the command they actually run carries an
+    explicit `--model`, never an environment default. A deterministic run
+    records no model — there is no model to name.
+
+    A registered target's `--model` normally lives inside its `--executor`
+    argument, one compound string rather than a separate command-list token
+    (`--executor "python3 claude_executor.py --model claude-opus-5"`), so each
+    token is re-split before the flag is searched for.
+    """
+    if tier != REAL_MODEL:
+        return None
+    flat: list[str] = []
+    for token in command:
+        flat.extend(shlex.split(token) if " " in token else [token])
+    for index, token in enumerate(flat):
+        if token == "--model" and index + 1 < len(flat):
+            return flat[index + 1]
+    return None
+
+
 def run_command(
     command: list[str], reports_per_case: bool
 ) -> tuple[subprocess.CompletedProcess[str], dict[str, str], dict[str, dict | None]]:
@@ -264,7 +301,7 @@ def results_dir(skill: str) -> Path:
 
 
 def previous_run(
-    directory: Path, tier: str, cases: dict[str, str], suite: str
+    directory: Path, tier: str, cases: dict[str, str], suite: str, model: str | None
 ) -> dict | None:
     """The most recent run this one can honestly be compared against.
 
@@ -292,6 +329,12 @@ def previous_run(
         # a diff across them would report the change of question as behavioral
         # movement.
         if recorded.get("suite", FORWARD_SUITE) != suite:
+            continue
+        # A before/after pair taken across a model update is two different
+        # subjects, not one subject over time. A summary recorded before this
+        # field existed has no model at all and is equally unusable as a
+        # model-pinned comparison.
+        if recorded.get("model") != model:
             continue
         recorded["_filename"] = path.name
         return recorded
@@ -376,6 +419,7 @@ def candidate_identity() -> dict:
         ]
     return {
         "sha": git("rev-parse", "HEAD"),
+        "tree": git("rev-parse", "HEAD^{tree}"),
         "branch": git("rev-parse", "--abbrev-ref", "HEAD"),
         "worktree_clean": None if relevant is None else not relevant,
     }
@@ -389,6 +433,7 @@ def build_summary(
     gap: str | None,
     note: str | None,
     suite: str,
+    model: str | None,
     command: list[str],
     completed: subprocess.CompletedProcess[str],
     cases: dict[str, str],
@@ -456,6 +501,7 @@ def build_summary(
         "suite": suite,
         "recorded_at": recorded_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
         "tier": tier,
+        "model": model,
         # Deliberately keyed off the forward suite whatever suite is being
         # recorded: the field's recorded meaning is "this skill has a
         # real-model forward executor", and making it suite-relative made
@@ -516,6 +562,7 @@ def plan(
         "skill": skill,
         "suite": suite,
         "tier": resolved_tier,
+        "model": model_for(command, resolved_tier),
         "gap": gap,
         "command": command,
     }
@@ -535,6 +582,7 @@ def record(
     command, resolved_tier, gap, reports_per_case = resolve_command(
         skill, tier, override, per_case, suite
     )
+    model = model_for(command, resolved_tier)
     completed, cases, case_evidence = run_command(command, reports_per_case)
     recorded_at = utc_now()
     directory = results_dir(skill)
@@ -545,13 +593,14 @@ def record(
         gap=gap,
         note=note,
         suite=suite,
+        model=model,
         command=command,
         completed=completed,
         cases=cases,
         case_evidence=case_evidence,
         expects_summary=reports_per_case,
         recorded_at=recorded_at,
-        previous=previous_run(directory, resolved_tier, cases, suite),
+        previous=previous_run(directory, resolved_tier, cases, suite, model),
     )
 
     path = directory / summary_filename(directory, recorded_at, stage, label, suite)

--- a/scripts/tests/test_record_eval_run.py
+++ b/scripts/tests/test_record_eval_run.py
@@ -347,6 +347,169 @@ class RecorderTests(unittest.TestCase):
         self.assertEqual(exit_code, 2)
         self.assertFalse((self.skills / "not-a-skill").exists())
 
+    # AC: a real-model summary names the model that produced it.
+    def test_recorded_summary_names_the_model_that_produced_it(self) -> None:
+        self.run_recorder(
+            "demo-skill",
+            "--tier",
+            "real-model",
+            "--command",
+            self.stub(passed=["alpha"], failed=[]) + " --model model-a",
+            "--per-case-output-dir",
+        )
+
+        summary = self.read_only_summary("demo-skill")
+        self.assertEqual(summary["model"], "model-a")
+
+    # AC: a deterministic summary names none, even where the command line
+    # happens to carry no `--model` at all.
+    def test_recorded_deterministic_summary_names_no_model(self) -> None:
+        self.run_recorder(
+            "demo-skill",
+            "--command",
+            self.stub(passed=["alpha"], failed=[]),
+            "--per-case-output-dir",
+        )
+
+        summary = self.read_only_summary("demo-skill")
+        self.assertIsNone(summary["model"])
+
+    # AC: a run is selected as another run's comparison only when tier, suite,
+    # and model all match — a before/after pair taken across a model update is
+    # two different subjects, not one subject over time.
+    def test_diff_selection_requires_a_matching_model(self) -> None:
+        self.run_recorder(
+            "demo-skill",
+            "--tier",
+            "real-model",
+            "--stage",
+            "before",
+            "--command",
+            self.stub(passed=["alpha"], failed=[]) + " --model model-a",
+            "--per-case-output-dir",
+        )
+        self.run_recorder(
+            "demo-skill",
+            "--tier",
+            "real-model",
+            "--stage",
+            "after",
+            "--command",
+            self.stub(passed=["alpha"], failed=[]) + " --model model-b",
+            "--per-case-output-dir",
+        )
+
+        files = self.results("demo-skill")
+        self.assertEqual(len(files), 2)
+        mismatched = json.loads(files[-1].read_text(encoding="utf-8"))
+        self.assertIsNone(mismatched["compared_to"])
+
+        self.run_recorder(
+            "demo-skill",
+            "--tier",
+            "real-model",
+            "--stage",
+            "after",
+            "--label",
+            "again",
+            "--command",
+            self.stub(passed=["alpha"], failed=[]) + " --model model-b",
+            "--per-case-output-dir",
+        )
+
+        files = self.results("demo-skill")
+        self.assertEqual(len(files), 3)
+        matched = json.loads(files[-1].read_text(encoding="utf-8"))
+        self.assertEqual(matched["compared_to"], files[-2].name)
+
+    # AC: a summary with no recorded model — the shape of every summary
+    # committed before this change — is not chosen as the comparison for a
+    # model-pinned run.
+    def test_summary_with_no_recorded_model_is_not_selected_as_comparison(
+        self,
+    ) -> None:
+        directory = self.skills / "demo-skill" / "evals" / "results"
+        directory.mkdir(parents=True, exist_ok=True)
+        legacy = {
+            "schema": record_eval_run.SUMMARY_SCHEMA,
+            "suite": "forward",
+            "tier": "real-model",
+            "cases": {"alpha": "pass"},
+        }
+        (directory / "2026-01-01T000000Z-0001-baseline.json").write_text(
+            json.dumps(legacy), encoding="utf-8"
+        )
+
+        self.run_recorder(
+            "demo-skill",
+            "--tier",
+            "real-model",
+            "--stage",
+            "after",
+            "--command",
+            self.stub(passed=["alpha"], failed=[]) + " --model model-a",
+            "--per-case-output-dir",
+        )
+
+        files = self.results("demo-skill")
+        self.assertEqual(len(files), 2)
+        summary = json.loads(files[-1].read_text(encoding="utf-8"))
+        self.assertIsNone(summary["compared_to"])
+
+    # AC: the recorded tree identifier still resolves to the evaluated content
+    # after the branch history that produced it is rewritten — first as a
+    # rebase would (a new parent), then as a squash-merge would (a brand new
+    # commit reusing the identical tree). `sha` cannot survive either; `tree`
+    # must survive both.
+    def test_candidate_tree_survives_rebase_and_squash(self) -> None:
+        repo = self.root / "git-repo"
+        repo.mkdir()
+
+        def git(*args: str, input: str | None = None) -> str:
+            completed = subprocess.run(
+                ["git", *args],
+                cwd=repo,
+                text=True,
+                capture_output=True,
+                input=input,
+                check=True,
+            )
+            return completed.stdout.strip()
+
+        git("init", "-q")
+        git("config", "user.email", "a@example.com")
+        git("config", "user.name", "a")
+        (repo / "file.txt").write_text("v1", encoding="utf-8")
+        git("add", "file.txt")
+        git("commit", "-q", "-m", "first")
+
+        with mock.patch.object(record_eval_run, "REPOSITORY_ROOT", repo):
+            before_rewrite = record_eval_run.candidate_identity()
+
+        original_tree = before_rewrite["tree"]
+        self.assertTrue(original_tree)
+
+        # A rebase: the same tree, a new synthetic parent.
+        empty_tree = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+        rebase_parent = git("commit-tree", empty_tree, "-m", "rebased-onto")
+        rebased = git(
+            "commit-tree", original_tree, "-p", rebase_parent, "-m", "rebased"
+        )
+        git("reset", "--hard", rebased)
+
+        # A squash-merge on top: yet another brand new commit, still the same
+        # tree, with no ancestry relationship to the original commit at all.
+        squashed = git("commit-tree", original_tree, "-m", "squashed")
+        git("reset", "--hard", squashed)
+
+        self.assertEqual((repo / "file.txt").read_text(encoding="utf-8"), "v1")
+
+        with mock.patch.object(record_eval_run, "REPOSITORY_ROOT", repo):
+            after_rewrite = record_eval_run.candidate_identity()
+
+        self.assertEqual(after_rewrite["tree"], original_tree)
+        self.assertNotEqual(after_rewrite["sha"], before_rewrite["sha"])
+
 
 class NormIsStatedTests(unittest.TestCase):
     """AC: the norm is written down where a contributor and a PR author read it."""
@@ -379,6 +542,31 @@ class NormIsStatedTests(unittest.TestCase):
         self.assertIn("run_forward.py", command)
         self.assertIn("--executor", command)
         self.assertIn("claude_executor.py", command)
+
+    # AC: a real-model run's own command carries an explicit model selection
+    # rather than relying on whatever `claude -p` defaults to in the
+    # environment that ran it.
+    def test_real_model_command_names_the_pinned_model(self) -> None:
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            record_eval_run.main(
+                ["implement-ticket", "--tier", "real-model", "--dry-run"]
+            )
+
+        resolved = json.loads(stdout.getvalue())
+        self.assertEqual(resolved["model"], record_eval_run.RECORDED_MODEL)
+        self.assertIn("--model claude-opus-5", " ".join(resolved["command"]))
+
+    # AC: a deterministic summary names no model — there is no model to name.
+    def test_deterministic_run_names_no_model(self) -> None:
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            record_eval_run.main(
+                ["implement-ticket", "--tier", "deterministic", "--dry-run"]
+            )
+
+        resolved = json.loads(stdout.getvalue())
+        self.assertIsNone(resolved["model"])
 
     def test_deterministic_only_skill_resolves_without_naming_a_tier(self) -> None:
         """A registry entry with no real-model command still runs, with its gap."""


### PR DESCRIPTION
## Summary

- Add `candidate.tree` (`git rev-parse HEAD^{tree}`) to every recorded eval
  summary, alongside the existing `candidate.sha`.
- Pin real-model executor invocations to an explicit `--model claude-opus-5`
  and record the resolved `model` in the summary.
- Require tier, suite, *and* model to match before a prior summary is chosen
  as a run's diff comparison.
- Document both provenance fields in `AGENTS.md`, including that summaries
  recorded before this change carry no model and are unattributed.

Refs #155

## Why

`candidate.sha` names a branch commit. `AGENTS.md` requires rebasing onto
`main` before a PR, which rewrites every branch SHA, and PRs land squashed, so
no branch commit survives as an ancestor of `main` — every summary merged so
far names a SHA `git show` cannot resolve in a fresh clone. `candidate.tree`
resolves identically under both rewrites.

The recorder accepted `--model` on its executors but never passed it, so every
real-model run used whatever `claude -p` defaulted to in that environment on
that day, and a before/after diff taken across a model update silently
compared two different subjects.

Non-goals (per the ticket's settled decisions): no backfilling a model or tree
onto already-committed summaries, no input-content digest (deferred), no
`SUMMARY_SCHEMA` bump, no re-recording of existing baselines under the new
pin.

## Test plan

- [x] `python3 -m unittest scripts.tests.test_record_eval_run -v` — 29 tests,
      including 7 new tests derived from the ticket's acceptance criteria
      (confirmed red at the base SHA, green at head).
- [x] `just format`
- [x] `just lint`
- [x] `just test` (full repository suite, including `review-fix-loop` and
      `review-suite`'s own corpora)
- [x] A manual recorded run (`review-fix-loop`, deterministic tier) confirmed
      `candidate.tree` is populated, `model` is `null` for a deterministic
      run, and the diff still selects a valid prior comparison — the
      resulting artifact file was not part of the ticket's scope and was not
      committed.
- [x] Fresh isolated review (`review-code-change`, all three lenses) came back
      clean with zero findings.

No eval-evidence obligation attaches to this ticket — it changes repository
doctrine (`AGENTS.md`) and recorder code, not a `SKILL.md` or a
behavior-governing skill reference (stated in the ticket itself).
