### PR TITLE
docs: decide the shaping authority mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,32 @@ summary: Chronological history of repository and skill changes.
 
 # Changelog
 
+## 2026-08-12 — Settled how the shaping doctrine gets its authority: a bundled synced contract, not a new skill
+
+- docs: decide the shaping authority mechanism — the design record told a reader
+  the cited-versus-called framing was contested and that Spec B "should not be
+  built until that alternative is argued down or adopted," which left every
+  downstream leaf waiting on a question nobody had answered. The bundled synced
+  contract is adopted: canonical doctrine text distributed by stable path and
+  mechanically drift-checked, with no new skill. The `review-suite`
+  counterexample holds and draws the line the brief missed — there, the synced
+  text carries the contract and the skills carry the verdict — so the question
+  was never which mechanism is legitimate but whether any caller has
+  demonstrated it needs a verdict, and none has. The publication size gate is
+  the strongest candidate and already runs the contract mechanism without
+  failing. The executable verdict and the fourth review lens are rejected with
+  reasons, the telemetry-first ordering is adopted alongside, Spec C's planner
+  alternative is left open, and every downstream leaf carries a disposition:
+  #190 and #191 superseded, #192 and #193 re-cut against the bundled doctrine,
+  #194 and #195 activated. The decision is reversible on the telemetry it keeps.
+  A new contract test holds all of it against both the canonical Markdown and
+  its HTML presentation copy, which is what makes their equivalence checkable.
+
 ## 2026-08-11 — Gave the cognitive-shaping doctrine a single canonical home in compris, and made recorded evidence reproducible by a later reader: named the tree and model an eval summary measured, and made the root test suite import under the invocation ticket bodies actually name
 
 - fix: make every `scripts/tests/` module import under the module-path
-  invocation, not only under discovery — each module took its sibling
+  invocation, not only under discovery
+  (e906fb92b9a2c1df56562c2b1ab71daf34063203) — each module took its sibling
   `helpers.py` on the `sys.path` entry `unittest discover` happens to supply, so
   `python3 -m unittest scripts.tests.test_skill_authoring_doc`, the form ticket
   bodies keep naming as required pre-merge verification (#186 did), errored with
@@ -20,7 +42,8 @@ summary: Chronological history of repository and skill changes.
   5431e75; `carve-changesets` and `review-fix-loop` carry the same defect and
   stay discovery-only for now.
 
-- docs: publish the canonical cognitive-shaping doctrine —
+- docs: publish the canonical cognitive-shaping doctrine
+  (5c45cd2b9b9137f985b9e5e9d343894553efc1cd) —
   `docs/cognitive-shaping-doctrine.md` is now the one place the standard that
   decides whether a unit of work is comprehensible is stated. It carries the
   mental-model test at its fixed wording, all eight breakdown rules, the

--- a/docs/cognitive-driven-development.html
+++ b/docs/cognitive-driven-development.html
@@ -368,6 +368,7 @@
   .record.open { border-left: 3px solid var(--warn); }
   .record.settled { border-left: 3px solid var(--good); }
   .record h3 { margin: 0 0 8px; font-size: 16px; }
+  .record h4 { margin: 22px 0 8px; font-size: 15px; }
   .record p { margin: 0 0 12px; font-size: 16px; }
   .record p:last-child { margin-bottom: 0; }
   .record .why {
@@ -768,6 +769,13 @@
         <code>review-code-change</code> does not implement its three lenses, it invokes them and
         reconciles typed verdicts.
       </p>
+      <div class="note">
+        <b>That framing was contested, and the contest is now settled against it.</b>
+        Cited-versus-called is a false binary, and
+        <a href="#decisions">the shaping authority decision</a> records why. The contract below is
+        preserved as the design it would take, not as work that is authorized — read it as the
+        rejected alternative's specification rather than a plan.
+      </div>
 
       <div class="contract">
         <dl>
@@ -846,8 +854,8 @@
           <p>The doctrine document at a pinned atelier commit; retire <code>carve-changesets</code>' own guardrails in its favor so it replaces a codification rather than becoming a fifth; <code>review-solution-simplicity</code> cites it; atelier points here. <strong>No new skills, no renames, no reversals</strong> — and it ends shared custody on its own.</p>
         </div></li>
         <li><div>
-          <h3>Spec B — an executable shaping verdict</h3>
-          <p>The shaping skill, its corpus, and re-split telemetry. Two callers exist on day one. Depends on A for the standard; does not depend on C. <strong>Gated</strong> on the bundled-contract alternative below.</p>
+          <h3>Spec B — the shaping authority <span class="tag later">re-cut</span></h3>
+          <p>Originally the shaping skill, its corpus, and re-split telemetry. <strong>Resolved:</strong> the executable verdict is rejected and the spec is re-cut around the bundled synced contract plus the telemetry that would later justify a verdict. What survives is the doctrine's distribution, its two consumers, and the measurement; the skill, its corpus, and its three terminal states do not. Depends on A for the standard it distributes; does not depend on C.</p>
         </div></li>
         <li><div>
           <h3>Spec C — the planner</h3>
@@ -867,16 +875,21 @@
     </section>
 
     <section id="alts">
-      <p class="kicker">Not yet ruled out</p>
+      <p class="kicker">Weighed, and three of them ruled on</p>
       <h2>Alternatives the conversation never examined</h2>
       <p>
         This shape was reached by convergence over one long conversation, which is exactly the
         condition under which unexamined alternatives survive. The first is the most serious,
         because it attacks Spec B's premise rather than varying it.
       </p>
+      <p>
+        Three of the four have since been ruled on — see
+        <a href="#decisions">the shaping authority decision</a>. They are kept here in the form
+        they were argued in, because a decision read without the case against it is an assertion.
+      </p>
 
-      <div class="record open">
-        <h3>A bundled synced contract, with no new skill</h3>
+      <div class="record settled">
+        <h3>A bundled synced contract, with no new skill — <b>adopted</b></h3>
         <p>
           This brief argues "a document gets cited; a skill gets called," and concludes only a
           skill makes doctrine enforceable. <strong>That is a false binary, and the counterexample
@@ -889,13 +902,12 @@
           <b>Trades away:</b> nothing measures whether a breakdown obeyed the doctrine, so no typed
           verdict at the size gate and no prediction-feedback loop. <b>Buys:</b> the smallest change
           that ends shared custody, on infrastructure already built and tested, with no new
-          contract, terminal states, or corpus. Spec B should not be built until this is argued
-          down or adopted.
+          contract, terminal states, or corpus.
         </p>
       </div>
 
-      <div class="record open">
-        <h3>Shape as a fourth review lens</h3>
+      <div class="record settled">
+        <h3>Shape as a fourth review lens — <b>rejected</b></h3>
         <p>
           <code>review-code-change</code> already invokes three read-only lenses against a shared
           schema. A shape lens inherits the packet, the result contract, the validator, and the
@@ -910,7 +922,7 @@
       </div>
 
       <div class="record open">
-        <h3>Build only the missing edge</h3>
+        <h3>Build only the missing edge — <b>still open</b></h3>
         <p>
           Keep <code>ready-ticket</code> under its name and per-item authority, and build the one
           thing it cannot do: turning <code>decomposition_recommended</code> into a parent plus
@@ -925,8 +937,8 @@
         </p>
       </div>
 
-      <div class="record open">
-        <h3>An ordering variant: telemetry first</h3>
+      <div class="record settled">
+        <h3>An ordering variant: telemetry first — <b>adopted</b></h3>
         <p>
           The brief calls re-split telemetry "the real measure," and it appears nowhere in the
           program. Shipping it first — leaf tickets record a predicted shape, which
@@ -941,6 +953,132 @@
     <section id="decisions">
       <p class="kicker">Settled, with reasons</p>
       <h2>Decisions on record</h2>
+
+      <div class="record settled">
+        <h3>The shaping authority is a bundled synced contract, not a new skill</h3>
+        <p>
+          The selected mechanism is the bundled synced contract: canonical doctrine text,
+          distributed by stable path and mechanically drift-checked, with no new skill.
+        </p>
+        <p>
+          The text already exists — <code>cognitive-shaping-doctrine.md</code> is compris's
+          statement of the standard, and Spec A shipped it. What is missing is only its
+          <em>distribution</em>: nothing bundles it into a consumer and nothing drift-checks it, so
+          no skill loads it today. That gap, not a new contract shape, is what Spec B now closes.
+        </p>
+        <p>
+          <b>The counterexample holds.</b> <code>review-suite/</code> distributes canonical
+          normative text that <code>just sync-contracts</code> bundles verbatim into each consumer
+          and <code>just check-installed</code> drift-checks, with no skill involved. Three skills
+          consume it that way today. So <em>a document gets cited; a skill gets called</em> is a
+          false binary, and the mechanism that refutes it has been running in this tree the whole
+          time.
+        </p>
+        <p>
+          It also draws the line the brief needed. In <code>review-suite/</code> the synced text
+          carries the contract and the skills carry the verdict. Each mechanism is doing what the
+          other cannot, which means the question was never which one is legitimate. It is whether
+          any caller has demonstrated it needs a verdict rather than a contract.
+        </p>
+        <p>
+          <b>None has, and the strongest candidate is evidence against.</b> The publication size
+          gate already runs the contract mechanism: it loads <code>carve-changesets</code> by
+          stable name, reads its live guardrails, and is forbidden to substitute local heuristics.
+          That is text loaded by stable name and judged in place, and it has not failed. It has
+          also barely been asked — <code>carve-changesets</code> has never carved anything here —
+          but an unexercised mechanism is a reason to measure it, not a reason to replace it with a
+          larger one.
+        </p>
+        <p>
+          That reading is the brief's own. It concedes the program is capability-driven rather than
+          failure-driven, against the authoring standard's requirement that a change trace to an
+          observed failure. A synced contract is the smallest mechanism that satisfies the
+          capability; a skill, a contract, three terminal states, a trap-based corpus and a judge
+          panel is the largest.
+        </p>
+        <ul>
+          <li>
+            <b>Rejected: an executable shaping verdict.</b> No caller has demonstrated it needs a
+            verdict rather than a contract. Its distinctive value — a typed judgment and the
+            prediction-feedback loop — is real but unmeasurable until something records predictions
+            to compare against, which is the ordering problem below rather than an argument for
+            building it first.
+          </li>
+          <li>
+            <b>Rejected: shape as a fourth review lens.</b> It answers a question no caller is
+            asking, at the one moment the answer cannot be acted on. Lenses run on a committed
+            candidate, so a lens reports that a merged-shaped change was badly shaped after the
+            shaping is spent. It would also inherit <code>review-code-change</code>'s aggregate
+            verdict, making shape a review blocker in a repository that has deliberately declined
+            shape gating.
+          </li>
+          <li>
+            <b>Not ruled on: build only the missing edge.</b> It varies Spec C's planner rather
+            than Spec B's authority, and Spec C stays independent of this decision. Deciding it
+            here would settle a planner question under a mechanism ticket.
+          </li>
+          <li>
+            <b>Adopted alongside: the telemetry-first ordering.</b> It is the instrument that would
+            make a later executable verdict an evidence-driven choice rather than a second
+            convergence. It is buildable today against <code>git log</code> with zero prose
+            changes, and it already earned its keep once: the retrospective pass caught the
+            eval-results distortion on first contact.
+          </li>
+        </ul>
+        <p class="why">
+          <b>This decision is reversible on evidence rather than on argument.</b> The executable
+          verdict is rejected as unjustified now, not as wrong. The telemetry this spec keeps is
+          what would justify it: once predicted shape and actual outcome are recorded against named
+          re-split triggers, the question stops being which mechanism sounds enforceable and
+          becomes whether the contract mechanism's predictions held. Re-open it on that data.
+        </p>
+
+        <h4>Downstream disposition</h4>
+        <p>
+          Every Spec B leaf, and what to do with it. Executing these is caller-owned work that
+          follows this record; nothing here mutates the graph.
+        </p>
+        <div class="tablewrap">
+          <table>
+            <thead>
+              <tr><th>Leaf</th><th>Disposition</th></tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>#190 — seam-based shaping corpus and evaluator</td>
+                <td><b>superseded</b> — it is the executable verdict's evaluation surface. Re-cut as the retrospective merged-history corpus, which grades shipped shape rather than a skill</td>
+              </tr>
+              <tr>
+                <td>#191 — the typed, read-only shaping skill</td>
+                <td><b>superseded</b> — closed with no replacement. This is the leaf the decision rejects outright</td>
+              </tr>
+              <tr>
+                <td>#192 — <code>carve-changesets</code> shape delegation</td>
+                <td><b>re-cut</b> — retire its cognitive-load guardrails and decomposition-order sections in favor of the bundled doctrine, consumed by stable path rather than invoked</td>
+              </tr>
+              <tr>
+                <td>#193 — <code>implement-ticket</code> publication-size gate</td>
+                <td><b>re-cut</b> — read the bundled doctrine by stable path instead of <code>carve-changesets</code>' live guardrails. The gate keeps classifying; no typed verdict arrives</td>
+              </tr>
+              <tr>
+                <td>#194 — predicted shape and actual outcome</td>
+                <td><b>activated</b> — unchanged in substance, and its blocker on #193 drops, since it no longer waits on a verdict contract</td>
+              </tr>
+              <tr>
+                <td>#195 — reviewability and operator-effort telemetry</td>
+                <td><b>activated</b> — unchanged, still following #194</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="why">
+          The stable contract every activated and re-cut leaf builds against is
+          <code>docs/cognitive-shaping-doctrine.md</code>, and its stable distribution is
+          <code>just sync-contracts</code> with <code>just check-installed</code> as the drift
+          check — the same pair <code>review-suite/</code> already uses. One leaf has to be cut for
+          that distribution itself, since it does not exist yet and #192 and #193 both depend on it.
+        </p>
+      </div>
 
       <div class="record settled">
         <h3><code>plan-implementation</code> consumes an approved design; it does not produce one</h3>

--- a/docs/cognitive-driven-development.html
+++ b/docs/cognitive-driven-development.html
@@ -499,7 +499,7 @@
       <li><a href="#custody">Ending shared custody</a></li>
       <li><a href="#shaper">The shaping skill</a></li>
       <li><a href="#program">Four specs</a></li>
-      <li><a href="#alts">Alternatives open</a></li>
+      <li><a href="#alts">Alternatives weighed</a></li>
       <li><a href="#decisions">Decisions on record</a></li>
       <li><a href="#status">What the evidence shows</a></li>
       <li><a href="#evidence">Verified evidence</a></li>
@@ -969,10 +969,10 @@
         <p>
           <b>The counterexample holds.</b> <code>review-suite/</code> distributes canonical
           normative text that <code>just sync-contracts</code> bundles verbatim into each consumer
-          and <code>just check-installed</code> drift-checks, with no skill involved. Three skills
-          consume it that way today. So <em>a document gets cited; a skill gets called</em> is a
-          false binary, and the mechanism that refutes it has been running in this tree the whole
-          time.
+          and a bundled-contract test drift-checks under <code>just test</code>, with no skill
+          involved. Three skills consume it that way today. So <em>a document gets cited; a skill
+          gets called</em> is a false binary, and the mechanism that refutes it has been running in
+          this tree the whole time.
         </p>
         <p>
           It also draws the line the brief needed. In <code>review-suite/</code> the synced text
@@ -1074,9 +1074,14 @@
         <p class="why">
           The stable contract every activated and re-cut leaf builds against is
           <code>docs/cognitive-shaping-doctrine.md</code>, and its stable distribution is
-          <code>just sync-contracts</code> with <code>just check-installed</code> as the drift
-          check — the same pair <code>review-suite/</code> already uses. One leaf has to be cut for
-          that distribution itself, since it does not exist yet and #192 and #193 both depend on it.
+          <code>just sync-contracts</code> with a bundled-contract test under
+          <code>just test</code> as the drift gate — the same pair <code>review-suite/</code>
+          already uses. Take that pairing literally: <code>just check-installed</code> compares the
+          separately <em>installed</em> snapshot under <code>~/.agents/skills</code> and is
+          deliberately excluded from <code>lint</code> and <code>check</code>, so it is a useful
+          operator check but cannot be the gate a downstream leaf relies on. One leaf has to be cut
+          for that distribution itself, since it does not exist yet and #192 and #193 both depend
+          on it.
         </p>
       </div>
 

--- a/docs/cognitive-driven-development.md
+++ b/docs/cognitive-driven-development.md
@@ -8,9 +8,9 @@ Nothing described here is built. This document records the direction, the
 decisions behind it, the evidence they rest on, the four specs it decomposes
 into, the alternatives weighed against them, and the one experiment still owed.
 
-This Markdown is canonical for review. [`cognitive-driven-development.html`] is
-a presentation copy of the same content, committed alongside it. When one
-changes, change both.
+This Markdown is canonical for review. [cognitive-driven-development.html] is a
+presentation copy of the same content, committed alongside it. When one changes,
+change both.
 
 ## The practice
 
@@ -383,8 +383,8 @@ justified by *before* the program is built.
 The selected mechanism is the bundled synced contract: canonical doctrine text,
 distributed by stable path and mechanically drift-checked, with no new skill.
 
-The text already exists. [`cognitive-shaping-doctrine.md`] is compris's
-statement of the standard, and Spec A shipped it. What is missing is only its
+The text already exists. [cognitive-shaping-doctrine.md] is compris's statement
+of the standard, and Spec A shipped it. What is missing is only its
 *distribution* — nothing bundles it into a consumer and nothing drift-checks it,
 so no skill loads it today. That gap, not a new contract shape, is what Spec B
 now closes.
@@ -721,7 +721,7 @@ surface-observable contract.
 
 <!-- inline reference link definitions. please keep alphabetized -->
 
+[cognitive-driven-development.html]: cognitive-driven-development.html
+[cognitive-shaping-doctrine.md]: cognitive-shaping-doctrine.md
 [the shaping authority decision]: #the-shaping-authority-is-a-bundled-synced-contract-not-a-new-skill
 [the shaping authority is a bundled synced contract, not a new skill]: #the-shaping-authority-is-a-bundled-synced-contract-not-a-new-skill
-[`cognitive-driven-development.html`]: cognitive-driven-development.html
-[`cognitive-shaping-doctrine.md`]: cognitive-shaping-doctrine.md

--- a/docs/cognitive-driven-development.md
+++ b/docs/cognitive-driven-development.md
@@ -6,12 +6,11 @@ together with the vocabulary that carries it and the skill that enforces it.
 
 Nothing described here is built. This document records the direction, the
 decisions behind it, the evidence they rest on, the four specs it decomposes
-into, the alternatives not yet ruled out, and the one experiment still owed.
+into, the alternatives weighed against them, and the one experiment still owed.
 
-This Markdown is canonical for review.
-[`cognitive-driven-development.html`](cognitive-driven-development.html) is a
-presentation copy of the same content, committed alongside it. When one changes,
-change both.
+This Markdown is canonical for review. [`cognitive-driven-development.html`] is
+a presentation copy of the same content, committed alongside it. When one
+changes, change both.
 
 ## The practice
 
@@ -207,11 +206,12 @@ makes the doctrine enforceable rather than aspirational, and compris has the
 exact precedent — `review-code-change` does not implement its three lenses, it
 invokes them and reconciles typed verdicts.
 
-**That framing is contested, and the contest is unresolved.**
-Cited-versus-called is a false binary: `review-suite/` distributes canonical
-normative text by mechanical sync and drift check, with no skill involved. See
-[Alternatives not yet ruled out](#alternatives-not-yet-ruled-out). Spec B should
-not be built until that alternative is argued down or adopted.
+**That framing was contested, and the contest is now settled against it.**
+Cited-versus-called is a false binary, and
+[the shaping authority is a bundled synced contract, not a new skill] records
+why. The contract below is preserved as the design it would take, not as work
+that is authorized; read it as the rejected alternative's specification rather
+than a plan.
 
 | Facet               | Contract                                                                                                                                                                                                                                                  |
 | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -273,14 +273,17 @@ it; atelier drops its section and points here.
 actually ends shared custody, and it is complete on its own. Ships on
 infrastructure that already exists.
 
-### Spec B — an executable shaping verdict
+### Spec B — the shaping authority
 
-The shaping skill and its contract, the shaping corpus, and the re-split
-telemetry. Two real callers exist on day one: `carve-changesets`, and
-`implement-ticket`'s size gate, which already loads a shape authority by stable
-name and is forbidden to substitute local heuristics.
+Originally *an executable shaping verdict*: the shaping skill and its contract,
+the shaping corpus, and the re-split telemetry.
 
-*Depends on A for the standard it enforces.* Does not depend on C.
+*Resolved.* The executable verdict is rejected and the spec is re-cut around the
+bundled synced contract plus the telemetry that would later justify a verdict.
+What survives is the doctrine's distribution, its two consumers, and the
+measurement; the skill, its corpus, and its three terminal states do not.
+
+*Depends on A for the standard it distributes.* Does not depend on C.
 
 ### Spec C — the planner
 
@@ -311,14 +314,18 @@ becomes `plan-implementation` under Spec C. `implement-ticket` does not mislead;
 it really does take one ticket, and `implement-epic` keeps a noun users say out
 loud. A big-bang rename buys nothing and costs routing.
 
-## Alternatives not yet ruled out
+## Alternatives the conversation never examined
 
 The shape above was reached by convergence over one long conversation, which is
 exactly the condition under which unexamined alternatives survive. Three were
 never put on the table. The first is the most serious, because it attacks Spec
 B's premise rather than offering a variation on it.
 
-### A bundled synced contract, with no new skill
+Three of the four have since been ruled on — see
+[the shaping authority decision]. They are kept here in the form they were
+argued in, because a decision read without the case against it is an assertion.
+
+### A bundled synced contract, with no new skill — **adopted**
 
 This brief argues that "a document gets cited; a skill gets called," and
 concludes that only a skill makes the doctrine enforceable. **That is a false
@@ -335,7 +342,7 @@ corpus.
 *Trades away:* nothing measures whether a given breakdown obeyed the doctrine,
 so there is no typed verdict at the size gate and no prediction-feedback loop.
 
-### Shape as a fourth review lens
+### Shape as a fourth review lens — **rejected**
 
 `review-code-change` already invokes three read-only lenses and reconciles typed
 verdicts against a shared schema. A shape lens would inherit the shared packet,
@@ -347,7 +354,7 @@ decompositions, so this cannot serve plan-time input. It covers two of the three
 named callers, which isolates the real question — whether the third caller alone
 justifies a new contract shape, three terminal states, and a new corpus.
 
-### Build only the missing edge
+### Build only the missing edge — **still open**
 
 Keep `ready-ticket` under its name and its per-item authority, and build the one
 thing it demonstrably cannot do: turning `decomposition_recommended` into a
@@ -360,7 +367,7 @@ Spec C bundles — is the value in the *graph output* or in the *breakdown
 method*? This delivers the first without buying the second, and the answer says
 whether Spec C needs to exist as written.
 
-### An ordering variant worth naming
+### An ordering variant worth naming — **adopted**
 
 This brief calls re-split telemetry "the real measure," and it appears nowhere
 in the program. Shipping it first — leaf tickets record a predicted shape, which
@@ -370,6 +377,91 @@ with zero prose changes, would produce the labeled data this whole program is
 justified by *before* the program is built.
 
 ## Decisions on record
+
+### The shaping authority is a bundled synced contract, not a new skill
+
+The selected mechanism is the bundled synced contract: canonical doctrine text,
+distributed by stable path and mechanically drift-checked, with no new skill.
+
+The text already exists. [`cognitive-shaping-doctrine.md`] is compris's
+statement of the standard, and Spec A shipped it. What is missing is only its
+*distribution* — nothing bundles it into a consumer and nothing drift-checks it,
+so no skill loads it today. That gap, not a new contract shape, is what Spec B
+now closes.
+
+**The counterexample holds.** `review-suite/` distributes canonical normative
+text that `just sync-contracts` bundles verbatim into each consumer and
+`just check-installed` drift-checks, with no skill involved. Three skills
+consume it that way today. So *a document gets cited; a skill gets called* is a
+false binary, and the mechanism that refutes it has been running in this tree
+the whole time.
+
+It also draws the line the brief needed. In `review-suite/` the synced text
+carries the contract and the skills carry the verdict. Each mechanism is doing
+what the other cannot, which means the question was never which one is
+legitimate. It is whether any caller has demonstrated it needs a verdict rather
+than a contract.
+
+**None has, and the strongest candidate is evidence against.** The publication
+size gate already runs the contract mechanism: it loads `carve-changesets` by
+stable name, reads its live guardrails, and is forbidden to substitute local
+heuristics. That is text loaded by stable name and judged in place, and it has
+not failed. It has also barely been asked — `carve-changesets` has never carved
+anything here — but an unexercised mechanism is a reason to measure it, not a
+reason to replace it with a larger one.
+
+That reading is the brief's own. It concedes the program is capability-driven
+rather than failure-driven, against `docs/skill-authoring.md:24`'s requirement
+that a change trace to an observed failure. A synced contract is the smallest
+mechanism that satisfies the capability; a skill, a contract, three terminal
+states, a trap-based corpus and a judge panel is the largest.
+
+- **Rejected: an executable shaping verdict.** No caller has demonstrated it
+  needs a verdict rather than a contract. Its distinctive value — a typed
+  judgment and the prediction-feedback loop — is real but unmeasurable until
+  something records predictions to compare against, which is the ordering
+  problem below rather than an argument for building it first.
+- **Rejected: shape as a fourth review lens.** It answers a question no caller
+  is asking, at the one moment the answer cannot be acted on. Lenses run on a
+  committed candidate, so a lens reports that a merged-shaped change was badly
+  shaped after the shaping is spent. It would also inherit
+  `review-code-change`'s aggregate verdict, making shape a review blocker in a
+  repository that has deliberately declined shape gating.
+- **Not ruled on: build only the missing edge.** It varies Spec C's planner
+  rather than Spec B's authority, and Spec C stays independent of this decision.
+  Deciding it here would settle a planner question under a mechanism ticket.
+- **Adopted alongside: the telemetry-first ordering.** It is the instrument that
+  would make a later executable verdict an evidence-driven choice rather than a
+  second convergence. It is buildable today against `git log` with zero prose
+  changes, and it already earned its keep once: the retrospective pass caught
+  the eval-results distortion on first contact.
+
+**This decision is reversible on evidence rather than on argument.** The
+executable verdict is rejected as unjustified now, not as wrong. The telemetry
+this spec keeps is what would justify it: once predicted shape and actual
+outcome are recorded against named re-split triggers, the question stops being
+which mechanism sounds enforceable and becomes whether the contract mechanism's
+predictions held. Re-open it on that data.
+
+#### Downstream disposition
+
+Every Spec B leaf, and what to do with it. Executing these is caller-owned work
+that follows this record; nothing here mutates the graph.
+
+| Leaf                                               | Disposition                                                                                                                                                           |
+| -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| #190 — seam-based shaping corpus and evaluator     | **superseded** — it is the executable verdict's evaluation surface. Re-cut as the retrospective merged-history corpus, which grades shipped shape rather than a skill |
+| #191 — the typed, read-only shaping skill          | **superseded** — closed with no replacement. This is the leaf the decision rejects outright                                                                           |
+| #192 — `carve-changesets` shape delegation         | **re-cut** — retire its cognitive-load guardrails and decomposition-order sections in favor of the bundled doctrine, consumed by stable path rather than invoked      |
+| #193 — `implement-ticket` publication-size gate    | **re-cut** — read the bundled doctrine by stable path instead of `carve-changesets`' live guardrails. The gate keeps classifying; no typed verdict arrives            |
+| #194 — predicted shape and actual outcome          | **activated** — unchanged in substance, and its blocker on #193 drops, since it no longer waits on a verdict contract                                                 |
+| #195 — reviewability and operator-effort telemetry | **activated** — unchanged, still following #194                                                                                                                       |
+
+The stable contract every activated and re-cut leaf builds against is
+`docs/cognitive-shaping-doctrine.md`, and its stable distribution is
+`just sync-contracts` with `just check-installed` as the drift check — the same
+pair `review-suite/` already uses. One leaf has to be cut for that distribution
+itself, since it does not exist yet and #192 and #193 both depend on it.
 
 ### `plan-implementation` consumes an approved design; it does not produce one
 
@@ -622,3 +714,10 @@ surface-observable contract.
   house step. Preserves the binding; a translation step can lose or invent.
 - _Structure only_ — take the file map, task boundaries and sequencing; compris
   owns everything test-shaped. Cleanest boundary, least peer value.
+
+<!-- inline reference link definitions. please keep alphabetized -->
+
+[the shaping authority decision]: #the-shaping-authority-is-a-bundled-synced-contract-not-a-new-skill
+[the shaping authority is a bundled synced contract, not a new skill]: #the-shaping-authority-is-a-bundled-synced-contract-not-a-new-skill
+[`cognitive-driven-development.html`]: cognitive-driven-development.html
+[`cognitive-shaping-doctrine.md`]: cognitive-shaping-doctrine.md

--- a/docs/cognitive-driven-development.md
+++ b/docs/cognitive-driven-development.md
@@ -390,11 +390,11 @@ so no skill loads it today. That gap, not a new contract shape, is what Spec B
 now closes.
 
 **The counterexample holds.** `review-suite/` distributes canonical normative
-text that `just sync-contracts` bundles verbatim into each consumer and
-`just check-installed` drift-checks, with no skill involved. Three skills
-consume it that way today. So *a document gets cited; a skill gets called* is a
-false binary, and the mechanism that refutes it has been running in this tree
-the whole time.
+text that `just sync-contracts` bundles verbatim into each consumer and a
+bundled-contract test drift-checks under `just test`, with no skill involved.
+Three skills consume it that way today. So *a document gets cited; a skill gets
+called* is a false binary, and the mechanism that refutes it has been running in
+this tree the whole time.
 
 It also draws the line the brief needed. In `review-suite/` the synced text
 carries the contract and the skills carry the verdict. Each mechanism is doing
@@ -459,9 +459,13 @@ that follows this record; nothing here mutates the graph.
 
 The stable contract every activated and re-cut leaf builds against is
 `docs/cognitive-shaping-doctrine.md`, and its stable distribution is
-`just sync-contracts` with `just check-installed` as the drift check — the same
-pair `review-suite/` already uses. One leaf has to be cut for that distribution
-itself, since it does not exist yet and #192 and #193 both depend on it.
+`just sync-contracts` with a bundled-contract test under `just test` as the
+drift gate — the same pair `review-suite/` already uses. Take that pairing
+literally: `just check-installed` compares the separately *installed* snapshot
+under `~/.agents/skills` and is deliberately excluded from `lint` and `check`,
+so it is a useful operator check but cannot be the gate a downstream leaf relies
+on. One leaf has to be cut for that distribution itself, since it does not exist
+yet and #192 and #193 both depend on it.
 
 ### `plan-implementation` consumes an approved design; it does not produce one
 

--- a/scripts/tests/test_cognitive_driven_development_doc.py
+++ b/scripts/tests/test_cognitive_driven_development_doc.py
@@ -125,27 +125,24 @@ REVERSIBILITY = compact(
     """
 )
 
-# Every downstream Spec B leaf, and the disposition it carries. `superseded`
-# and `re-cut` and `activated` are the closed vocabulary; a leaf missing from
-# this table is a leaf whose owner cannot tell whether to build it.
-DOWNSTREAM_DISPOSITIONS = {
-    "#190": "superseded",
-    "#191": "superseded",
-    "#192": "re-cut",
-    "#193": "re-cut",
-    "#194": "activated",
-    "#195": "activated",
-}
+# Every downstream Spec B leaf, named together with the disposition it carries.
+# `superseded`, `re-cut` and `activated` are the closed vocabulary; a leaf
+# missing from this table is a leaf whose owner cannot tell whether to build it.
+# Each phrase pairs the leaf with its verdict, so adjacency is asserted rather
+# than inferred — a bare leaf number would not do, since #192, #193 and #194 are
+# each mentioned again outside the table.
+DOWNSTREAM_DISPOSITIONS = (
+    "#190 — seam-based shaping corpus and evaluator superseded",
+    "#191 — the typed, read-only shaping skill superseded",
+    "#192 — carve-changesets shape delegation re-cut",
+    "#193 — implement-ticket publication-size gate re-cut",
+    "#194 — predicted shape and actual outcome activated",
+    "#195 — reviewability and operator-effort telemetry activated",
+)
 
 # The stable name the activated and re-cut work builds against. Without it the
 # disposition says what to do and not what to do it against.
 STABLE_CONTRACT_NAME = "docs/cognitive-shaping-doctrine.md"
-
-# A disposition belongs to the leaf it sits beside, so it is searched for in a
-# window narrower than one entry. Every disposition lands within about fifty
-# characters of its leaf, and no entry is anywhere near this short, so the
-# window cannot reach a neighbour's verdict.
-ENTRY_WINDOW = 100
 
 
 def strip_html(markup: str) -> str:
@@ -214,17 +211,9 @@ class ShapingAuthorityDecisionTests(unittest.TestCase):
         self.assert_in_both(REVERSIBILITY)
 
     def test_every_downstream_leaf_carries_a_disposition(self):
-        for leaf, disposition in DOWNSTREAM_DISPOSITIONS.items():
-            for copy_name, text in self.copies.items():
-                with self.subTest(copy=copy_name, leaf=leaf):
-                    start = text.find(leaf)
-                    self.assertNotEqual(start, -1, f"{leaf} is never mentioned")
-                    entry = text[start : start + ENTRY_WINDOW]
-                    self.assertIn(
-                        disposition,
-                        entry,
-                        f"{leaf} carries no {disposition!r} disposition",
-                    )
+        for disposition in DOWNSTREAM_DISPOSITIONS:
+            with self.subTest(leaf=disposition[:4]):
+                self.assert_in_both(disposition)
 
     def test_the_activated_work_names_its_stable_contract(self):
         self.assert_in_both(STABLE_CONTRACT_NAME)

--- a/scripts/tests/test_cognitive_driven_development_doc.py
+++ b/scripts/tests/test_cognitive_driven_development_doc.py
@@ -1,0 +1,226 @@
+"""Contract invariants for the shaping-authority decision in the design record.
+
+`docs/cognitive-driven-development.md` left the shaping authority's mechanism
+contested and told the reader Spec B "should not be built until that
+alternative is argued down or adopted." These tests hold the recorded decision
+that closes it: one selected mechanism, a stated reason for every rejected
+alternative, an explicit answer to the `review-suite` sync/drift counterexample,
+and a disposition for every downstream leaf.
+
+The Markdown is canonical and the HTML is a presentation copy of the same
+content, so every load-bearing claim is asserted against **both**. That is what
+makes their equivalence checkable: the two files are worded and structured
+differently by design, so only the stable claims can be compared, and those are
+exactly the ones a reader would be misled by if they drifted.
+
+Repository-wide rather than skill-scoped, so these live here alongside
+`test_cognitive_shaping_doctrine.py` rather than inside any one skill.
+"""
+
+from __future__ import annotations
+
+import html as html_module
+import re
+import sys
+import unittest
+from pathlib import Path
+
+TESTS_DIR = Path(__file__).resolve().parent
+if str(TESTS_DIR) not in sys.path:
+    sys.path.insert(0, str(TESTS_DIR))
+
+from helpers import compact  # noqa: E402
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+DESIGN_MARKDOWN = REPOSITORY_ROOT / "docs" / "cognitive-driven-development.md"
+DESIGN_HTML = REPOSITORY_ROOT / "docs" / "cognitive-driven-development.html"
+
+# The wording that told a reader the mechanism was still open. Its absence is
+# what "no longer unresolved" means; leaving it in place beside a recorded
+# decision would leave the document contradicting itself. Matched in lower case
+# because the two copies carry these phrases in headings, kickers and prose.
+UNRESOLVED_MARKERS = (
+    "the contest is unresolved",
+    "should not be built until",
+    "not yet ruled out",
+    "gated on the bundled-contract alternative",
+)
+
+# Exactly one mechanism is selected, and it is named in one sentence rather
+# than left for a reader to infer from tone.
+SELECTED_MECHANISM = compact(
+    """
+    The selected mechanism is the bundled synced contract: canonical doctrine
+    text, distributed by stable path and mechanically drift-checked, with no new
+    skill.
+    """
+)
+
+# Every alternative the design left live, and the evidence-based reason it was
+# rejected or adopted. A decision that names its choice without disposing of
+# the alternatives is a preference, not a decision.
+ALTERNATIVE_DISPOSITIONS = (
+    compact(
+        """
+        Rejected: an executable shaping verdict. No caller has demonstrated it
+        needs a verdict rather than a contract.
+        """
+    ),
+    compact(
+        """
+        Rejected: shape as a fourth review lens. It answers a question no caller
+        is asking, at the one moment the answer cannot be acted on.
+        """
+    ),
+    compact(
+        """
+        Not ruled on: build only the missing edge. It varies Spec C's planner
+        rather than Spec B's authority, and Spec C stays independent of this
+        decision.
+        """
+    ),
+    compact(
+        """
+        Adopted alongside: the telemetry-first ordering. It is the instrument
+        that would make a later executable verdict an evidence-driven choice
+        rather than a second convergence.
+        """
+    ),
+)
+
+# The counterexample the ticket requires an explicit answer to. Both halves
+# matter: that the mechanism is real, and what it demarcates. Written without
+# code markup, since both copies have theirs stripped before comparison.
+COUNTEREXAMPLE_CLAIMS = (
+    compact(
+        """
+        The counterexample holds. review-suite/ distributes canonical normative
+        text that just sync-contracts bundles verbatim into each consumer and
+        just check-installed drift-checks, with no skill involved.
+        """
+    ),
+    compact(
+        """
+        In review-suite/ the synced text carries the contract and the skills
+        carry the verdict.
+        """
+    ),
+)
+
+# The evidence that decides it, and the one thing that keeps this decision
+# reversible rather than final.
+DECIDING_EVIDENCE = compact(
+    """
+    The publication size gate already runs the contract mechanism: it loads
+    carve-changesets by stable name, reads its live guardrails, and is
+    forbidden to substitute local heuristics. That is text loaded by stable
+    name and judged in place, and it has not failed.
+    """
+)
+
+REVERSIBILITY = compact(
+    """
+    This decision is reversible on evidence rather than on argument.
+    """
+)
+
+# Every downstream Spec B leaf, and the disposition it carries. `superseded`
+# and `re-cut` and `activated` are the closed vocabulary; a leaf missing from
+# this table is a leaf whose owner cannot tell whether to build it.
+DOWNSTREAM_DISPOSITIONS = {
+    "#190": "superseded",
+    "#191": "superseded",
+    "#192": "re-cut",
+    "#193": "re-cut",
+    "#194": "activated",
+    "#195": "activated",
+}
+
+# The stable name the activated and re-cut work builds against. Without it the
+# disposition says what to do and not what to do it against.
+STABLE_CONTRACT_NAME = "docs/cognitive-shaping-doctrine.md"
+
+# A disposition belongs to the leaf it sits beside, so it is searched for in a
+# window narrower than one entry. Every disposition lands within about fifty
+# characters of its leaf, and no entry is anywhere near this short, so the
+# window cannot reach a neighbour's verdict.
+ENTRY_WINDOW = 100
+
+
+def strip_html(markup: str) -> str:
+    """Reduce the presentation copy to the prose a reader actually sees."""
+    without_style = re.sub(
+        r"<style\b.*?</style>", " ", markup, flags=re.DOTALL | re.IGNORECASE
+    )
+    without_comments = re.sub(r"<!--.*?-->", " ", without_style, flags=re.DOTALL)
+    return html_module.unescape(re.sub(r"<[^>]+>", " ", without_comments))
+
+
+def strip_markdown(source: str) -> str:
+    """Reduce the canonical copy to the same prose, dropping its own markup.
+
+    Emphasis and table pipes are Markdown's counterpart of the tags stripped
+    from the presentation copy. Removing both is what lets one claim be
+    asserted against two files that are deliberately formatted differently.
+    """
+    without_emphasis = re.sub(r"\*{1,2}|`", "", source)
+    return without_emphasis.replace("|", " ")
+
+
+class ShapingAuthorityDecisionTests(unittest.TestCase):
+    """Assert the decision against both copies, one claim at a time."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.copies = {
+            "markdown": compact(strip_markdown(DESIGN_MARKDOWN.read_text())),
+            "html": compact(strip_html(DESIGN_HTML.read_text())),
+        }
+
+    def assert_in_both(self, claim: str):
+        for copy_name, text in self.copies.items():
+            with self.subTest(copy=copy_name):
+                self.assertIn(claim, text)
+
+    def test_the_mechanism_is_no_longer_presented_as_unresolved(self):
+        for marker in UNRESOLVED_MARKERS:
+            for copy_name, text in self.copies.items():
+                with self.subTest(copy=copy_name, marker=marker):
+                    self.assertNotIn(marker, text.lower())
+
+    def test_one_selected_mechanism_is_named(self):
+        self.assert_in_both(SELECTED_MECHANISM)
+
+    def test_every_live_alternative_is_disposed_of_with_a_reason(self):
+        for disposition in ALTERNATIVE_DISPOSITIONS:
+            with self.subTest(disposition=disposition[:48]):
+                self.assert_in_both(disposition)
+
+    def test_the_review_suite_counterexample_is_answered_explicitly(self):
+        for claim in COUNTEREXAMPLE_CLAIMS:
+            with self.subTest(claim=claim[:48]):
+                self.assert_in_both(claim)
+
+    def test_the_deciding_evidence_and_its_reversibility_are_recorded(self):
+        self.assert_in_both(DECIDING_EVIDENCE)
+        self.assert_in_both(REVERSIBILITY)
+
+    def test_every_downstream_leaf_carries_a_disposition(self):
+        for leaf, disposition in DOWNSTREAM_DISPOSITIONS.items():
+            for copy_name, text in self.copies.items():
+                with self.subTest(copy=copy_name, leaf=leaf):
+                    start = text.find(leaf)
+                    self.assertNotEqual(start, -1, f"{leaf} is never mentioned")
+                    entry = text[start : start + ENTRY_WINDOW]
+                    self.assertIn(
+                        disposition,
+                        entry,
+                        f"{leaf} carries no {disposition!r} disposition",
+                    )
+
+    def test_the_activated_work_names_its_stable_contract(self):
+        self.assert_in_both(STABLE_CONTRACT_NAME)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_cognitive_driven_development_doc.py
+++ b/scripts/tests/test_cognitive_driven_development_doc.py
@@ -95,8 +95,9 @@ COUNTEREXAMPLE_CLAIMS = (
     compact(
         """
         The counterexample holds. review-suite/ distributes canonical normative
-        text that just sync-contracts bundles verbatim into each consumer and
-        just check-installed drift-checks, with no skill involved.
+        text that just sync-contracts bundles verbatim into each consumer and a
+        bundled-contract test drift-checks under just test, with no skill
+        involved.
         """
     ),
     compact(
@@ -148,12 +149,19 @@ ENTRY_WINDOW = 100
 
 
 def strip_html(markup: str) -> str:
-    """Reduce the presentation copy to the prose a reader actually sees."""
+    """Reduce the presentation copy to the prose a reader actually sees.
+
+    Each tag becomes a space, since dropping it outright would weld the words
+    on either side together. That leaves a space before any punctuation that
+    followed a tag — `<code>just test</code>,` — which the rendered page does
+    not show, so it is closed again here.
+    """
     without_style = re.sub(
         r"<style\b.*?</style>", " ", markup, flags=re.DOTALL | re.IGNORECASE
     )
     without_comments = re.sub(r"<!--.*?-->", " ", without_style, flags=re.DOTALL)
-    return html_module.unescape(re.sub(r"<[^>]+>", " ", without_comments))
+    spaced = html_module.unescape(re.sub(r"<[^>]+>", " ", without_comments))
+    return re.sub(r"\s+([,.;:!?])", r"\1", spaced)
 
 
 def strip_markdown(source: str) -> str:


### PR DESCRIPTION
## Summary

Records the decision GitHub issue #189 asks for: **the shaping authority is a bundled synced contract, not a new skill.** The design record told a reader the cited-versus-called framing was contested and that Spec B "should not be built until that alternative is argued down or adopted," which left six downstream leaves waiting on a question nobody had answered.

The decision is recorded in `docs/cognitive-driven-development.md` and its HTML presentation copy, and held in place by a new contract test asserted against both.

## The decision

**Selected: the bundled synced contract** — canonical doctrine text, distributed by stable path and mechanically drift-checked, with no new skill. `docs/cognitive-shaping-doctrine.md` already exists; what is missing is only its distribution.

**The `review-suite` counterexample is answered explicitly.** It holds — `just sync-contracts` bundles canonical normative text verbatim into three consumers today with no skill involved — and it draws the line the brief missed: there, the synced text carries the contract and the skills carry the verdict. So the question was never which mechanism is legitimate. It is whether any caller has demonstrated it needs a verdict rather than a contract, and none has. The publication size gate is the strongest candidate and already runs the contract mechanism without failing.

**Rejected with reasons:** the executable shaping verdict (no caller has demonstrated it needs one; the brief itself concedes the program is capability-driven rather than failure-driven) and the fourth review lens (it answers at the one moment the answer cannot be acted on, and would make shape a review blocker in a repository that deliberately declines shape gating).

**Adopted alongside:** the telemetry-first ordering. **Left open:** build only the missing edge, which varies Spec C's planner rather than Spec B's authority.

The decision is reversible on evidence rather than argument — the telemetry it keeps is exactly what would justify reopening it.

## Downstream disposition

| Leaf | Disposition |
| --- | --- |
| #190 | superseded — re-cut as the retrospective merged-history corpus |
| #191 | superseded — closed with no replacement |
| #192 | re-cut against the bundled doctrine, consumed by stable path |
| #193 | re-cut against the bundled doctrine |
| #194 | activated; its blocker on #193 drops |
| #195 | activated; still follows #194 |

Executing these is caller-owned post-merge work. **This PR mutates no issue.**

## Validation at head `63457f0`

- `python3 -m unittest discover -s scripts/tests -p 'test_cognitive_driven_development_doc.py'` — 7 tests, OK. All 7 fail at the base the work started from, before the document changed.
- The same module under the module-path form (`python3 -m unittest scripts.tests.test_cognitive_driven_development_doc`, `PYTHONPATH` stripped) — 7 tests, OK, per the convention `main` added in #209.
- `just format`, `just lint`, `just test` — all pass (14 suites, zero failures).
- CI green on `63457f0`.
- Review converged: three fresh lenses clean at `63457f0` vs base `e906fb9`, across three review passes and two fix cycles.

## Non-goals preserved

Implementing the selected mechanism; re-litigating the doctrine; treating the design's preferred framing as the decision; mutating the issue graph. Spec C stays independent, and the design remains capability-driven rather than claiming an observed repository failure.

## What review changed

Three findings were verified against the codebase and accepted:

1. The record named `just check-installed` as the drift gate, but `review-suite/CONTRACT.md` pairs `just sync-contracts` with the bundled-contract test, and the justfile marks `check-installed` as deliberately outside `lint` and `check`. A downstream leaf taking the earlier wording literally would have shipped a drift check that never runs in CI.
2. The test asserted each leaf's disposition by character proximity, which passed only because each table row happened to be its leaf's first occurrence — `#192`, `#193` and `#194` each appear more than once per copy. It now asserts the full leaf-plus-disposition phrase, which occurs exactly once in both.
3. The reference-definition block could not be hand-sorted while its labels carried backticks; `just format` reordered it every run. Removing them makes the alphabetical order survive formatting.

One finding is deferred: two entries under "Decisions on record" still describe the rejected skill's corpus and rubric as live decisions. Marking them is a follow-up — this ticket's non-goals keep it out of scope here.

Refs #189
