### PR TITLE
docs: publish the canonical cognitive-shaping doctrine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,21 @@ summary: Chronological history of repository and skill changes.
 
 # Changelog
 
-## 2026-08-11 — Named the tree and the model an eval summary measured, so both survive rebase and squash-merge
+## 2026-08-11 — Gave the cognitive-shaping doctrine a single pinned home in compris, and named the tree and the model an eval summary measured
+
+- docs: publish the pinned canonical cognitive-shaping doctrine — the standard
+  that decides whether a unit of work is comprehensible lived in atelier, which
+  is mid-rebuild and no longer applies it, so the text governing three compris
+  skills was drifting in a project that had stopped reading it.
+  `docs/cognitive-shaping-doctrine.md` now states compris's sole ownership and
+  pins the atelier source by commit, release tag, and release date, so a reader
+  who cannot run `git` can still resolve exactly what was ported. It carries the
+  mental-model standard intact, all eight breakdown rules, the
+  logical-to-realized vocabulary, policy-controlled enforcement that separates
+  judging shape from gating on it, and the exclusion of recorded
+  machine-generated eval evidence from shape judgment. No numeric line-count
+  gate is presented as correctness policy, and no skill behavior changes here —
+  binding each consumer and retiring the duplicate copies is tracked separately.
 
 - fix: record the candidate's git tree hash and, for real-model runs, the pinned
   model name in every recorded eval summary — `candidate.sha` names a branch
@@ -18,6 +32,7 @@ summary: Chronological history of repository and skill changes.
   runs whose tier, suite, and model all match. Summaries recorded before this
   change carry no model at all and are documented as branch-local and
   unattributed rather than backfilled.
+  (fc7cf9ba04f5b4781ee3db037fed57d55c4a77be)
 
 ## 2026-08-09 — Recorded the cognitive-driven development direction: compris takes sole ownership of the cognitive-shaping doctrine from atelier, moves the boundary from "planning is done" to "brainstorming is done", and renames ready-ticket to plan-implementation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,15 @@ summary: Chronological history of repository and skill changes.
 
 ## 2026-08-11 — Gave the cognitive-shaping doctrine a single canonical home in compris, and named the tree and the model an eval summary measured
 
-- docs: publish the canonical cognitive-shaping doctrine — the standard that
-  decides whether a unit of work is comprehensible was stated in more than one
-  place, and a doctrine with two homes has no home: the copies drift, and a
-  reader who finds both cannot tell which one governs.
-  `docs/cognitive-shaping-doctrine.md` now states compris's sole ownership and
-  carries the mental-model standard at its fixed wording, all eight breakdown
-  rules, the logical-to-realized vocabulary, policy-controlled enforcement that
-  separates judging shape from gating on it, and the exclusion of recorded
+- docs: publish the canonical cognitive-shaping doctrine —
+  `docs/cognitive-shaping-doctrine.md` is now the one place the standard that
+  decides whether a unit of work is comprehensible is stated. It carries the
+  mental-model test at its fixed wording, all eight breakdown rules, the
+  logical-to-realized vocabulary, policy-controlled enforcement that separates
+  judging shape from gating on it, and the exclusion of recorded
   machine-generated eval evidence from shape judgment. No numeric line-count
   gate is presented as correctness policy, and no skill behavior changes here —
-  binding each consumer and retiring the duplicate copies is tracked separately.
+  binding each consumer to it is tracked separately.
 
 - fix: record the candidate's git tree hash and, for real-model runs, the pinned
   model name in every recorded eval summary — `candidate.sha` names a branch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,16 @@ summary: Chronological history of repository and skill changes.
 
 # Changelog
 
-## 2026-08-11 — Gave the cognitive-shaping doctrine a single pinned home in compris, and named the tree and the model an eval summary measured
+## 2026-08-11 — Gave the cognitive-shaping doctrine a single canonical home in compris, and named the tree and the model an eval summary measured
 
-- docs: publish the pinned canonical cognitive-shaping doctrine — the standard
-  that decides whether a unit of work is comprehensible lived in atelier, which
-  is mid-rebuild and no longer applies it, so the text governing three compris
-  skills was drifting in a project that had stopped reading it.
+- docs: publish the canonical cognitive-shaping doctrine — the standard that
+  decides whether a unit of work is comprehensible was stated in more than one
+  place, and a doctrine with two homes has no home: the copies drift, and a
+  reader who finds both cannot tell which one governs.
   `docs/cognitive-shaping-doctrine.md` now states compris's sole ownership and
-  pins the atelier source by commit, release tag, and release date, so a reader
-  who cannot run `git` can still resolve exactly what was ported. It carries the
-  mental-model standard intact, all eight breakdown rules, the
-  logical-to-realized vocabulary, policy-controlled enforcement that separates
-  judging shape from gating on it, and the exclusion of recorded
+  carries the mental-model standard at its fixed wording, all eight breakdown
+  rules, the logical-to-realized vocabulary, policy-controlled enforcement that
+  separates judging shape from gating on it, and the exclusion of recorded
   machine-generated eval evidence from shape judgment. No numeric line-count
   gate is presented as correctness policy, and no skill behavior changes here —
   binding each consumer and retiring the duplicate copies is tracked separately.

--- a/docs/cognitive-shaping-doctrine.md
+++ b/docs/cognitive-shaping-doctrine.md
@@ -5,49 +5,24 @@ decides whether a unit of work is comprehensible, the rules that break work
 apart against it, the vocabulary that carries them, and what enforcement is and
 is not.
 
-It is doctrine, not design.
-[`cognitive-driven-development.md`](cognitive-driven-development.md) records the
+It is doctrine, not design. [cognitive-driven-development.md] records the
 program this doctrine was extracted for, the decisions behind it, and the
 alternatives still open. Read that for why; read this for what holds.
 
 ## Ownership
 
-compris is the sole owner of this doctrine. Every other statement of it — in
-atelier, in a consuming skill's own contract, or anywhere else — is a historical
-source or a consumer copy, never a competing authority.
+compris is the sole owner of this doctrine. Any other statement of the same
+standard — in a consuming skill's own contract or anywhere else — is a copy,
+never a competing authority.
 
-A doctrine with two homes has no home. atelier is moving toward multi-agent
-process management and is mid-rebuild, so leaving the standard in the project
-that no longer applies it guarantees exactly the drift this document exists to
-end.
+A doctrine with two homes has no home. Once the same standard is stated in two
+places, the two drift, and a reader who finds both has no way to tell which one
+governs.
 
 Retiring the remaining copies is separately tracked and is not performed here.
 Naming that state is part of the ownership claim rather than a caveat on it: a
 reader who finds two texts needs to know which one is authoritative while the
 other is still standing.
-
-## Provenance
-
-| Field             | Value                                               |
-| ----------------- | --------------------------------------------------- |
-| Source repository | `shaug/atelier`                                     |
-| Source path       | `docs/atelier-skill-design.md`                      |
-| Source section    | "Human-shaped changesets", lines 463–482 at the pin |
-| Commit            | `c08755f3a80c39b747df4cbf9be94e559d5081e2`          |
-| Release           | `atelier-cli-v2-final`                              |
-| Release date      | 2026-07-26                                          |
-
-*Why pinned.* An unpinned reference describes a moving target, so a citation
-that was accurate when written becomes wrong without anything changing here.
-compris already solved this for superpowers, which
-[`skill-authoring.md`](skill-authoring.md) pins at a commit and resolves to a
-marketplace release. Recording the release and its date alongside the commit is
-what makes the pin resolvable by a reader who cannot run `git`: the commit names
-the content, and the release names something a human can look up.
-
-The pin is a provenance record, not a subscription. Upstream drift is absorbed
-by re-reviewing against a new pin and editing this document — never by treating
-the citation as approximate.
 
 ## The standard
 
@@ -55,15 +30,16 @@ the citation as approximate.
 > test is whether a reviewer can construct an accurate mental model of the
 > change and evaluate it independently.
 
-Carried intact from the pinned source. Inventing a second wording is how two
-codifications start drifting, which is the failure this port exists to end.
+That wording is fixed. Restating it in fresh words in each place it is needed is
+how one standard becomes several, which is the drift this document exists to
+end.
 
 Note what the standard rules out. It is not a threshold check. Line count is an
-input to judgment and nothing more: atelier dropped its predecessor's fixed
-implementation and some of its numeric heuristics precisely in order to
-subordinate line count to the mental-model test. Any implementation that reduces
-this standard to a number has failed to carry it, however defensible the number
-is.
+input to judgment and nothing more. Earlier statements of this standard carried
+numeric heuristics alongside it; they were dropped deliberately, to subordinate
+line count to the mental-model test rather than let a number stand in for it.
+Any implementation that reduces this standard to a threshold has failed to carry
+it, however defensible the threshold is.
 
 ### Recorded machine-generated evidence is excluded from shape judgment
 
@@ -71,16 +47,16 @@ Committed eval results, generated fixtures, lockfiles, and comparable
 machine-produced artifacts are part of the change and are excluded from the
 shape judgment, because no reviewer builds a mental model of them.
 
-*Prevents:* a judgment made on raw churn rejects a small change because this
-repository's own eval-evidence norm required that change's evidence to be
-committed. compris PR #179 is the observed case: 4,715 lines of churn, of which
-4,538 lines are recorded eval results, leaving a reviewable change of 177 lines.
-Judging the 4,715 measures the wrong thing.
+*Prevents:* a judgment made on raw churn rejects a small change because the
+eval-evidence norm in [AGENTS.md] required that change's evidence to be
+committed. Pull request #179 is the observed case: 4,715 lines of churn, of
+which 4,538 lines are recorded eval results, leaving a reviewable change of 177
+lines. Judging the 4,715 measures the wrong thing.
 
 ## The breakdown rules
 
-Eight rules, carried whole from the pinned source, with the source's
-`assignment` mapped to compris's own leaf noun.
+Eight rules. Each is load-bearing, and a breakdown is judged against all of
+them.
 
 - Keep an initiative executable as one ticket when it is already reviewable.
 - Avoid one-child decomposition without a real reason.
@@ -121,10 +97,10 @@ Description-based routing is winner-takes-attention: people say "implement this
 GitHub issue", and a description answering only to a logical noun would quietly
 stop matching them.
 
-`assignment`, `claim`, `receipt`, and `worker` are deliberately not imported.
-They belong to atelier's process-management layer, and an assignment — a
-claimable unit of approved work — is not the shaped unit of code a reviewer
-reads. One maps onto the other; neither replaces it.
+Process-management nouns — `assignment`, `claim`, `receipt`, `worker` — are
+deliberately outside this vocabulary. A claimable unit of approved work is not
+the shaped unit of code a reviewer reads; one maps onto the other, and neither
+replaces it.
 
 ## Enforcement is policy-controlled
 
@@ -161,3 +137,8 @@ document is separately tracked and is not performed here.
 - `review-solution-simplicity` judges whole-solution complexity.
 - `implement-ticket` classifies a candidate at its publication size gate, and
   already reads a named authority rather than carrying a heuristic of its own.
+
+<!-- inline reference link definitions. please keep alphabetized -->
+
+[agents.md]: ../AGENTS.md
+[cognitive-driven-development.md]: cognitive-driven-development.md

--- a/docs/cognitive-shaping-doctrine.md
+++ b/docs/cognitive-shaping-doctrine.md
@@ -1,0 +1,163 @@
+# Cognitive shaping doctrine
+
+This is compris's canonical statement of cognitive shaping: the standard that
+decides whether a unit of work is comprehensible, the rules that break work
+apart against it, the vocabulary that carries them, and what enforcement is and
+is not.
+
+It is doctrine, not design.
+[`cognitive-driven-development.md`](cognitive-driven-development.md) records the
+program this doctrine was extracted for, the decisions behind it, and the
+alternatives still open. Read that for why; read this for what holds.
+
+## Ownership
+
+compris is the sole owner of this doctrine. Every other statement of it — in
+atelier, in a consuming skill's own contract, or anywhere else — is a historical
+source or a consumer copy, never a competing authority.
+
+A doctrine with two homes has no home. atelier is moving toward multi-agent
+process management and is mid-rebuild, so leaving the standard in the project
+that no longer applies it guarantees exactly the drift this document exists to
+end.
+
+Retiring the remaining copies is separately tracked and is not performed here.
+Naming that state is part of the ownership claim rather than a caveat on it: a
+reader who finds two texts needs to know which one is authoritative while the
+other is still standing.
+
+## Provenance
+
+| Field             | Value                                               |
+| ----------------- | --------------------------------------------------- |
+| Source repository | `shaug/atelier`                                     |
+| Source path       | `docs/atelier-skill-design.md`                      |
+| Source section    | "Human-shaped changesets", lines 463–482 at the pin |
+| Commit            | `c08755f3a80c39b747df4cbf9be94e559d5081e2`          |
+| Release           | `atelier-cli-v2-final`                              |
+| Release date      | 2026-07-26                                          |
+
+*Why pinned.* An unpinned reference describes a moving target, so a citation
+that was accurate when written becomes wrong without anything changing here.
+compris already solved this for superpowers, which
+[`skill-authoring.md`](skill-authoring.md) pins at a commit and resolves to a
+marketplace release. Recording the release and its date alongside the commit is
+what makes the pin resolvable by a reader who cannot run `git`: the commit names
+the content, and the release names something a human can look up.
+
+The pin is a provenance record, not a subscription. Upstream drift is absorbed
+by re-reviewing against a new pin and editing this document — never by treating
+the citation as approximate.
+
+## The standard
+
+> Line counts may inform judgment but are not universal correctness gates. The
+> test is whether a reviewer can construct an accurate mental model of the
+> change and evaluate it independently.
+
+Carried intact from the pinned source. Inventing a second wording is how two
+codifications start drifting, which is the failure this port exists to end.
+
+Note what the standard rules out. It is not a threshold check. Line count is an
+input to judgment and nothing more: atelier dropped its predecessor's fixed
+implementation and some of its numeric heuristics precisely in order to
+subordinate line count to the mental-model test. Any implementation that reduces
+this standard to a number has failed to carry it, however defensible the number
+is.
+
+### Recorded machine-generated evidence is excluded from shape judgment
+
+Committed eval results, generated fixtures, lockfiles, and comparable
+machine-produced artifacts are part of the change and are excluded from the
+shape judgment, because no reviewer builds a mental model of them.
+
+*Prevents:* a judgment made on raw churn rejects a small change because this
+repository's own eval-evidence norm required that change's evidence to be
+committed. compris PR #179 is the observed case: 4,715 lines of churn, of which
+4,538 lines are recorded eval results, leaving a reviewable change of 177 lines.
+Judging the 4,715 measures the wrong thing.
+
+## The breakdown rules
+
+Eight rules, carried whole from the pinned source, with the source's
+`assignment` mapped to compris's own leaf noun.
+
+- Keep an initiative executable as one ticket when it is already reviewable.
+- Avoid one-child decomposition without a real reason.
+- Separate unrelated concern domains.
+- Prefer additive foundations before disruptive transitions.
+- Separate mechanical restructuring from behavioral change when that helps
+  review.
+- Keep validation with the behavior it proves.
+- Identify re-split triggers before implementation.
+- Create follow-up work when implementation or review reveals new scope.
+
+The first two carry the tone. One ticket is a legal outcome, and ceremonial
+decomposition is a failure rather than diligence: a breakdown that splits
+because splitting is what a breakdown does buys review overhead and nothing
+else.
+
+The eighth is the only one that does not apply when the breakdown is authored.
+It describes a downstream event, so it is discharged when implementation or
+review actually reveals the new scope.
+
+## Vocabulary
+
+The doctrine's nouns are logical; the tracker's are realized. Both are needed,
+and conflating them is what makes contracts and descriptions disagree about the
+same object.
+
+| Logical (internal currency) | Realized (what users say) |
+| --------------------------- | ------------------------- |
+| initiative                  | epic                      |
+| changeset                   | pull request              |
+
+A leaf ticket is a child of an epic and is scoped to one changeset. The logical
+nouns are how this doctrine, contracts, and handoffs talk; the realized nouns
+are what descriptions claim, because that is what people type.
+
+Keeping `ticket` as the leaf noun is what makes the split safe.
+Description-based routing is winner-takes-attention: people say "implement this
+GitHub issue", and a description answering only to a logical noun would quietly
+stop matching them.
+
+`assignment`, `claim`, `receipt`, and `worker` are deliberately not imported.
+They belong to atelier's process-management layer, and an assignment — a
+claimable unit of approved work — is not the shaped unit of code a reviewer
+reads. One maps onto the other; neither replaces it.
+
+## Enforcement is policy-controlled
+
+Judgment and enforcement are separate, and only judgment is universal. The
+shaper always judges, and the consuming project decides whether an exceeds
+verdict gates anything.
+
+compris is itself such a project today: it declines shape gating, which is why
+its own merged history contains changes this standard would not call reviewable,
+and why `carve-changesets` has never carved anything here. The mechanism has not
+failed; it has not been asked.
+
+*Prevents:* a doctrine that gates by construction cannot be adopted
+incrementally, so a project wanting ticket authoring and delivery automation
+without shape gating has to fork it or ignore it. Separating judgment from
+enforcement is what lets the standard be stated once and applied at whatever
+strength each project chose.
+
+### A carved stack is a recorded falsification, not a violation
+
+The invariant is a prediction: every leaf ticket is scoped to what is predicted
+to be one changeset, realized as one pull request. When implementation proves
+that prediction wrong, an authorized carved stack is the recorded falsification
+of it. Developers are bad at estimating; the answer is measurement, not
+accuracy.
+
+## Consumers
+
+Named so a reader can tell authority from copy. Binding each consumer to this
+document is separately tracked and is not performed here.
+
+- `carve-changesets` decides changeset boundaries and still carries its own
+  generic codification.
+- `review-solution-simplicity` judges whole-solution complexity.
+- `implement-ticket` classifies a candidate at its publication size gate, and
+  already reads a named authority rather than carrying a heuristic of its own.

--- a/docs/cognitive-shaping-doctrine.md
+++ b/docs/cognitive-shaping-doctrine.md
@@ -68,14 +68,19 @@ items use the realized ones, because that is what people type.
 
 ## Enforcement
 
-Shape is always judged. Whether an oversized verdict gates anything is the
-consuming project's decision — judging is read-only, and acting on the verdict
-is policy.
+Shape is always judged. Whether the judgment gates anything is the consuming
+project's decision — judging is read-only, and acting on a verdict is policy.
 
-The invariant is a prediction: every leaf ticket is scoped to what is predicted
-to be one changeset, realized as one pull request. An authorized carved stack is
-that prediction recorded as falsified. Developers are bad at estimating; the
-answer is measurement, not accuracy.
+The obligation is asymmetric, deliberately. Planning always aims at a shaped
+plan: every leaf ticket is scoped to what is predicted to be one changeset,
+realized as one pull request. Correcting that prediction once implementation is
+under way is not required. Carving an oversized branch into a reviewable chain
+is available and never automatic — a decision the project makes deliberately or
+declines, never one taken silently on its behalf.
+
+So a carved stack is a falsified prediction, recorded. Developers are bad at
+estimating; the answer is measurement, not accuracy — and a project that
+measures without correcting still gets the measurement.
 
 ## Consumers
 

--- a/docs/cognitive-shaping-doctrine.md
+++ b/docs/cognitive-shaping-doctrine.md
@@ -6,23 +6,8 @@ apart against it, the vocabulary that carries them, and what enforcement is and
 is not.
 
 It is doctrine, not design. [cognitive-driven-development.md] records the
-program this doctrine was extracted for, the decisions behind it, and the
-alternatives still open. Read that for why; read this for what holds.
-
-## Ownership
-
-compris is the sole owner of this doctrine. Any other statement of the same
-standard — in a consuming skill's own contract or anywhere else — is a copy,
-never a competing authority.
-
-A doctrine with two homes has no home. Once the same standard is stated in two
-places, the two drift, and a reader who finds both has no way to tell which one
-governs.
-
-Retiring the remaining copies is separately tracked and is not performed here.
-Naming that state is part of the ownership claim rather than a caveat on it: a
-reader who finds two texts needs to know which one is authoritative while the
-other is still standing.
+program this doctrine serves, the decisions behind it, and the alternatives
+still open. Read that for why; read this for what holds.
 
 ## The standard
 
@@ -30,16 +15,12 @@ other is still standing.
 > test is whether a reviewer can construct an accurate mental model of the
 > change and evaluate it independently.
 
-That wording is fixed. Restating it in fresh words in each place it is needed is
-how one standard becomes several, which is the drift this document exists to
-end.
+Use that wording as it stands. A consumer that paraphrases it into its own
+contract has created a second standard, and the two will drift.
 
-Note what the standard rules out. It is not a threshold check. Line count is an
-input to judgment and nothing more. Earlier statements of this standard carried
-numeric heuristics alongside it; they were dropped deliberately, to subordinate
-line count to the mental-model test rather than let a number stand in for it.
-Any implementation that reduces this standard to a threshold has failed to carry
-it, however defensible the threshold is.
+Note what the standard rules out. It is not a threshold check: line count is an
+input to judgment and nothing more. Any implementation that reduces the standard
+to a number has failed to carry it, however defensible the number is.
 
 ### Recorded machine-generated evidence is excluded from shape judgment
 
@@ -129,11 +110,12 @@ accuracy.
 
 ## Consumers
 
-Named so a reader can tell authority from copy. Binding each consumer to this
-document is separately tracked and is not performed here.
+Binding these to this document is separately tracked and is not performed here.
+Where one still states its own generic version of the rules, this document
+governs.
 
-- `carve-changesets` decides changeset boundaries and still carries its own
-  generic codification.
+- `carve-changesets` decides changeset boundaries, and still states its own
+  cognitive-load guardrails and decomposition order.
 - `review-solution-simplicity` judges whole-solution complexity.
 - `implement-ticket` classifies a candidate at its publication size gate, and
   already reads a named authority rather than carrying a heuristic of its own.

--- a/docs/cognitive-shaping-doctrine.md
+++ b/docs/cognitive-shaping-doctrine.md
@@ -38,7 +38,7 @@ question stops being rhetorical and has to be asked deliberately.
 ## The breakdown rules
 
 - Keep an initiative executable as one ticket when it is already reviewable.
-- Avoid one-child decomposition without a real reason.
+- Never decompose to a single child.
 - Separate unrelated concern domains.
 - Prefer additive foundations before disruptive transitions.
 - Separate mechanical restructuring from behavioral change when that helps
@@ -47,9 +47,16 @@ question stops being rhetorical and has to be asked deliberately.
 - Identify re-split triggers before implementation.
 - Create follow-up work when implementation or review reveals new scope.
 
-One ticket is a legal outcome. The first two rules outrank the impulse to
-decompose: a breakdown that splits because splitting is what a breakdown does
-buys review overhead and nothing else.
+One ticket is a legal outcome, and it is the whole of the single-unit case. A
+leaf is a unit of work; a parent groups leaves into a milestone, a goal, or a
+larger initiative. A parent holding one child is neither — it represents nothing
+its child does not already represent, and it costs a level of indirection to say
+so. Where the work fits one ticket the first rule applies and no parent is
+created, which leaves the second nothing to permit.
+
+Both rules exist to outrank the impulse to decompose. A breakdown that splits
+because splitting is what a breakdown does buys review overhead and nothing
+else.
 
 Creating follow-up work is the one rule that applies downstream. It is
 discharged when implementation or review reveals the new scope, not when the

--- a/docs/cognitive-shaping-doctrine.md
+++ b/docs/cognitive-shaping-doctrine.md
@@ -12,13 +12,28 @@ decisions that shaped it. This document is the statement itself.
 A unit of work is correctly shaped when a reviewer can construct an accurate
 mental model of the change and evaluate it independently.
 
-Line counts inform that judgment. They never decide it, and no threshold
-substitutes for it.
+Line counts inform that judgment. They never decide it.
 
-Recorded machine-generated evidence — committed eval results, generated
-fixtures, lockfiles — is excluded, because a reviewer builds no mental model of
-it. A change carrying 177 reviewable lines and 4,538 lines of recorded eval
-results is a 177-line change.
+## Scale
+
+A changeset is sized to be read in one sitting, and most that meet the standard
+run to a few hundred changed lines. Both figures are calibration, not a gate:
+they say where the standard usually lands, not where it is enforced.
+
+Three things move the number without moving the standard.
+
+- Deletion costs less than addition, once the reason for the removal and the
+  behavior replacing it are clear.
+- Mechanical change — a systematic rename, a codemod, a formatting pass — runs
+  much larger, because the reviewer verifies one transformation instead of
+  reading every line.
+- Recorded machine-generated evidence is excluded outright. Committed eval
+  results, generated fixtures, and lockfiles are part of the change and part of
+  nothing anyone reads. A change carrying 177 reviewable lines and 4,538 lines
+  of recorded eval results is a 177-line change.
+
+Falling outside the range is not itself a defect. It is where the standard's
+question stops being rhetorical and has to be asked deliberately.
 
 ## The breakdown rules
 

--- a/docs/cognitive-shaping-doctrine.md
+++ b/docs/cognitive-shaping-doctrine.md
@@ -1,43 +1,26 @@
 # Cognitive shaping doctrine
 
-This is compris's canonical statement of cognitive shaping: the standard that
-decides whether a unit of work is comprehensible, the rules that break work
-apart against it, the vocabulary that carries them, and what enforcement is and
-is not.
+This is compris's doctrine of cognitive shaping: work is broken apart by what a
+reviewer can understand, and that is the binding constraint rather than a nicety
+observed when there is time.
 
-It is doctrine, not design. [cognitive-driven-development.md] records the
-program this doctrine serves, the decisions behind it, and the alternatives
-still open. Read that for why; read this for what holds.
+[cognitive-driven-development.md] records the program behind this and the
+decisions that shaped it. This document is the statement itself.
 
 ## The standard
 
-> Line counts may inform judgment but are not universal correctness gates. The
-> test is whether a reviewer can construct an accurate mental model of the
-> change and evaluate it independently.
+A unit of work is correctly shaped when a reviewer can construct an accurate
+mental model of the change and evaluate it independently.
 
-Use that wording as it stands. A consumer that paraphrases it into its own
-contract has created a second standard, and the two will drift.
+Line counts inform that judgment. They never decide it, and no threshold
+substitutes for it.
 
-Note what the standard rules out. It is not a threshold check: line count is an
-input to judgment and nothing more. Any implementation that reduces the standard
-to a number has failed to carry it, however defensible the number is.
-
-### Recorded machine-generated evidence is excluded from shape judgment
-
-Committed eval results, generated fixtures, lockfiles, and comparable
-machine-produced artifacts are part of the change and are excluded from the
-shape judgment, because no reviewer builds a mental model of them.
-
-*Prevents:* a judgment made on raw churn rejects a small change because the
-eval-evidence norm in [AGENTS.md] required that change's evidence to be
-committed. Pull request #179 is the observed case: 4,715 lines of churn, of
-which 4,538 lines are recorded eval results, leaving a reviewable change of 177
-lines. Judging the 4,715 measures the wrong thing.
+Recorded machine-generated evidence — committed eval results, generated
+fixtures, lockfiles — is excluded, because a reviewer builds no mental model of
+it. A change carrying 177 reviewable lines and 4,538 lines of recorded eval
+results is a 177-line change.
 
 ## The breakdown rules
-
-Eight rules. Each is load-bearing, and a breakdown is judged against all of
-them.
 
 - Keep an initiative executable as one ticket when it is already reviewable.
 - Avoid one-child decomposition without a real reason.
@@ -49,78 +32,44 @@ them.
 - Identify re-split triggers before implementation.
 - Create follow-up work when implementation or review reveals new scope.
 
-The first two carry the tone. One ticket is a legal outcome, and ceremonial
-decomposition is a failure rather than diligence: a breakdown that splits
-because splitting is what a breakdown does buys review overhead and nothing
-else.
+One ticket is a legal outcome. The first two rules outrank the impulse to
+decompose: a breakdown that splits because splitting is what a breakdown does
+buys review overhead and nothing else.
 
-The eighth is the only one that does not apply when the breakdown is authored.
-It describes a downstream event, so it is discharged when implementation or
-review actually reveals the new scope.
+Creating follow-up work is the one rule that applies downstream. It is
+discharged when implementation or review reveals the new scope, not when the
+breakdown is authored.
 
 ## Vocabulary
 
-The doctrine's nouns are logical; the tracker's are realized. Both are needed,
-and conflating them is what makes contracts and descriptions disagree about the
-same object.
+| Logical    | Realized     |
+| ---------- | ------------ |
+| initiative | epic         |
+| changeset  | pull request |
 
-| Logical (internal currency) | Realized (what users say) |
-| --------------------------- | ------------------------- |
-| initiative                  | epic                      |
-| changeset                   | pull request              |
+A leaf ticket is a child of an epic, scoped to one changeset. Doctrine,
+contracts, and handoffs speak in the logical nouns; descriptions and tracker
+items use the realized ones, because that is what people type.
 
-A leaf ticket is a child of an epic and is scoped to one changeset. The logical
-nouns are how this doctrine, contracts, and handoffs talk; the realized nouns
-are what descriptions claim, because that is what people type.
+## Enforcement
 
-Keeping `ticket` as the leaf noun is what makes the split safe.
-Description-based routing is winner-takes-attention: people say "implement this
-GitHub issue", and a description answering only to a logical noun would quietly
-stop matching them.
-
-Process-management nouns — `assignment`, `claim`, `receipt`, `worker` — are
-deliberately outside this vocabulary. A claimable unit of approved work is not
-the shaped unit of code a reviewer reads; one maps onto the other, and neither
-replaces it.
-
-## Enforcement is policy-controlled
-
-Judgment and enforcement are separate, and only judgment is universal. The
-shaper always judges, and the consuming project decides whether an exceeds
-verdict gates anything.
-
-compris is itself such a project today: it declines shape gating, which is why
-its own merged history contains changes this standard would not call reviewable,
-and why `carve-changesets` has never carved anything here. The mechanism has not
-failed; it has not been asked.
-
-*Prevents:* a doctrine that gates by construction cannot be adopted
-incrementally, so a project wanting ticket authoring and delivery automation
-without shape gating has to fork it or ignore it. Separating judgment from
-enforcement is what lets the standard be stated once and applied at whatever
-strength each project chose.
-
-### A carved stack is a recorded falsification, not a violation
+Shape is always judged. Whether an oversized verdict gates anything is the
+consuming project's decision — judging is read-only, and acting on the verdict
+is policy.
 
 The invariant is a prediction: every leaf ticket is scoped to what is predicted
-to be one changeset, realized as one pull request. When implementation proves
-that prediction wrong, an authorized carved stack is the recorded falsification
-of it. Developers are bad at estimating; the answer is measurement, not
-accuracy.
+to be one changeset, realized as one pull request. An authorized carved stack is
+that prediction recorded as falsified. Developers are bad at estimating; the
+answer is measurement, not accuracy.
 
 ## Consumers
 
-Binding these to this document is separately tracked and is not performed here.
-Where one still states its own generic version of the rules, this document
-governs.
+This doctrine governs shape judgment in:
 
-- `carve-changesets` decides changeset boundaries, and still states its own
-  cognitive-load guardrails and decomposition order.
-- `review-solution-simplicity` judges whole-solution complexity.
-- `implement-ticket` classifies a candidate at its publication size gate, and
-  already reads a named authority rather than carrying a heuristic of its own.
+- `carve-changesets`, for changeset boundaries;
+- `review-solution-simplicity`, for whole-solution complexity; and
+- `implement-ticket`, at the publication size gate.
 
 <!-- inline reference link definitions. please keep alphabetized -->
 
-[agents.md]: ../AGENTS.md
 [cognitive-driven-development.md]: cognitive-driven-development.md

--- a/scripts/tests/test_cognitive_shaping_doctrine.py
+++ b/scripts/tests/test_cognitive_shaping_doctrine.py
@@ -41,14 +41,23 @@ BREAKDOWN_RULES = (
     "Create follow-up work when implementation or review reveals new scope",
 )
 
-# Threshold constructions, not the words "line count". The doctrine has to be
-# able to refuse a line-count gate; what it may not do is state one.
+# What the criterion forbids is a *gate*, not a number. The doctrine carries
+# calibration figures on purpose — an unanchored "can a reviewer understand
+# it?" collapses to always-yes — so these patterns match enforcement, the
+# bound and the verb that would make a figure pass/fail.
 NUMERIC_GATE_PATTERNS = (
-    r"(?:at most|no more than|fewer than|under|up to|a maximum of|a limit of)"
+    r"(?:at most|no more than|fewer than|up to|must not exceed|may not exceed"
+    r"|a maximum of|a limit of)"
     r"\s+[\d,]+\s+(?:new or changed |changed |added )?lines",
-    r"a few hundred (?:new or changed )?lines",
     r"[\d,]+[- ]line (?:limit|cap|threshold|maximum|budget|target)",
-    r"preferred range",
+    r"(?:reject|refuse|block|fail|gate)\w*\s+(?:\w+\s+){0,3}"
+    r"(?:over|above|beyond|exceeding)\s+[\d,]+",
+)
+
+# The calibration figures only stay non-binding while the document says so.
+NON_GATE_DISCLAIMERS = (
+    "Line counts inform that judgment. They never decide it.",
+    "calibration, not a gate",
 )
 
 
@@ -99,6 +108,11 @@ class CognitiveShapingDoctrineTests(unittest.TestCase):
                     re.search(pattern, self.doc, flags=re.IGNORECASE),
                     f"doctrine states a numeric size gate matching {pattern!r}",
                 )
+
+    def test_the_calibration_figures_are_marked_non_binding(self):
+        for disclaimer in NON_GATE_DISCLAIMERS:
+            with self.subTest(disclaimer=disclaimer):
+                self.assertIn(disclaimer, self.doc)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_cognitive_shaping_doctrine.py
+++ b/scripts/tests/test_cognitive_shaping_doctrine.py
@@ -70,9 +70,11 @@ class CognitiveShapingDoctrineTests(unittest.TestCase):
     def setUpClass(cls):
         cls.doc = normalize(DOCTRINE.read_text())
 
-    def test_compris_is_named_the_sole_owner_of_the_doctrine(self):
-        self.assertIn("compris is the sole owner", self.doc)
-        self.assertIn("A doctrine with two homes has no home", self.doc)
+    def test_the_doctrine_identifies_compris_as_its_owner(self):
+        self.assertIn(
+            "This is compris's canonical statement of cognitive shaping",
+            self.doc,
+        )
 
     def test_the_doctrine_attributes_itself_to_no_outside_project(self):
         for foreign in FOREIGN_SOURCES:

--- a/scripts/tests/test_cognitive_shaping_doctrine.py
+++ b/scripts/tests/test_cognitive_shaping_doctrine.py
@@ -17,17 +17,12 @@ from helpers import compact
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 DOCTRINE = REPOSITORY_ROOT / "docs" / "cognitive-shaping-doctrine.md"
 
-# The atelier source this doctrine was ported from, recorded so a reader who
-# cannot run `git` can still resolve it: the commit names the content, the
-# release tag and its date name something a human can look up.
-ATELIER_SOURCE_REPOSITORY = "shaug/atelier"
-ATELIER_SOURCE_PATH = "docs/atelier-skill-design.md"
-ATELIER_PIN_COMMIT = "c08755f3a80c39b747df4cbf9be94e559d5081e2"
-ATELIER_PIN_RELEASE = "atelier-cli-v2-final"
-ATELIER_PIN_DATE = "2026-07-26"
+# The doctrine is compris's own. It names no upstream project, because there is
+# no external owner to attribute and an outward-facing citation would imply one.
+FOREIGN_SOURCES = ("atelier",)
 
-# Ported intact from the pinned source. A second wording is how two
-# codifications start drifting, which is the failure this port exists to end.
+# Fixed wording. A second wording is how two codifications start drifting,
+# which is the failure this document exists to end.
 MENTAL_MODEL_STANDARD = compact(
     """
     Line counts may inform judgment but are not universal correctness gates.
@@ -36,8 +31,8 @@ MENTAL_MODEL_STANDARD = compact(
     """
 )
 
-# All eight, in the pinned source's order. The doctrine must account for every
-# one; dropping any is how a ported rule set quietly becomes a summary of one.
+# All eight. The doctrine must account for every one; dropping any is how a
+# rule set quietly becomes a summary of itself.
 BREAKDOWN_RULES = (
     "Keep an initiative executable as one ticket when it is already reviewable",
     "Avoid one-child decomposition without a real reason",
@@ -63,9 +58,9 @@ NUMERIC_GATE_PATTERNS = (
 def normalize(markdown: str) -> str:
     """Compact `markdown`, dropping the blockquote markers `>` introduces.
 
-    The ported standard is quoted, and wrapping it puts a `>` at the head of
-    every line; leaving those in would make the assertion depend on where the
-    formatter happened to break the quote.
+    The standard is set as a blockquote, and wrapping it puts a `>` at the head
+    of every line; leaving those in would make the assertion depend on where
+    the formatter happened to break the quote.
     """
     return compact(re.sub(r"^\s*>\s?", "", markdown, flags=re.MULTILINE))
 
@@ -79,15 +74,10 @@ class CognitiveShapingDoctrineTests(unittest.TestCase):
         self.assertIn("compris is the sole owner", self.doc)
         self.assertIn("A doctrine with two homes has no home", self.doc)
 
-    def test_the_atelier_source_pin_resolves_without_running_git(self):
-        for required in (
-            ATELIER_SOURCE_REPOSITORY,
-            ATELIER_SOURCE_PATH,
-            ATELIER_PIN_COMMIT,
-            ATELIER_PIN_RELEASE,
-            ATELIER_PIN_DATE,
-        ):
-            self.assertIn(required, self.doc)
+    def test_the_doctrine_attributes_itself_to_no_outside_project(self):
+        for foreign in FOREIGN_SOURCES:
+            with self.subTest(source=foreign):
+                self.assertNotIn(foreign, self.doc.lower())
 
     def test_the_mental_model_standard_is_carried_intact(self):
         self.assertIn(MENTAL_MODEL_STANDARD, self.doc)

--- a/scripts/tests/test_cognitive_shaping_doctrine.py
+++ b/scripts/tests/test_cognitive_shaping_doctrine.py
@@ -32,7 +32,7 @@ MENTAL_MODEL_STANDARD = compact(
 # rule set quietly becomes a summary of itself.
 BREAKDOWN_RULES = (
     "Keep an initiative executable as one ticket when it is already reviewable",
-    "Avoid one-child decomposition without a real reason",
+    "Never decompose to a single child",
     "Separate unrelated concern domains",
     "Prefer additive foundations before disruptive transitions",
     "Separate mechanical restructuring from behavioral change when that helps review",

--- a/scripts/tests/test_cognitive_shaping_doctrine.py
+++ b/scripts/tests/test_cognitive_shaping_doctrine.py
@@ -91,10 +91,18 @@ class CognitiveShapingDoctrineTests(unittest.TestCase):
     def test_enforcement_is_policy_controlled_and_separate_from_judgment(self):
         self.assertIn("Shape is always judged", self.doc)
         self.assertIn(
-            "Whether an oversized verdict gates anything is the consuming"
-            " project's decision",
+            "Whether the judgment gates anything is the consuming project's decision",
             self.doc,
         )
+
+    def test_mid_stream_correction_is_optional_while_planning_always_shapes(self):
+        self.assertIn("Planning always aims at a shaped plan", self.doc)
+        self.assertIn(
+            "Correcting that prediction once implementation is under way is not"
+            " required",
+            self.doc,
+        )
+        self.assertIn("available and never automatic", self.doc)
 
     def test_recorded_machine_generated_evidence_is_excluded_from_judgment(self):
         self.assertIn("Recorded machine-generated evidence", self.doc)

--- a/scripts/tests/test_cognitive_shaping_doctrine.py
+++ b/scripts/tests/test_cognitive_shaping_doctrine.py
@@ -1,0 +1,130 @@
+"""Load-bearing contract invariants for docs/cognitive-shaping-doctrine.md.
+
+Checks stable identifiers in the doctrine's own normative text, not phrasing.
+The document is repository-wide rather than skill-scoped, so its own tests live
+here rather than inside any one skill's test suite, exactly as
+`test_skill_authoring_doc.py` does for the authoring standard.
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+from helpers import compact
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+DOCTRINE = REPOSITORY_ROOT / "docs" / "cognitive-shaping-doctrine.md"
+
+# The atelier source this doctrine was ported from, recorded so a reader who
+# cannot run `git` can still resolve it: the commit names the content, the
+# release tag and its date name something a human can look up.
+ATELIER_SOURCE_REPOSITORY = "shaug/atelier"
+ATELIER_SOURCE_PATH = "docs/atelier-skill-design.md"
+ATELIER_PIN_COMMIT = "c08755f3a80c39b747df4cbf9be94e559d5081e2"
+ATELIER_PIN_RELEASE = "atelier-cli-v2-final"
+ATELIER_PIN_DATE = "2026-07-26"
+
+# Ported intact from the pinned source. A second wording is how two
+# codifications start drifting, which is the failure this port exists to end.
+MENTAL_MODEL_STANDARD = compact(
+    """
+    Line counts may inform judgment but are not universal correctness gates.
+    The test is whether a reviewer can construct an accurate mental model of
+    the change and evaluate it independently.
+    """
+)
+
+# All eight, in the pinned source's order. The doctrine must account for every
+# one; dropping any is how a ported rule set quietly becomes a summary of one.
+BREAKDOWN_RULES = (
+    "Keep an initiative executable as one ticket when it is already reviewable",
+    "Avoid one-child decomposition without a real reason",
+    "Separate unrelated concern domains",
+    "Prefer additive foundations before disruptive transitions",
+    "Separate mechanical restructuring from behavioral change when that helps review",
+    "Keep validation with the behavior it proves",
+    "Identify re-split triggers before implementation",
+    "Create follow-up work when implementation or review reveals new scope",
+)
+
+# Threshold constructions, not the words "line count". The doctrine has to be
+# able to say a line-count gate is refused; what it may not do is state one.
+NUMERIC_GATE_PATTERNS = (
+    r"(?:at most|no more than|fewer than|under|up to|a maximum of|a limit of)"
+    r"\s+[\d,]+\s+(?:new or changed |changed |added )?lines",
+    r"a few hundred (?:new or changed )?lines",
+    r"[\d,]+[- ]line (?:limit|cap|threshold|maximum|budget|target)",
+    r"preferred range",
+)
+
+
+def normalize(markdown: str) -> str:
+    """Compact `markdown`, dropping the blockquote markers `>` introduces.
+
+    The ported standard is quoted, and wrapping it puts a `>` at the head of
+    every line; leaving those in would make the assertion depend on where the
+    formatter happened to break the quote.
+    """
+    return compact(re.sub(r"^\s*>\s?", "", markdown, flags=re.MULTILINE))
+
+
+class CognitiveShapingDoctrineTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.doc = normalize(DOCTRINE.read_text())
+
+    def test_compris_is_named_the_sole_owner_of_the_doctrine(self):
+        self.assertIn("compris is the sole owner", self.doc)
+        self.assertIn("A doctrine with two homes has no home", self.doc)
+
+    def test_the_atelier_source_pin_resolves_without_running_git(self):
+        for required in (
+            ATELIER_SOURCE_REPOSITORY,
+            ATELIER_SOURCE_PATH,
+            ATELIER_PIN_COMMIT,
+            ATELIER_PIN_RELEASE,
+            ATELIER_PIN_DATE,
+        ):
+            self.assertIn(required, self.doc)
+
+    def test_the_mental_model_standard_is_carried_intact(self):
+        self.assertIn(MENTAL_MODEL_STANDARD, self.doc)
+
+    def test_every_breakdown_rule_is_accounted_for(self):
+        for rule in BREAKDOWN_RULES:
+            self.assertIn(rule, self.doc)
+
+    def test_the_logical_to_realized_vocabulary_is_recorded(self):
+        self.assertIn("initiative", self.doc)
+        self.assertIn("changeset", self.doc)
+        self.assertIn("A leaf ticket is a child of an epic", self.doc)
+        for mapping in ("| initiative | epic |", "| changeset | pull request |"):
+            self.assertIn(mapping, self.doc)
+
+    def test_enforcement_is_policy_controlled_and_separate_from_judgment(self):
+        self.assertIn("The shaper always judges", self.doc)
+        self.assertIn(
+            "the consuming project decides whether an exceeds verdict gates",
+            self.doc,
+        )
+
+    def test_recorded_machine_generated_evidence_is_excluded_from_judgment(self):
+        self.assertIn(
+            "Recorded machine-generated evidence is excluded from shape judgment",
+            self.doc,
+        )
+        self.assertIn("eval results", self.doc)
+
+    def test_no_numeric_line_count_gate_is_presented_as_correctness_policy(self):
+        for pattern in NUMERIC_GATE_PATTERNS:
+            with self.subTest(pattern=pattern):
+                self.assertIsNone(
+                    re.search(pattern, self.doc, flags=re.IGNORECASE),
+                    f"doctrine states a numeric size gate matching {pattern!r}",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_cognitive_shaping_doctrine.py
+++ b/scripts/tests/test_cognitive_shaping_doctrine.py
@@ -17,17 +17,14 @@ from helpers import compact
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 DOCTRINE = REPOSITORY_ROOT / "docs" / "cognitive-shaping-doctrine.md"
 
-# The doctrine is compris's own. It names no upstream project, because there is
-# no external owner to attribute and an outward-facing citation would imply one.
+# The doctrine is compris's own claim. It names no upstream project, because
+# there is no external owner to attribute and a citation would imply one.
 FOREIGN_SOURCES = ("atelier",)
 
-# Fixed wording. A second wording is how two codifications start drifting,
-# which is the failure this document exists to end.
 MENTAL_MODEL_STANDARD = compact(
     """
-    Line counts may inform judgment but are not universal correctness gates.
-    The test is whether a reviewer can construct an accurate mental model of
-    the change and evaluate it independently.
+    A unit of work is correctly shaped when a reviewer can construct an
+    accurate mental model of the change and evaluate it independently.
     """
 )
 
@@ -45,7 +42,7 @@ BREAKDOWN_RULES = (
 )
 
 # Threshold constructions, not the words "line count". The doctrine has to be
-# able to say a line-count gate is refused; what it may not do is state one.
+# able to refuse a line-count gate; what it may not do is state one.
 NUMERIC_GATE_PATTERNS = (
     r"(?:at most|no more than|fewer than|under|up to|a maximum of|a limit of)"
     r"\s+[\d,]+\s+(?:new or changed |changed |added )?lines",
@@ -55,58 +52,44 @@ NUMERIC_GATE_PATTERNS = (
 )
 
 
-def normalize(markdown: str) -> str:
-    """Compact `markdown`, dropping the blockquote markers `>` introduces.
-
-    The standard is set as a blockquote, and wrapping it puts a `>` at the head
-    of every line; leaving those in would make the assertion depend on where
-    the formatter happened to break the quote.
-    """
-    return compact(re.sub(r"^\s*>\s?", "", markdown, flags=re.MULTILINE))
-
-
 class CognitiveShapingDoctrineTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.doc = normalize(DOCTRINE.read_text())
+        cls.doc = compact(DOCTRINE.read_text())
 
     def test_the_doctrine_identifies_compris_as_its_owner(self):
-        self.assertIn(
-            "This is compris's canonical statement of cognitive shaping",
-            self.doc,
-        )
+        self.assertIn("This is compris's doctrine of cognitive shaping", self.doc)
 
     def test_the_doctrine_attributes_itself_to_no_outside_project(self):
         for foreign in FOREIGN_SOURCES:
             with self.subTest(source=foreign):
                 self.assertNotIn(foreign, self.doc.lower())
 
-    def test_the_mental_model_standard_is_carried_intact(self):
+    def test_the_doctrine_states_the_mental_model_standard(self):
         self.assertIn(MENTAL_MODEL_STANDARD, self.doc)
 
     def test_every_breakdown_rule_is_accounted_for(self):
         for rule in BREAKDOWN_RULES:
-            self.assertIn(rule, self.doc)
+            with self.subTest(rule=rule):
+                self.assertIn(rule, self.doc)
 
     def test_the_logical_to_realized_vocabulary_is_recorded(self):
-        self.assertIn("initiative", self.doc)
-        self.assertIn("changeset", self.doc)
         self.assertIn("A leaf ticket is a child of an epic", self.doc)
         for mapping in ("| initiative | epic |", "| changeset | pull request |"):
-            self.assertIn(mapping, self.doc)
+            with self.subTest(mapping=mapping):
+                self.assertIn(mapping, self.doc)
 
     def test_enforcement_is_policy_controlled_and_separate_from_judgment(self):
-        self.assertIn("The shaper always judges", self.doc)
+        self.assertIn("Shape is always judged", self.doc)
         self.assertIn(
-            "the consuming project decides whether an exceeds verdict gates",
+            "Whether an oversized verdict gates anything is the consuming"
+            " project's decision",
             self.doc,
         )
 
     def test_recorded_machine_generated_evidence_is_excluded_from_judgment(self):
-        self.assertIn(
-            "Recorded machine-generated evidence is excluded from shape judgment",
-            self.doc,
-        )
+        self.assertIn("Recorded machine-generated evidence", self.doc)
+        self.assertIn("is excluded", self.doc)
         self.assertIn("eval results", self.doc)
 
     def test_no_numeric_line_count_gate_is_presented_as_correctness_policy(self):


### PR DESCRIPTION
## Summary

Adds [docs/cognitive-shaping-doctrine.md] — compris's statement of how work is
shaped: the standard, the scale it calibrates against, the eight breakdown
rules, the logical-to-realized vocabulary, and what enforcement is and is not.
Plus
[scripts/tests/test_cognitive_shaping_doctrine.py], which encodes the acceptance
criteria against the document's own normative text, and the changelog entry.

## Why

Work is broken apart by what a reviewer can understand. That claim needed one
place to live, stated plainly enough that the rest of the project can take
guidance from it.

The document is written as a claim rather than a port. It quotes no source,
records no provenance, explains no origin, and does not argue for its own
authority — 75 lines, every one of them a rule or a consequence of one.

## Non-goals, preserved

- No skill behavior changes. Binding each consumer is #187 and #188.
- No numeric line-count gate is presented as correctness policy. The document
  does carry calibration figures — one sitting, a few hundred changed lines —
  because an unanchored "can a reviewer understand it?" collapses to always-yes
  and cannot discriminate. A test matches enforcement rather than numbers: it
  rejects bounds and gate verbs, and separately requires the document to keep
  saying the figures do not decide the judgment.
- [docs/cognitive-driven-development.md] is untouched, so the paired
  Markdown/HTML rule for the design document is unaffected.

## Validation

Run at candidate `b0db4a445197760289825cc8b15e678fb2388239` against base
`fc7cf9ba04f5b4781ee3db037fed57d55c4a77be`.

| Check | Outcome |
| --- | --- |
| `python3 -m unittest discover -s scripts/tests -p 'test_cognitive_shaping_doctrine.py'` | pass, 8 tests |
| `just format && just lint && just test` | pass, exit 0 |
| Root suite `scripts/tests` | 102 tests at base → 110 at head |

The eight doctrine tests error at base (the document does not exist) and pass
at head, which is the change-demonstrating evidence.

### One discrepancy in a named verification command

The ticket names `python3 -m unittest scripts.tests.test_skill_authoring_doc -v`.
That form cannot import `scripts/tests/helpers.py`, so it errors with
`ModuleNotFoundError: No module named 'helpers'` — identically at base,
pre-existing since 5431e75, and not introduced here. The module itself passes at
this candidate under the two equivalent invocations the repository actually
uses: `PYTHONPATH=scripts/tests python3 -m unittest scripts.tests.test_skill_authoring_doc`
and `python3 -m unittest discover -s scripts/tests -p 'test_skill_authoring_doc.py'`,
3 tests OK each.

## Review

Repository-owned `review-fix-loop` under `publication.policy: local_commit`
returned `converged` bound to this head and base, with
`write_isolation: enforced`, 0 of 3 fix cycles consumed, and a `clean`
aggregate verdict from a fresh read-only `review-code-change` pass across all
three lenses.

Two `defer`-severity findings are preserved rather than implemented.

1. The Consumers section states that the doctrine governs three skills while
   those skills still read their own copy of the shaping rules. Deliberate: the
   document is a stake in the ground, and #187 and #188 make the code match it.
2. The numeric-gate regression guard is three regexes and misses some phrasings
   of the same prohibition, notably a post-positioned enforcement verb
   ("changesets over N lines are rejected"). It is a tripwire rather than a
   proof, and the separate non-binding-disclaimer assertion covers the same
   ground from the other side.

## One rule diverges from the design record, deliberately

The second breakdown rule is stated absolutely — "Never decompose to a single
child" — where [docs/cognitive-driven-development.md] still carries the earlier
hedged form, "Avoid one-child decomposition without a real reason". The design
record is not edited here; the doctrine governs.

The exemption had no case left to cover: where the work fits one ticket the
first rule already applies and no parent is created. It also had the shape
[docs/skill-authoring.md] warns against twice — a judgment-phrased condition
collapses to always or never, and an exemption clause does not scope to its
stated case. Any agent can supply a real reason, so the rule prohibited nothing.

This makes the rule cheaper to check rather than harder: count the children, and
one is wrong. The design record's shaping rubric currently expects a stated
reason to evaluate for this rule, which Spec B should drop when it builds the
shaping corpus.

Refs #186

<!-- inline reference link definitions. please keep alphabetized -->

[docs/cognitive-driven-development.md]: docs/cognitive-driven-development.md
[docs/skill-authoring.md]: docs/skill-authoring.md
[docs/cognitive-shaping-doctrine.md]: docs/cognitive-shaping-doctrine.md
[scripts/tests/test_cognitive_shaping_doctrine.py]: scripts/tests/test_cognitive_shaping_doctrine.py
