### PR TITLE
test: hold every eval corpus to the terminal states its skill's prose defines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,32 @@ summary: Chronological history of repository and skill changes.
 
 # Changelog
 
-## 2026-08-12 — Settled how the shaping doctrine gets its authority: a bundled synced contract, not a new skill
+## 2026-08-12 — Closed the last gap between what the eval harness asserts and what any skill's prose defines, and settled how the shaping doctrine gets its authority: a bundled synced contract, not a new skill
 
-- docs: decide the shaping authority mechanism — the design record told a reader
+- test: hold every eval corpus to the terminal states its skill's prose defines
+  — a corpus state no prose names is unreachable for a model given only the
+  skill prompt, so the case grades whichever deterministic stand-in was written
+  knowing the expected string rather than the prose the evaluation exists to
+  check. `implement-epic`'s own corpus carried eleven such labels
+  (`waiting_for_child_merge`, `epic_children_merged`, `closeout_blocked`,
+  `umbrella_open`, and seven more) as required terminal states, alongside two
+  the prose does define; `ready-ticket`'s corpus already drew only on its four
+  documented states, which is the shape the others now match. Each of the
+  fifteen affected cases maps through the rule "Report the epic result" already
+  states — a stop condition means `blocked`, otherwise `mixed_ticket_results` —
+  and the authorized-closeout case records `null`, because that section reports
+  a closeout through closeout evidence rather than a single-word label. No
+  scenario detail is lost: `required_actions` already carried it, and the
+  boundary each case protects is now pinned there instead of in a bespoke label.
+  A new repository-root test enforces the invariant across every skill's corpus,
+  the shared forward corpus attributed per target skill, the closed vocabulary
+  `claude_executor.py` shows the evaluated model, and every state
+  `fixture_executor.py` can emit. `mixed_ticket_results` itself, the state that
+  prompted this, was defined in `implement-epic`'s prose by #162; this is what
+  keeps the next one from reaching the harness undefined.
+
+- docs: decide the shaping authority mechanism
+  (0c2d94c9b027373cc42e6742654945a0eedbecfb) — the design record told a reader
   the cited-versus-called framing was contested and that Spec B "should not be
   built until that alternative is argued down or adopted," which left every
   downstream leaf waiting on a question nobody had answered. The bundled synced

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,18 @@ summary: Chronological history of repository and skill changes.
   a closeout through closeout evidence rather than a single-word label. No
   scenario detail is lost: `required_actions` already carried it, and the
   boundary each case protects is now pinned there instead of in a bespoke label.
-  A new repository-root test enforces the invariant across every skill's corpus,
-  the shared forward corpus attributed per target skill, the closed vocabulary
-  `claude_executor.py` shows the evaluated model, and every state
-  `fixture_executor.py` can emit. `mixed_ticket_results` itself, the state that
-  prompted this, was defined in `implement-epic`'s prose by #162; this is what
-  keeps the next one from reaching the harness undefined.
+  A new repository-root test enforces the invariant over every harness surface
+  it discovers by glob rather than by name — all eight case corpora across six
+  skills, each attributed per target skill; both `claude_executor.py`
+  vocabularies, which are what a real-model run shows the evaluated model; and
+  all three `fixture_executor.py` deterministic stand-ins, whose emitted states
+  must stay inside the vocabulary a real packet is actually offered. A corpus
+  recording its outcome under a key the test cannot read fails the suite instead
+  of being silently exempt, which is what an earlier draft did to
+  `review-code-change`'s twelve nested `result.verdict` cases.
+  `mixed_ticket_results` itself, the state that prompted this, was defined in
+  `implement-epic`'s prose by #162; this is what keeps the next one from
+  reaching the harness undefined.
 
 - docs: decide the shaping authority mechanism
   (0c2d94c9b027373cc42e6742654945a0eedbecfb) — the design record told a reader

--- a/scripts/tests/test_terminal_state_prose_coverage.py
+++ b/scripts/tests/test_terminal_state_prose_coverage.py
@@ -18,6 +18,13 @@ named, so a skill that grows a corpus or an executor is covered on arrival:
 - each `scripts/evals/fixture_executor.py`, whose deterministic stand-in must
   emit nothing its skill's prose and its sibling vocabulary do not both allow.
 
+Those globs are rooted at `skills/*` and match the three shapes above, which is
+this module's scope boundary: the invariant binds a harness a skill owns, where
+that skill's own prose is what must define the state. Harnesses of another shape
+or another root are not reached — `review-suite/scripts/evals/`,
+`triggering/executors/`, and `review-fix-loop`'s corpus, which is a Python
+module rather than one of the JSON corpora named above.
+
 Corpora record an outcome under three different keys, and an unrecognized
 fourth would exempt a whole corpus while every assertion here still passed —
 so `corpus_outcomes` raises on a case it cannot read rather than returning
@@ -38,6 +45,7 @@ import ast
 import json
 import tempfile
 import unittest
+from collections.abc import Iterable
 from pathlib import Path
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
@@ -65,21 +73,15 @@ def skill_prose(skill: str) -> str:
     return "\n".join(path.read_text() for path in documents if path.is_file())
 
 
-def undefined_states(
-    claimed: dict[str, set[str]], prose: dict[str, str]
-) -> dict[str, set[str]]:
-    """Return, per skill, the claimed states that skill's own prose never defines.
+def undefined_states(states: Iterable[str], prose: str) -> set[str]:
+    """Return the claimed states the given prose never defines.
 
     A state counts as defined only in its backticked form, which is how every
     skill in this repository writes one. Bare-word matching would accept the
     English words "blocked" and "merged" wherever they appear as prose and
     report coverage a reader could not act on.
     """
-    return {
-        skill: missing
-        for skill, states in claimed.items()
-        if (missing := {s for s in states if f"`{s}`" not in prose.get(skill, "")})
-    }
+    return {state for state in states if f"`{state}`" not in prose}
 
 
 def corpora() -> list[Path]:
@@ -91,15 +93,19 @@ def corpora() -> list[Path]:
     )
 
 
-def corpus_outcomes(path: Path) -> dict[str, str | None]:
-    """One corpus's outcomes, attributed to the skill each case targets.
+def corpus_outcomes(path: Path) -> list[tuple[str, str, str | None]]:
+    """One corpus's `(target skill, case id, outcome)` triples, in file order.
+
+    A list rather than a mapping: keying by target and case id would silently
+    collapse a repeated pair into one entry, dropping a case from every
+    assertion below — the same invisible exemption this module exists to close.
 
     Raises on a case recording its outcome somewhere this function cannot read.
-    Returning `None` there instead would exempt the corpus silently, which is
-    the same invisible gap this module exists to close.
+    Returning `None` there instead would exempt the corpus silently, for the
+    same reason.
     """
     owner = path.parents[1].name
-    outcomes: dict[str, str | None] = {}
+    outcomes: list[tuple[str, str, str | None]] = []
     for case in json.loads(path.read_text()):
         target = case.get("target_skill", owner)
         for key in OUTCOME_KEYS:
@@ -118,7 +124,7 @@ def corpus_outcomes(path: Path) -> dict[str, str | None]:
                     )
                 nested = nested[key]
             outcome = nested
-        outcomes[f"{target}::{case['case_id']}"] = outcome
+        outcomes.append((target, case["case_id"], outcome))
     return outcomes
 
 
@@ -173,7 +179,7 @@ def executor_targets(executor: Path) -> list[str]:
     corpus = SKILLS_ROOT / owner / "evals" / "forward_expectations.json"
     if not corpus.is_file():
         return [owner]
-    return sorted({key.split("::", 1)[0] for key in corpus_outcomes(corpus)})
+    return sorted({target for target, _, _ in corpus_outcomes(corpus)})
 
 
 class TerminalStateProseCoverageTests(unittest.TestCase):
@@ -182,26 +188,26 @@ class TerminalStateProseCoverageTests(unittest.TestCase):
         # silently returned nothing — the exact shape of vacuous coverage this
         # file exists to prevent.
         self.assertEqual(
-            {"a-skill": {"invented_state"}},
+            {"invented_state"},
             undefined_states(
-                {"a-skill": {"documented_state", "invented_state"}},
-                {"a-skill": "ends in `documented_state` when the gate passes"},
+                {"documented_state", "invented_state"},
+                "ends in `documented_state` when the gate passes",
             ),
         )
         self.assertEqual(
-            {},
+            set(),
             undefined_states(
-                {"a-skill": {"documented_state"}},
-                {"a-skill": "ends in `documented_state` when the gate passes"},
+                {"documented_state"},
+                "ends in `documented_state` when the gate passes",
             ),
         )
 
     def test_the_detector_requires_the_backticked_form(self):
         self.assertEqual(
-            {"a-skill": {"merged"}},
+            {"merged"},
             undefined_states(
-                {"a-skill": {"merged"}},
-                {"a-skill": "the candidate is merged once every gate passes"},
+                {"merged"},
+                "the candidate is merged once every gate passes",
             ),
         )
 
@@ -228,13 +234,12 @@ class TerminalStateProseCoverageTests(unittest.TestCase):
             with self.subTest(corpus=display(corpus)):
                 outcomes = corpus_outcomes(corpus)
                 self.assertTrue(outcomes)
-                self.assertTrue([o for o in outcomes.values() if o is not None])
+                self.assertTrue([o for _, _, o in outcomes if o is not None])
 
     def test_every_corpus_outcome_is_defined_by_its_target_skill(self):
         for corpus in corpora():
             claimed: dict[str, set[str]] = {}
-            for key, outcome in corpus_outcomes(corpus).items():
-                target, case_id = key.split("::", 1)
+            for target, case_id, outcome in corpus_outcomes(corpus):
                 with self.subTest(corpus=corpus.parents[1].name, case=case_id):
                     self.assertIsInstance(
                         outcome,
@@ -243,42 +248,37 @@ class TerminalStateProseCoverageTests(unittest.TestCase):
                     )
                 if isinstance(outcome, str):
                     claimed.setdefault(target, set()).add(outcome)
-            with self.subTest(corpus=display(corpus)):
-                self.assertEqual(
-                    {},
-                    undefined_states(
-                        claimed, {skill: skill_prose(skill) for skill in claimed}
-                    ),
-                )
+            for target, states in sorted(claimed.items()):
+                with self.subTest(corpus=display(corpus), target=target):
+                    self.assertEqual(
+                        set(), undefined_states(states, skill_prose(target))
+                    )
 
     def test_every_declared_vocabulary_is_defined_across_its_targets(self):
         for executor in sorted(SKILLS_ROOT.glob("*/scripts/evals/claude_executor.py")):
             # The executor offers one vocabulary to every packet regardless of
             # target, so it is defined collectively rather than by any one skill.
             targets = executor_targets(executor)
-            collective = " and ".join(targets)
             with self.subTest(executor=display(executor)):
                 self.assertEqual(
-                    {},
+                    set(),
                     undefined_states(
-                        {collective: declared_vocabulary(executor)},
-                        {collective: "\n".join(skill_prose(s) for s in targets)},
+                        declared_vocabulary(executor),
+                        "\n".join(skill_prose(s) for s in targets),
                     ),
                 )
 
     def test_every_fixture_executor_stays_inside_its_skills_vocabulary(self):
         for executor in sorted(SKILLS_ROOT.glob("*/scripts/evals/fixture_executor.py")):
             targets = executor_targets(executor)
-            collective = " and ".join(targets)
             emitted = emitted_states(executor)
             sibling = executor.parent / "claude_executor.py"
             with self.subTest(executor=display(executor)):
                 self.assertTrue(emitted)
                 self.assertEqual(
-                    {},
+                    set(),
                     undefined_states(
-                        {collective: emitted},
-                        {collective: "\n".join(skill_prose(s) for s in targets)},
+                        emitted, "\n".join(skill_prose(s) for s in targets)
                     ),
                 )
                 if sibling.is_file():
@@ -299,7 +299,7 @@ class TerminalStateProseCoverageTests(unittest.TestCase):
                 continue
             claimed = {
                 outcome
-                for outcome in corpus_outcomes(corpus).values()
+                for _, _, outcome in corpus_outcomes(corpus)
                 if isinstance(outcome, str)
             }
             with self.subTest(corpus=display(corpus)):

--- a/scripts/tests/test_terminal_state_prose_coverage.py
+++ b/scripts/tests/test_terminal_state_prose_coverage.py
@@ -8,15 +8,21 @@ simulation rather than the prose the evaluation exists to check.
 
 This test spans every skill, so it lives in the repository-root suite rather
 than inside any one skill's, exactly as `test_suite_invocation.py` does for an
-invariant no single skill owns.
+invariant no single skill owns. Every surface is discovered by glob rather than
+named, so a skill that grows a corpus or an executor is covered on arrival:
 
-Two harness surfaces claim a terminal state, and both are covered:
+- each `evals/expectations.json` and `evals/forward_expectations.json`, whose
+  per-case outcome must be defined by the prose of the skill that case targets;
+- each `scripts/evals/claude_executor.py`, whose closed vocabulary is what a
+  real-model executor shows the evaluated model; and
+- each `scripts/evals/fixture_executor.py`, whose deterministic stand-in must
+  emit nothing its skill's prose and its sibling vocabulary do not both allow.
 
-- a skill's own `evals/expectations.json`, whose per-case state must be defined
-  by the prose of the skill that case targets; and
-- the shared forward harness under `skills/implement-ticket/scripts/evals/`,
-  whose closed vocabulary is what a real-model executor shows the evaluated
-  model, and whose deterministic stand-in must not emit anything outside it.
+Corpora record an outcome under three different keys, and an unrecognized
+fourth would exempt a whole corpus while every assertion here still passed —
+so `corpus_outcomes` raises on a case it cannot read rather than returning
+nothing, and `test_every_corpus_yields_outcomes` fails the suite on a corpus
+that yields none.
 
 One expectation value is deliberately not a string: `implement-epic` reports an
 authorized parent closeout through the closeout evidence its own reference
@@ -30,20 +36,26 @@ from __future__ import annotations
 
 import ast
 import json
+import tempfile
 import unittest
 from pathlib import Path
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 SKILLS_ROOT = REPOSITORY_ROOT / "skills"
-FORWARD_EVALS = SKILLS_ROOT / "implement-ticket" / "scripts" / "evals"
-FORWARD_CORPUS = (
-    SKILLS_ROOT / "implement-ticket" / "evals" / "forward_expectations.json"
-)
-CLAUDE_EXECUTOR = FORWARD_EVALS / "claude_executor.py"
-FIXTURE_EXECUTOR = FORWARD_EVALS / "fixture_executor.py"
 
-# The per-case key each corpus uses for the state its target skill must report.
-STATE_KEYS = ("terminal_state", "workflow_state")
+# The flat keys a corpus uses for the outcome its target skill must report.
+# `review-code-change` reports an aggregate verdict instead, nested one level
+# down, so the nested path is read as well.
+OUTCOME_KEYS = ("terminal_state", "workflow_state")
+NESTED_OUTCOME_PATH = ("result", "verdict")
+
+
+def display(path: Path) -> str:
+    """A repository-relative path when possible, so failures name one location."""
+    try:
+        return str(path.relative_to(REPOSITORY_ROOT))
+    except ValueError:
+        return str(path)
 
 
 def skill_prose(skill: str) -> str:
@@ -70,47 +82,65 @@ def undefined_states(
     }
 
 
-def corpus_states() -> dict[Path, dict[str, object]]:
-    """Every `evals/expectations.json` case's claimed state, keyed by corpus."""
-    corpora = {}
-    for path in sorted(SKILLS_ROOT.glob("*/evals/expectations.json")):
-        cases = json.loads(path.read_text())
-        corpora[path] = {
-            case["case_id"]: next(
-                (case[key] for key in STATE_KEYS if key in case), None
-            )
-            for case in cases
-        }
-    return corpora
+def corpora() -> list[Path]:
+    """Every case corpus that records an expected outcome."""
+    return sorted(
+        path
+        for name in ("expectations.json", "forward_expectations.json")
+        for path in SKILLS_ROOT.glob(f"*/evals/{name}")
+    )
 
 
-def forward_corpus_states_by_target() -> dict[str, set[str]]:
-    """The shared forward corpus's states, attributed to the skill each targets."""
-    claimed: dict[str, set[str]] = {}
-    for case in json.loads(FORWARD_CORPUS.read_text()):
-        claimed.setdefault(case["target_skill"], set()).add(case["terminal_state"])
-    return claimed
+def corpus_outcomes(path: Path) -> dict[str, str | None]:
+    """One corpus's outcomes, attributed to the skill each case targets.
+
+    Raises on a case recording its outcome somewhere this function cannot read.
+    Returning `None` there instead would exempt the corpus silently, which is
+    the same invisible gap this module exists to close.
+    """
+    owner = path.parents[1].name
+    outcomes: dict[str, str | None] = {}
+    for case in json.loads(path.read_text()):
+        target = case.get("target_skill", owner)
+        for key in OUTCOME_KEYS:
+            if key in case:
+                outcome = case[key]
+                break
+        else:
+            nested = case
+            for key in NESTED_OUTCOME_PATH:
+                if not isinstance(nested, dict) or key not in nested:
+                    raise AssertionError(
+                        f"{display(path)}: case "
+                        f"{case['case_id']!r} records its outcome under no key "
+                        f"this test reads ({', '.join(OUTCOME_KEYS)}, or "
+                        f"{'.'.join(NESTED_OUTCOME_PATH)})"
+                    )
+                nested = nested[key]
+            outcome = nested
+        outcomes[f"{target}::{case['case_id']}"] = outcome
+    return outcomes
 
 
-def declared_vocabulary() -> set[str]:
-    """The closed terminal-state vocabulary `claude_executor.py` shows the model."""
-    module = ast.parse(CLAUDE_EXECUTOR.read_text())
+def declared_vocabulary(executor: Path) -> set[str]:
+    """The closed terminal-state vocabulary an executor shows the model."""
+    module = ast.parse(executor.read_text())
     for node in module.body:
         if isinstance(node, ast.Assign) and any(
             isinstance(target, ast.Name) and target.id == "TERMINAL_STATES"
             for target in node.targets
         ):
             return set(ast.literal_eval(node.value))
-    raise AssertionError(f"{CLAUDE_EXECUTOR} declares no TERMINAL_STATES vocabulary")
+    raise AssertionError(f"{display(executor)} declares no TERMINAL_STATES")
 
 
-def fixture_emitted_states() -> set[str]:
-    """Every terminal state `fixture_executor.py` can emit, read from its source.
+def emitted_states(executor: Path) -> set[str]:
+    """Every terminal state an executor can emit, read from its source.
 
     Reading the source rather than running it keeps the check exhaustive: a
     branch no packet reaches still has to draw from the shared vocabulary.
     """
-    module = ast.parse(FIXTURE_EXECUTOR.read_text())
+    module = ast.parse(executor.read_text())
     emitted: set[str] = set()
     for node in ast.walk(module):
         if isinstance(node, ast.Dict):
@@ -129,6 +159,21 @@ def fixture_emitted_states() -> set[str]:
             ):
                 emitted.add(node.value.value)
     return emitted
+
+
+def executor_targets(executor: Path) -> list[str]:
+    """Every skill an executor's packets may target.
+
+    A forward corpus is shared: `implement-ticket`'s targets `implement-epic`
+    too, so both executors there legitimately handle a state only the epic
+    skill's prose defines. Attributing them to the owning skill alone would
+    report that as an undefined state.
+    """
+    owner = executor.parents[2].name
+    corpus = SKILLS_ROOT / owner / "evals" / "forward_expectations.json"
+    if not corpus.is_file():
+        return [owner]
+    return sorted({key.split("::", 1)[0] for key in corpus_outcomes(corpus)})
 
 
 class TerminalStateProseCoverageTests(unittest.TestCase):
@@ -160,59 +205,105 @@ class TerminalStateProseCoverageTests(unittest.TestCase):
             ),
         )
 
-    def test_the_harness_surfaces_are_non_empty(self):
-        # A glob or parse that silently matched nothing would make the coverage
-        # assertions vacuous.
-        corpora = corpus_states()
-        self.assertGreater(len(corpora), 1)
-        for path, cases in corpora.items():
-            with self.subTest(corpus=path.relative_to(REPOSITORY_ROOT)):
-                self.assertTrue(cases)
-        self.assertTrue(forward_corpus_states_by_target())
-        self.assertTrue(declared_vocabulary())
-        self.assertTrue(fixture_emitted_states())
+    def test_an_unreadable_case_outcome_fails_rather_than_exempts(self):
+        corpus = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        path = corpus / "skills" / "a-skill" / "evals" / "expectations.json"
+        path.parent.mkdir(parents=True)
+        path.write_text(json.dumps([{"case_id": "renamed-key", "outcome": "blocked"}]))
+        with self.assertRaises(AssertionError) as raised:
+            corpus_outcomes(path)
+        self.assertIn("renamed-key", str(raised.exception))
 
-    def test_every_skill_corpus_state_is_defined_by_that_skill(self):
-        for path, cases in corpus_states().items():
-            skill = path.parents[1].name
-            states = set()
-            for case_id, state in cases.items():
-                with self.subTest(corpus=skill, case=case_id):
+    def test_every_harness_surface_is_discovered(self):
+        # A glob that silently matched nothing would make every coverage
+        # assertion below vacuous.
+        self.assertGreater(len(corpora()), 1)
+        self.assertTrue(sorted(SKILLS_ROOT.glob("*/scripts/evals/claude_executor.py")))
+        self.assertTrue(sorted(SKILLS_ROOT.glob("*/scripts/evals/fixture_executor.py")))
+
+    def test_every_corpus_yields_outcomes(self):
+        # A corpus whose every case read as `None` would pass the coverage
+        # assertion by having nothing to check.
+        for corpus in corpora():
+            with self.subTest(corpus=display(corpus)):
+                outcomes = corpus_outcomes(corpus)
+                self.assertTrue(outcomes)
+                self.assertTrue([o for o in outcomes.values() if o is not None])
+
+    def test_every_corpus_outcome_is_defined_by_its_target_skill(self):
+        for corpus in corpora():
+            claimed: dict[str, set[str]] = {}
+            for key, outcome in corpus_outcomes(corpus).items():
+                target, case_id = key.split("::", 1)
+                with self.subTest(corpus=corpus.parents[1].name, case=case_id):
                     self.assertIsInstance(
-                        state,
+                        outcome,
                         (str, type(None)),
-                        "an expected state is a documented label or null",
+                        "an expected outcome is a documented label or null",
                     )
-                if isinstance(state, str):
-                    states.add(state)
-            with self.subTest(corpus=skill):
+                if isinstance(outcome, str):
+                    claimed.setdefault(target, set()).add(outcome)
+            with self.subTest(corpus=display(corpus)):
                 self.assertEqual(
-                    {}, undefined_states({skill: states}, {skill: skill_prose(skill)})
+                    {},
+                    undefined_states(
+                        claimed, {skill: skill_prose(skill) for skill in claimed}
+                    ),
                 )
 
-    def test_every_forward_corpus_state_is_defined_by_its_target_skill(self):
-        claimed = forward_corpus_states_by_target()
-        prose = {skill: skill_prose(skill) for skill in claimed}
-        self.assertEqual({}, undefined_states(claimed, prose))
+    def test_every_declared_vocabulary_is_defined_across_its_targets(self):
+        for executor in sorted(SKILLS_ROOT.glob("*/scripts/evals/claude_executor.py")):
+            # The executor offers one vocabulary to every packet regardless of
+            # target, so it is defined collectively rather than by any one skill.
+            targets = executor_targets(executor)
+            collective = " and ".join(targets)
+            with self.subTest(executor=display(executor)):
+                self.assertEqual(
+                    {},
+                    undefined_states(
+                        {collective: declared_vocabulary(executor)},
+                        {collective: "\n".join(skill_prose(s) for s in targets)},
+                    ),
+                )
 
-    def test_the_shared_vocabulary_is_defined_across_the_targeted_skills(self):
-        # The executors offer one vocabulary to every packet regardless of
-        # target, so it is defined collectively rather than by any one skill.
-        targets = sorted(forward_corpus_states_by_target())
-        collective = " and ".join(targets)
-        self.assertEqual(
-            {},
-            undefined_states(
-                {collective: declared_vocabulary()},
-                {collective: "\n".join(skill_prose(skill) for skill in targets)},
-            ),
-        )
+    def test_every_fixture_executor_stays_inside_its_skills_vocabulary(self):
+        for executor in sorted(SKILLS_ROOT.glob("*/scripts/evals/fixture_executor.py")):
+            targets = executor_targets(executor)
+            collective = " and ".join(targets)
+            emitted = emitted_states(executor)
+            sibling = executor.parent / "claude_executor.py"
+            with self.subTest(executor=display(executor)):
+                self.assertTrue(emitted)
+                self.assertEqual(
+                    {},
+                    undefined_states(
+                        {collective: emitted},
+                        {collective: "\n".join(skill_prose(s) for s in targets)},
+                    ),
+                )
+                if sibling.is_file():
+                    # A state only the simulation can produce grades the
+                    # simulation: a real-model packet is never offered it.
+                    self.assertEqual(set(), emitted - declared_vocabulary(sibling))
 
-    def test_both_executors_and_the_forward_corpus_share_one_vocabulary(self):
-        vocabulary = declared_vocabulary()
-        corpus = set().union(*forward_corpus_states_by_target().values())
-        self.assertEqual(set(), corpus - vocabulary)
-        self.assertEqual(set(), fixture_emitted_states() - vocabulary)
+    def test_every_forward_corpus_stays_inside_its_declared_vocabulary(self):
+        for corpus in sorted(SKILLS_ROOT.glob("*/evals/forward_expectations.json")):
+            executor = (
+                SKILLS_ROOT
+                / corpus.parents[1].name
+                / "scripts"
+                / "evals"
+                / "claude_executor.py"
+            )
+            if not executor.is_file():
+                continue
+            claimed = {
+                outcome
+                for outcome in corpus_outcomes(corpus).values()
+                if isinstance(outcome, str)
+            }
+            with self.subTest(corpus=display(corpus)):
+                self.assertEqual(set(), claimed - declared_vocabulary(executor))
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_terminal_state_prose_coverage.py
+++ b/scripts/tests/test_terminal_state_prose_coverage.py
@@ -1,0 +1,219 @@
+"""No terminal state reaches an eval harness without a skill's prose defining it.
+
+A terminal state that exists only in the harness cannot be measured. A model
+given the skill prompt has no way to produce a string the prose never names, so
+the case is unreachable at the real-model tier and passes only under a
+deterministic executor written knowing the expected string — which grades the
+simulation rather than the prose the evaluation exists to check.
+
+This test spans every skill, so it lives in the repository-root suite rather
+than inside any one skill's, exactly as `test_suite_invocation.py` does for an
+invariant no single skill owns.
+
+Two harness surfaces claim a terminal state, and both are covered:
+
+- a skill's own `evals/expectations.json`, whose per-case state must be defined
+  by the prose of the skill that case targets; and
+- the shared forward harness under `skills/implement-ticket/scripts/evals/`,
+  whose closed vocabulary is what a real-model executor shows the evaluated
+  model, and whose deterministic stand-in must not emit anything outside it.
+
+One expectation value is deliberately not a string: `implement-epic` reports an
+authorized parent closeout through the closeout evidence its own reference
+requires "rather than a separate single-word label", so its corpus records
+`null` there instead of inventing a label its prose declines to define. `null`
+is the only permitted non-string, and `skills/implement-epic/scripts/tests/
+test_orchestration_contract.py` pins which case carries it.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import unittest
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+SKILLS_ROOT = REPOSITORY_ROOT / "skills"
+FORWARD_EVALS = SKILLS_ROOT / "implement-ticket" / "scripts" / "evals"
+FORWARD_CORPUS = (
+    SKILLS_ROOT / "implement-ticket" / "evals" / "forward_expectations.json"
+)
+CLAUDE_EXECUTOR = FORWARD_EVALS / "claude_executor.py"
+FIXTURE_EXECUTOR = FORWARD_EVALS / "fixture_executor.py"
+
+# The per-case key each corpus uses for the state its target skill must report.
+STATE_KEYS = ("terminal_state", "workflow_state")
+
+
+def skill_prose(skill: str) -> str:
+    """Every normative document a skill ships: its SKILL.md and references."""
+    root = SKILLS_ROOT / skill
+    documents = [root / "SKILL.md", *sorted(root.glob("references/**/*.md"))]
+    return "\n".join(path.read_text() for path in documents if path.is_file())
+
+
+def undefined_states(
+    claimed: dict[str, set[str]], prose: dict[str, str]
+) -> dict[str, set[str]]:
+    """Return, per skill, the claimed states that skill's own prose never defines.
+
+    A state counts as defined only in its backticked form, which is how every
+    skill in this repository writes one. Bare-word matching would accept the
+    English words "blocked" and "merged" wherever they appear as prose and
+    report coverage a reader could not act on.
+    """
+    return {
+        skill: missing
+        for skill, states in claimed.items()
+        if (missing := {s for s in states if f"`{s}`" not in prose.get(skill, "")})
+    }
+
+
+def corpus_states() -> dict[Path, dict[str, object]]:
+    """Every `evals/expectations.json` case's claimed state, keyed by corpus."""
+    corpora = {}
+    for path in sorted(SKILLS_ROOT.glob("*/evals/expectations.json")):
+        cases = json.loads(path.read_text())
+        corpora[path] = {
+            case["case_id"]: next(
+                (case[key] for key in STATE_KEYS if key in case), None
+            )
+            for case in cases
+        }
+    return corpora
+
+
+def forward_corpus_states_by_target() -> dict[str, set[str]]:
+    """The shared forward corpus's states, attributed to the skill each targets."""
+    claimed: dict[str, set[str]] = {}
+    for case in json.loads(FORWARD_CORPUS.read_text()):
+        claimed.setdefault(case["target_skill"], set()).add(case["terminal_state"])
+    return claimed
+
+
+def declared_vocabulary() -> set[str]:
+    """The closed terminal-state vocabulary `claude_executor.py` shows the model."""
+    module = ast.parse(CLAUDE_EXECUTOR.read_text())
+    for node in module.body:
+        if isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == "TERMINAL_STATES"
+            for target in node.targets
+        ):
+            return set(ast.literal_eval(node.value))
+    raise AssertionError(f"{CLAUDE_EXECUTOR} declares no TERMINAL_STATES vocabulary")
+
+
+def fixture_emitted_states() -> set[str]:
+    """Every terminal state `fixture_executor.py` can emit, read from its source.
+
+    Reading the source rather than running it keeps the check exhaustive: a
+    branch no packet reaches still has to draw from the shared vocabulary.
+    """
+    module = ast.parse(FIXTURE_EXECUTOR.read_text())
+    emitted: set[str] = set()
+    for node in ast.walk(module):
+        if isinstance(node, ast.Dict):
+            for key, value in zip(node.keys, node.values):
+                if (
+                    isinstance(key, ast.Constant)
+                    and key.value == "terminal_state"
+                    and isinstance(value, ast.Constant)
+                    and isinstance(value.value, str)
+                ):
+                    emitted.add(value.value)
+        elif isinstance(node, ast.Assign) and isinstance(node.value, ast.Constant):
+            if isinstance(node.value.value, str) and any(
+                isinstance(target, ast.Name) and target.id == "terminal_state"
+                for target in node.targets
+            ):
+                emitted.add(node.value.value)
+    return emitted
+
+
+class TerminalStateProseCoverageTests(unittest.TestCase):
+    def test_the_detector_reports_a_state_no_prose_defines(self):
+        # Without this, every assertion below would still pass if the detector
+        # silently returned nothing — the exact shape of vacuous coverage this
+        # file exists to prevent.
+        self.assertEqual(
+            {"a-skill": {"invented_state"}},
+            undefined_states(
+                {"a-skill": {"documented_state", "invented_state"}},
+                {"a-skill": "ends in `documented_state` when the gate passes"},
+            ),
+        )
+        self.assertEqual(
+            {},
+            undefined_states(
+                {"a-skill": {"documented_state"}},
+                {"a-skill": "ends in `documented_state` when the gate passes"},
+            ),
+        )
+
+    def test_the_detector_requires_the_backticked_form(self):
+        self.assertEqual(
+            {"a-skill": {"merged"}},
+            undefined_states(
+                {"a-skill": {"merged"}},
+                {"a-skill": "the candidate is merged once every gate passes"},
+            ),
+        )
+
+    def test_the_harness_surfaces_are_non_empty(self):
+        # A glob or parse that silently matched nothing would make the coverage
+        # assertions vacuous.
+        corpora = corpus_states()
+        self.assertGreater(len(corpora), 1)
+        for path, cases in corpora.items():
+            with self.subTest(corpus=path.relative_to(REPOSITORY_ROOT)):
+                self.assertTrue(cases)
+        self.assertTrue(forward_corpus_states_by_target())
+        self.assertTrue(declared_vocabulary())
+        self.assertTrue(fixture_emitted_states())
+
+    def test_every_skill_corpus_state_is_defined_by_that_skill(self):
+        for path, cases in corpus_states().items():
+            skill = path.parents[1].name
+            states = set()
+            for case_id, state in cases.items():
+                with self.subTest(corpus=skill, case=case_id):
+                    self.assertIsInstance(
+                        state,
+                        (str, type(None)),
+                        "an expected state is a documented label or null",
+                    )
+                if isinstance(state, str):
+                    states.add(state)
+            with self.subTest(corpus=skill):
+                self.assertEqual(
+                    {}, undefined_states({skill: states}, {skill: skill_prose(skill)})
+                )
+
+    def test_every_forward_corpus_state_is_defined_by_its_target_skill(self):
+        claimed = forward_corpus_states_by_target()
+        prose = {skill: skill_prose(skill) for skill in claimed}
+        self.assertEqual({}, undefined_states(claimed, prose))
+
+    def test_the_shared_vocabulary_is_defined_across_the_targeted_skills(self):
+        # The executors offer one vocabulary to every packet regardless of
+        # target, so it is defined collectively rather than by any one skill.
+        targets = sorted(forward_corpus_states_by_target())
+        collective = " and ".join(targets)
+        self.assertEqual(
+            {},
+            undefined_states(
+                {collective: declared_vocabulary()},
+                {collective: "\n".join(skill_prose(skill) for skill in targets)},
+            ),
+        )
+
+    def test_both_executors_and_the_forward_corpus_share_one_vocabulary(self):
+        vocabulary = declared_vocabulary()
+        corpus = set().union(*forward_corpus_states_by_target().values())
+        self.assertEqual(set(), corpus - vocabulary)
+        self.assertEqual(set(), fixture_emitted_states() - vocabulary)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/implement-epic/evals/README.md
+++ b/skills/implement-epic/evals/README.md
@@ -7,3 +7,12 @@ replayed manually or through a compatible headless agent harness. Dependency
 provenance cases are also mirrored into the shared fresh-process forward corpus;
 run them with `just eval-implement-epic`. Give an evaluated agent only scenario
 inputs; never show it expectations.
+
+`workflow_state` draws only on the states "Report the epic result" defines:
+`blocked`, `mixed_ticket_results`, or `null` for an authorized parent closeout,
+which that section reports through closeout evidence rather than a single-word
+label. A case's own scenario is carried by `required_actions`, not by a bespoke
+state label — a label the prose never defines is unreachable for a model given
+only the prompt, so the case would grade a deterministic stand-in instead of the
+prose. `scripts/tests/test_terminal_state_prose_coverage.py` at the repository
+root enforces that across every skill's corpus.

--- a/skills/implement-epic/evals/expectations.json
+++ b/skills/implement-epic/evals/expectations.json
@@ -1,17 +1,17 @@
 [
   {
     "case_id": "two-child-refresh-chain",
-    "workflow_state": "epic_children_merged",
+    "workflow_state": "mixed_ticket_results",
     "required_actions": ["invoke G-101 once", "verify merged", "refresh the complete graph", "select G-102 only after refresh", "invoke G-102 once"]
   },
   {
     "case_id": "named-child-boundary",
-    "workflow_state": "requested_child_merged",
+    "workflow_state": "mixed_ticket_results",
     "required_actions": ["invoke only G-111", "refresh and report ready work", "leave G-112 and G-110 open"]
   },
   {
     "case_id": "ready-pr-does-not-unblock",
-    "workflow_state": "waiting_for_child_merge",
+    "workflow_state": "mixed_ticket_results",
     "required_actions": ["record G-121 ready_pr", "do not select G-122", "do not claim child or epic complete"]
   },
   {
@@ -21,7 +21,7 @@
   },
   {
     "case_id": "blocked-then-independent-ready",
-    "workflow_state": "partial_progress",
+    "workflow_state": "blocked",
     "required_actions": ["preserve G-141 blocked", "select independently ready G-142", "refresh after G-142 merge"]
   },
   {
@@ -31,7 +31,7 @@
   },
   {
     "case_id": "compatible-installed-implement-ticket",
-    "workflow_state": "waiting_for_child_merge",
+    "workflow_state": "mixed_ticket_results",
     "required_actions": ["record the trusted distribution binding", "verify the complete terminal and authority contract", "select G-152", "invoke the installed implement-ticket exactly once", "record ready_pr without treating it as merged"]
   },
   {
@@ -61,27 +61,27 @@
   },
   {
     "case_id": "exclusive-delegated-worktree",
-    "workflow_state": "ticket_result_verified",
+    "workflow_state": "mixed_ticket_results",
     "required_actions": ["verify exclusive ownership", "verify returned candidate and worktree", "reject ambiguous mutation state"]
   },
   {
     "case_id": "ticket-evidence-pass-through",
-    "workflow_state": "graph_refresh_required",
+    "workflow_state": "mixed_ticket_results",
     "required_actions": ["verify ticket evidence without reproducing review rubrics", "verify merge and transition", "refresh graph"]
   },
   {
     "case_id": "late-feedback-blocks-closeout",
-    "workflow_state": "closeout_blocked",
+    "workflow_state": "blocked",
     "required_actions": ["keep G-180 open", "record the finding", "route authorized remediation through implement-ticket"]
   },
   {
     "case_id": "authorized-full-epic-closeout",
-    "workflow_state": "epic_closed",
+    "workflow_state": null,
     "required_actions": ["verify every child and parent acceptance ledger", "verify current-main and exact deployment identities", "close G-190", "report final graph and evidence"]
   },
   {
     "case_id": "umbrella-closeout-separately",
-    "workflow_state": "umbrella_open",
+    "workflow_state": "blocked",
     "required_actions": ["verify G-201 separately", "keep G-202 open", "keep G-200 open"]
   },
   {
@@ -91,12 +91,12 @@
   },
   {
     "case_id": "parallel-nonoverlap-required",
-    "workflow_state": "serial_execution_required",
+    "workflow_state": "mixed_ticket_results",
     "required_actions": ["reject parallel mutation", "sequence shared-contract work", "recompute readiness after each result"]
   },
   {
     "case_id": "equivalent-isolated-context-profile",
-    "workflow_state": "epic_children_merged",
+    "workflow_state": "mixed_ticket_results",
     "required_actions": ["accept equivalent isolated context terminology", "verify G-231 merged evidence", "refresh the complete graph", "preserve review ownership inside implement-ticket"]
   },
   {
@@ -121,17 +121,17 @@
   },
   {
     "case_id": "verify-stacked-child-result",
-    "workflow_state": "stack_child_verified",
+    "workflow_state": "mixed_ticket_results",
     "required_actions": ["verify stack topology and every PR gate", "verify all_merged and full-chain representation on base", "do not invoke carve-changesets directly", "refresh graph before considering G-282"]
   },
   {
     "case_id": "closed-children-missing-manual-browser",
-    "workflow_state": "closeout_blocked",
+    "workflow_state": "blocked",
     "required_actions": ["read the closed child ledger", "record manual browser evidence as missing", "keep G-290 open", "report delivery separately from acceptance"]
   },
   {
     "case_id": "reopened-correction-missing-journey-revalidation",
-    "workflow_state": "closeout_blocked",
+    "workflow_state": "blocked",
     "required_actions": ["preserve the corrective child result", "require full affected journey revalidation", "keep G-300 open", "do not impose unrelated full-system testing"]
   },
   {

--- a/skills/implement-epic/scripts/tests/test_orchestration_contract.py
+++ b/skills/implement-epic/scripts/tests/test_orchestration_contract.py
@@ -120,7 +120,7 @@ class ImplementEpicContractTests(unittest.TestCase):
 
     def test_dependency_provenance_evals_are_paired_and_result_blind(self):
         expected_states = {
-            "compatible-installed-implement-ticket": "waiting_for_child_merge",
+            "compatible-installed-implement-ticket": "mixed_ticket_results",
             "missing-implement-ticket": "blocked",
             "third-party-same-name-implement-ticket": "blocked",
             "incompatible-repository-implement-ticket": "blocked",
@@ -235,43 +235,76 @@ class ImplementEpicContractTests(unittest.TestCase):
         self.assertTrue(self.cases)
         self.assertEqual(set(self.cases), set(self.expectations))
 
+    def test_eval_expectations_draw_only_on_documented_states(self):
+        # A corpus state this skill's prose never defines is unreachable for a
+        # model given only the prompt, so the case would grade a deterministic
+        # stand-in rather than the prose. `null` records the authorized-closeout
+        # case, which "Report the epic result" reports through closeout evidence
+        # rather than a single-word label. scripts/tests/
+        # test_terminal_state_prose_coverage.py enforces this across every skill.
+        for case_id, expectation in self.expectations.items():
+            with self.subTest(case=case_id):
+                self.assertIn(
+                    expectation["workflow_state"],
+                    ("blocked", "mixed_ticket_results", None),
+                )
+        unlabeled = {
+            case_id
+            for case_id, expectation in self.expectations.items()
+            if expectation["workflow_state"] is None
+        }
+        self.assertEqual({"authorized-full-epic-closeout"}, unlabeled)
+
     def test_eval_expectations_preserve_critical_boundaries(self):
-        self.assertEqual(
-            "waiting_for_child_merge",
-            self.expectations["ready-pr-does-not-unblock"]["workflow_state"],
-        )
-        self.assertEqual(
-            "blocked", self.expectations["missing-implement-ticket"]["workflow_state"]
-        )
-        self.assertEqual(
-            "closeout_blocked",
-            self.expectations["late-feedback-blocks-closeout"]["workflow_state"],
-        )
-        self.assertEqual(
-            "serial_execution_required",
-            self.expectations["parallel-nonoverlap-required"]["workflow_state"],
-        )
+        # Each documented state covers many scenarios, so the boundary a case
+        # exists to protect is pinned by its own required action rather than by
+        # a bespoke per-case label.
+        for case_id, state, boundary in (
+            (
+                "ready-pr-does-not-unblock",
+                "mixed_ticket_results",
+                "do not claim child or epic complete",
+            ),
+            (
+                "missing-implement-ticket",
+                "blocked",
+                "fail before child selection or mutation",
+            ),
+            ("late-feedback-blocks-closeout", "blocked", "keep G-180 open"),
+            (
+                "parallel-nonoverlap-required",
+                "mixed_ticket_results",
+                "reject parallel mutation",
+            ),
+            (
+                "verify-stacked-child-result",
+                "mixed_ticket_results",
+                "verify stack topology and every PR gate",
+            ),
+            (
+                "closed-children-missing-manual-browser",
+                "blocked",
+                "record manual browser evidence as missing",
+            ),
+            (
+                "reopened-correction-missing-journey-revalidation",
+                "blocked",
+                "require full affected journey revalidation",
+            ),
+            ("authorized-full-epic-closeout", None, "close G-190"),
+        ):
+            with self.subTest(case=case_id):
+                expectation = self.expectations[case_id]
+                self.assertEqual(state, expectation["workflow_state"])
+                self.assertIn(
+                    boundary, compact(" ".join(expectation["required_actions"]))
+                )
         for case_id in (
             "missing-review-dependency-through-ticket",
             "missing-isolation-capability",
             "missing-asynchronous-wait",
         ):
             self.assertEqual("blocked", self.expectations[case_id]["workflow_state"])
-        self.assertEqual(
-            "stack_child_verified",
-            self.expectations["verify-stacked-child-result"]["workflow_state"],
-        )
-        for case_id in (
-            "closed-children-missing-manual-browser",
-            "reopened-correction-missing-journey-revalidation",
-        ):
-            self.assertEqual(
-                "closeout_blocked", self.expectations[case_id]["workflow_state"]
-            )
-        self.assertEqual(
-            "epic_closed",
-            self.expectations["authorized-full-epic-closeout"]["workflow_state"],
-        )
 
     def test_verified_delivery_refreshes_graph_even_when_acceptance_blocks(self):
         self.assertIn(


### PR DESCRIPTION
## Summary

Closes the third acceptance criterion of #150: **no terminal state remains that
appears in the eval harness but in no skill's prose, and a test asserts it.**

- Add `scripts/tests/test_terminal_state_prose_coverage.py`, a repository-root
  test that discovers every harness surface by glob rather than by name and
  requires each declared outcome to be defined in the prose of the skill that
  case targets: all eight case corpora across six skills, both
  `claude_executor.py` vocabularies, and all three `fixture_executor.py`
  stand-ins, whose emitted states must stay inside the vocabulary a real packet
  is actually offered.
- Remap `skills/implement-epic/evals/expectations.json` onto the states
  "Report the epic result" defines. Eleven labels appeared in no skill's prose:
  `waiting_for_child_merge`, `epic_children_merged`, `closeout_blocked`,
  `umbrella_open`, `partial_progress`, `requested_child_merged`,
  `ticket_result_verified`, `graph_refresh_required`, `epic_closed`,
  `serial_execution_required`, `stack_child_verified`.
- Rework `test_eval_expectations_preserve_critical_boundaries` so each case's
  boundary is pinned by its own `required_actions`, and add
  `test_eval_expectations_draw_only_on_documented_states`.
- Correct `skills/implement-epic/evals/README.md`, which called every value a
  required terminal state without saying which vocabulary it draws on.

## Why

A corpus state no prose names is unreachable for a model given only the skill
prompt, so the case grades whichever deterministic stand-in was written knowing
the expected string — never the prose the evaluation exists to check. That is
the failure mode #150 was filed for, and `mixed_ticket_results` was only its
first instance; `implement-epic`'s own corpus carried eleven more.

`ready-ticket`'s corpus already drew only on its four documented terminal
states, so this is the repository's existing shape rather than a new demand.

## What #150's first two criteria needed

Both were already satisfied on `main` before this branch, by b86bf98 (#162),
which defined `mixed_ticket_results` in `skills/implement-epic/SKILL.md` under
"## Report the epic result" together with the verification obligation that
licenses claiming it — stop conditions are checked first, and a child's own
terminal state does not by itself rule one out. The ticket's "Decision needed"
is therefore already resolved in the repository, in favor of its option 1.

The four named cases' outcome is recorded in
`skills/implement-ticket/evals/results/2026-08-05T223453Z-0018-after.json`
(candidate cb8dd09): `verified-external-claim-remains-evidence` passes
outright, and the other three no longer carry a `terminal_state` mismatch —
their remaining failures are on unrelated action items.

## The remapping

Each of the fifteen affected cases maps through the rule the prose already
states: a stop condition means `blocked`, otherwise `mixed_ticket_results`. The
authorized-closeout case records `null`, because that section reports a closeout
through closeout evidence "rather than a separate single-word label", and
inventing a label would contradict the prose this change exists to follow.

No scenario detail is lost: `required_actions` already carried each case's
discrimination, and the reworked contract test now asserts it there. All fifteen
relabelled cases now agree with their previously-disagreeing mirrors in the
unchanged shared forward corpus.

Two remappings — `umbrella-closeout-separately` and
`blocked-then-independent-ready`, both now `blocked` — have no mirror in that
corpus and rest on prose reading alone. Both follow the "Stop conditions" list
directly (a required open child with missing acceptance evidence; an unresolved
product decision), but they are the two worth a second opinion.

## Validation

- `just format`, `just lint`, `just test` — all clean; every one of the 14
  suites OK.
- `python3 skills/implement-ticket/scripts/evals/run_forward.py` — 58/58.
- Change-demonstrating evidence (`evidence_behavioral_test`): the new test fails
  at the base SHA naming all eleven undefined `implement-epic` labels and passes
  at the head SHA. Verified again after the final refactor by setting a corpus
  case to a fabricated state, confirming the suite fails naming it and the
  target skill, and restoring a clean tree.

### Review

Repository-owned `review-code-change`, through a fresh read-only context each
time, over three cycles:

1. `changes_required` — the outcome extraction silently exempted
   `review-code-change`'s twelve nested `result.verdict` cases, and coverage was
   hardcoded to `implement-ticket`, leaving `ready-ticket`'s and
   `carve-changesets`' harnesses unasserted. Both real; neither had a live
   violation behind it.
2. `changes_required` (code simplicity only; the other two lenses clean) —
   `undefined_states` took parallel dicts whose grouping no caller read, and
   `corpus_outcomes` encoded a composite key two consumers split back apart.
3. **`clean`** — all three lenses fresh at the final head.

One finding is deferred, not fixed: the globs are rooted at `skills/*` and match
three named shapes, so `skills/review-fix-loop`'s Python-module corpus,
`review-suite/scripts/evals/`, and `triggering/executors/` are unreached. Every
state in those surfaces was enumerated and is prose-defined today, so AC3 holds
in fact; the exposure is prospective, and the docstring states the boundary
rather than implying coverage it lacks.

### Model-behavior evidence

This change alters no `SKILL.md` and no `references/` file, so the eval-evidence
norm in `AGENTS.md` does not fire, and a fresh real-model run could not observe
it: skill prompts and `forward_expectations.json` are untouched, which the
unchanged deterministic 58/58 confirms. The corpus this change rewrites is keyed
on `workflow_state`, which no runner or executor reads, and `implement-epic` has
no executor of its own.

Refs #150
