### PR TITLE
fix: make every root-suite test module import under the module-path invocation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,9 +114,33 @@ said. Neither satisfies the other.
   micro-testing, the contractual layer, peer precedence, and context economy.
   Its testing doctrine reaches further than skill authoring: it governs test
   evidence for any change to this repository's code.
+
 - Skill root contains `SKILL.md` and optional `scripts/`, `references/`, and
   `assets/`.
+
 - Tests live under `scripts/tests/` and should use `unittest`.
+
+- A test module that imports a sibling helper establishes its own `sys.path`
+  entry from `__file__`, rather than relying on the one discovery happens to
+  supply:
+
+  ```python
+  TESTS_DIR = Path(__file__).resolve().parent
+  if str(TESTS_DIR) not in sys.path:
+      sys.path.insert(0, str(TESTS_DIR))
+
+  from helpers import compact  # noqa: E402
+  ```
+
+  Without it the module imports only under `unittest discover`, and the
+  module-path form ticket bodies name as required verification —
+  `python3 -m unittest scripts.tests.test_skill_authoring_doc` — errors with
+  `ModuleNotFoundError` before any assertion runs, so a later reader cannot
+  reproduce the recorded evidence. `scripts/tests/test_suite_invocation.py`
+  holds the root suite to this; `skills/carve-changesets/scripts/tests/` and
+  `skills/review-fix-loop/scripts/tests/` do not yet carry the shim and are
+  discovery-only.
+
 - Record intermediate record-keeping data under a skill-local dot directory (for
   example, `.skill-state/` or `.<skill-name>/`) and keep it out of git history
   via a skill-local `.gitignore`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,21 @@ summary: Chronological history of repository and skill changes.
 
 # Changelog
 
-## 2026-08-11 — Gave the cognitive-shaping doctrine a single canonical home in compris, and named the tree and the model an eval summary measured
+## 2026-08-11 — Gave the cognitive-shaping doctrine a single canonical home in compris, and made recorded evidence reproducible by a later reader: named the tree and model an eval summary measured, and made the root test suite import under the invocation ticket bodies actually name
+
+- fix: make every `scripts/tests/` module import under the module-path
+  invocation, not only under discovery — each module took its sibling
+  `helpers.py` on the `sys.path` entry `unittest discover` happens to supply, so
+  `python3 -m unittest scripts.tests.test_skill_authoring_doc`, the form ticket
+  bodies keep naming as required pre-merge verification (#186 did), errored with
+  `ModuleNotFoundError: No module named 'helpers'` before any assertion ran, and
+  a later reader running the criterion verbatim could not reproduce the recorded
+  evidence. Each module now establishes its own `__file__`-relative entry, the
+  convention `review-suite/scripts/tests/` already used, and
+  `test_suite_invocation.py` holds the suite to it by importing every module
+  from the repository root with `PYTHONPATH` stripped. Pre-existing since
+  5431e75; `carve-changesets` and `review-fix-loop` carry the same defect and
+  stay discovery-only for now.
 
 - docs: publish the canonical cognitive-shaping doctrine —
   `docs/cognitive-shaping-doctrine.md` is now the one place the standard that
@@ -15,6 +29,7 @@ summary: Chronological history of repository and skill changes.
   machine-generated eval evidence from shape judgment. No numeric line-count
   gate is presented as correctness policy, and no skill behavior changes here —
   binding each consumer to it is tracked separately.
+  (5c45cd2b9b9137f985b9e5e9d343894553efc1cd)
 
 - fix: record the candidate's git tree hash and, for real-model runs, the pinned
   model name in every recorded eval summary — `candidate.sha` names a branch

--- a/scripts/tests/test_bump_version.py
+++ b/scripts/tests/test_bump_version.py
@@ -2,12 +2,17 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import sys
 import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-from helpers import REPOSITORY_ROOT, copy_fixture
+TESTS_DIR = Path(__file__).resolve().parent
+if str(TESTS_DIR) not in sys.path:
+    sys.path.insert(0, str(TESTS_DIR))
+
+from helpers import REPOSITORY_ROOT, copy_fixture  # noqa: E402
 
 
 def _load(name: str, relative: str):

--- a/scripts/tests/test_cognitive_shaping_doctrine.py
+++ b/scripts/tests/test_cognitive_shaping_doctrine.py
@@ -9,10 +9,15 @@ here rather than inside any one skill's test suite, exactly as
 from __future__ import annotations
 
 import re
+import sys
 import unittest
 from pathlib import Path
 
-from helpers import compact
+TESTS_DIR = Path(__file__).resolve().parent
+if str(TESTS_DIR) not in sys.path:
+    sys.path.insert(0, str(TESTS_DIR))
+
+from helpers import compact  # noqa: E402
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 DOCTRINE = REPOSITORY_ROOT / "docs" / "cognitive-shaping-doctrine.md"

--- a/scripts/tests/test_marketplace_positioning.py
+++ b/scripts/tests/test_marketplace_positioning.py
@@ -9,10 +9,15 @@ carries the same "outer loop" / "compose with, not depend on" positioning.
 from __future__ import annotations
 
 import json
+import sys
 import unittest
 from pathlib import Path
 
-from helpers import compact
+TESTS_DIR = Path(__file__).resolve().parent
+if str(TESTS_DIR) not in sys.path:
+    sys.path.insert(0, str(TESTS_DIR))
+
+from helpers import compact  # noqa: E402
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 README = REPOSITORY_ROOT / "README.md"

--- a/scripts/tests/test_peer_composition_readme.py
+++ b/scripts/tests/test_peer_composition_readme.py
@@ -16,10 +16,15 @@ the edit this module exists to force when that commit lands.
 from __future__ import annotations
 
 import re
+import sys
 import unittest
 from pathlib import Path
 
-from helpers import compact
+TESTS_DIR = Path(__file__).resolve().parent
+if str(TESTS_DIR) not in sys.path:
+    sys.path.insert(0, str(TESTS_DIR))
+
+from helpers import compact  # noqa: E402
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 README = REPOSITORY_ROOT / "README.md"

--- a/scripts/tests/test_release_docs.py
+++ b/scripts/tests/test_release_docs.py
@@ -7,10 +7,15 @@ and operator-only tagging authority.
 
 from __future__ import annotations
 
+import sys
 import unittest
 from pathlib import Path
 
-from helpers import compact
+TESTS_DIR = Path(__file__).resolve().parent
+if str(TESTS_DIR) not in sys.path:
+    sys.path.insert(0, str(TESTS_DIR))
+
+from helpers import compact  # noqa: E402
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 RELEASE_NOTES = REPOSITORY_ROOT / "RELEASE-NOTES.md"

--- a/scripts/tests/test_skill_authoring_doc.py
+++ b/scripts/tests/test_skill_authoring_doc.py
@@ -7,10 +7,15 @@ own tests live here rather than inside any one skill's test suite.
 
 from __future__ import annotations
 
+import sys
 import unittest
 from pathlib import Path
 
-from helpers import compact
+TESTS_DIR = Path(__file__).resolve().parent
+if str(TESTS_DIR) not in sys.path:
+    sys.path.insert(0, str(TESTS_DIR))
+
+from helpers import compact  # noqa: E402
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 AUTHORING_DOC = REPOSITORY_ROOT / "docs" / "skill-authoring.md"

--- a/scripts/tests/test_suite_invocation.py
+++ b/scripts/tests/test_suite_invocation.py
@@ -1,0 +1,61 @@
+"""Every module in this suite must import under the module-path invocation.
+
+`just test-plugins` runs this suite by discovery, which puts `scripts/tests`
+on `sys.path` and makes a bare `from helpers import ...` resolve for free. The
+module-path form does not: `python3 -m unittest scripts.tests.test_x` puts the
+repository root on `sys.path` instead, so a module relying on discovery's
+implicit path errors with `ModuleNotFoundError: No module named 'helpers'`
+before a single assertion runs.
+
+Ticket bodies name that form as required pre-merge verification, so a module
+that only imports under discovery makes recorded evidence unreproducible for
+the next reader. Each module carries the `__file__`-relative `sys.path` shim
+already used across `review-suite/scripts/tests/`; this test is what keeps a
+new module from being added without one.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+TESTS_DIR = Path(__file__).resolve().parent
+REPOSITORY_ROOT = TESTS_DIR.parents[1]
+
+
+def _dotted_names() -> list[str]:
+    return sorted(f"scripts.tests.{path.stem}" for path in TESTS_DIR.glob("test_*.py"))
+
+
+class ModulePathInvocationTests(unittest.TestCase):
+    def test_the_suite_is_non_empty(self) -> None:
+        # A glob that silently matched nothing would make every other
+        # assertion here vacuous.
+        self.assertGreater(len(_dotted_names()), 1)
+
+    def test_every_module_imports_from_the_repository_root(self) -> None:
+        # PYTHONPATH is stripped so an ambient entry cannot supply the path
+        # the module is supposed to establish for itself.
+        environment = {k: v for k, v in os.environ.items() if k != "PYTHONPATH"}
+        for dotted in _dotted_names():
+            with self.subTest(module=dotted):
+                result = subprocess.run(
+                    [sys.executable, "-c", f"import {dotted}"],
+                    cwd=REPOSITORY_ROOT,
+                    env=environment,
+                    text=True,
+                    capture_output=True,
+                )
+                self.assertEqual(
+                    result.returncode,
+                    0,
+                    f"`python3 -m unittest {dotted}` cannot import "
+                    f"{dotted.rsplit('.', 1)[1]}.py:\n{result.stderr}",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_validate_plugins.py
+++ b/scripts/tests/test_validate_plugins.py
@@ -2,11 +2,16 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import sys
 import tempfile
 import unittest
 from pathlib import Path
 
-from helpers import REPOSITORY_ROOT, copy_fixture
+TESTS_DIR = Path(__file__).resolve().parent
+if str(TESTS_DIR) not in sys.path:
+    sys.path.insert(0, str(TESTS_DIR))
+
+from helpers import REPOSITORY_ROOT, copy_fixture  # noqa: E402
 
 SPEC = importlib.util.spec_from_file_location(
     "validate_plugins", REPOSITORY_ROOT / "scripts" / "validate_plugins.py"


### PR DESCRIPTION
## Summary

Every module under `scripts/tests/` took its sibling `helpers.py` on the
`sys.path` entry `unittest discover` happens to supply. Each now establishes
its own `__file__`-relative entry instead, so both invocation forms work:

```python
TESTS_DIR = Path(__file__).resolve().parent
if str(TESTS_DIR) not in sys.path:
    sys.path.insert(0, str(TESTS_DIR))

from helpers import compact  # noqa: E402
```

[scripts/tests/test_suite_invocation.py] is the guard: it imports every
`test_*.py` in the suite from the repository root with `PYTHONPATH` stripped,
so an ambient entry cannot paper over a missing shim. [AGENTS.md] records the
convention under Skill Conventions and names the two suites that do not yet
carry it.

## Why

Ticket bodies name `python3 -m unittest scripts.tests.test_<module>` as
required pre-merge verification — [#186] did. That form puts the repository
root on `sys.path` rather than `scripts/tests`, so the bare import raised
`ModuleNotFoundError: No module named 'helpers'` before a single assertion
ran. A later reader running the criterion verbatim could not reproduce the
recorded evidence. Pre-existing since 5431e75, and filed by a reviewer on
[#208] as the deferred finding `correctness.named-verification-command-cannot-import`.

## Why the shim rather than standardizing on discovery

The alternative was to leave the imports alone and name the discovery form
everywhere instead. A survey of every test module in the repository decided
it: the defect is not specific to this suite, and the suites that *do* work
already solve it exactly this way.

| Suite | Module-path form |
| --- | --- |
| `review-suite` (8), `ledger`, `triggering`, `implement-ticket`, `implement-epic`, `babysit-pr`, `ready-ticket` | works — already carries a `__file__`-relative shim |
| `scripts/tests` (6) | `ModuleNotFoundError: 'helpers'` |
| `carve-changesets/scripts/tests` (17) | `helpers`, `legacy_helpers`, `common`, `preflight`, `db_compare` |
| `review-fix-loop/scripts/tests` (2) | `helpers` |

So this finishes an existing convention rather than introducing a new one.
Standardizing on discovery would have walked back what the majority of suites
already do, and would have left [#186]'s named command broken permanently
instead of making it run.

Two incidental findings, neither acted on here: the file-path form
(`python3 -m unittest scripts/tests/test_x.py`) fails identically, and
hyphenated directories are not an obstacle — `python3 -m unittest
review-suite.scripts.tests.test_eval_oracles` passes today, because unittest
falls back to path resolution.

## Reviewer notes

- **The guard was verified capable of failing.** Removing the shim from one
  module fails it naming that module; restoring it passes. It then caught a
  real one unprompted: [#208] landed
  [scripts/tests/test_cognitive_shaping_doctrine.py] with the same bare import
  while this branch was in flight, and rebasing onto it turned the guard red.
  That module is fixed here too.
- **No skill prose changed**, so the eval-evidence norm does not apply. I
  considered whether `ready-ticket` should stop emitting the module-path form
  and concluded it should not: its template already asks for a verified
  command, the defect was that the command was unrunnable, and the shim fixes
  that at the source.
- **Two suites are deliberately out of scope.**
  `skills/carve-changesets/scripts/tests/` (17 modules) and
  `skills/review-fix-loop/scripts/tests/` (2) carry the same defect and stay
  discovery-only; [AGENTS.md] states this rather than leaving it implied.
  Extending the shim there is the same mechanical edit, and is what would make
  the module-path form safe for a ticket to name against any suite. It would
  also pair naturally with
  [docs/superpowers/plans/2026-08-05-carve-changesets-on-gh-stack.md], which
  names 14 unrunnable commands against that suite.

## Validation

Run at `473e6de` against base `5c45cd2`.

| Check | Outcome |
| --- | --- |
| `just format && just lint && just test` | pass, exit 0 — 14 suites green |
| Root suite `scripts/tests` | 112 tests at base -> 114 at head |
| `python3 -m unittest scripts.tests.test_skill_authoring_doc -v` (the string [#186] named) | errors at base, 3 tests OK at head |

The base/head difference on that last row is the change-demonstrating
evidence.

Refs [#186]

<!-- inline reference link definitions. please keep alphabetized -->

[#186]: https://github.com/shaug/compris/issues/186
[#208]: https://github.com/shaug/compris/pull/208
[AGENTS.md]: AGENTS.md
[docs/superpowers/plans/2026-08-05-carve-changesets-on-gh-stack.md]: docs/superpowers/plans/2026-08-05-carve-changesets-on-gh-stack.md
[scripts/tests/test_cognitive_shaping_doctrine.py]: scripts/tests/test_cognitive_shaping_doctrine.py
[scripts/tests/test_suite_invocation.py]: scripts/tests/test_suite_invocation.py
