### PR TITLE
docs: correct the eval-evidence norm's scope statement for the review-lens skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,18 +38,20 @@ changes that alter no obligation do not.
   collected, not what the registry offers.
 - **Where `just eval-record <skill>` has no corpus registered for that target**,
   it says so instead of recording something — that gap describes what the
-  recorder can drive, not whether a corpus exists at all. `review-code-change`,
-  `review-correctness`, `review-code-simplicity`, and
-  `review-solution-simplicity` are the current example:
-  `review-suite/scripts/evals/` ships six corpora that load each of those
-  skills' `SKILL.md` as `target_skill`, but its runner exposes `--artifact-dir`,
+  recorder can drive, not whether a corpus exists at all. The review-lens skills
+  are the current example: `review-suite/evals/` ships seven corpora (one under
+  `corpus/`, six under `strata/`) that load `review-code-change`,
+  `review-code-simplicity`, or `review-solution-simplicity` as `target_skill` —
+  `review-correctness`'s prose reaches the reviewer as a
+  `target_skill_dependency` of the `review-code-change`-targeted corpora rather
+  than as a directly named target — but the runner exposes `--artifact-dir`,
   `--attempts-out`, and `--report-out` rather than the `--output-dir` the
   recorder appends, and its exit codes report evaluation integrity rather than
-  case outcomes — so `just eval-record` can't drive it until that interface is
-  adapted. State the gap in the pull request, naming the corpus that already
-  exists when one does rather than reporting it as absent. Do not substitute the
-  skill's unit tests: they cannot observe `SKILL.md` prose, so a summary built
-  from them would carry no cases, no totals, and no diff.
+  case outcomes, so `just eval-record` can't drive any of them until that
+  interface is adapted. State the gap in the pull request, naming the corpus
+  that already exists when one does rather than reporting it as absent. Do not
+  substitute the skill's unit tests: they cannot observe `SKILL.md` prose, so a
+  summary built from them would carry no cases, no totals, and no diff.
 
 Record a run with:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,10 +36,20 @@ changes that alter no obligation do not.
   carries gap text stating that no model read the prose, whether or not a
   real-model executor exists for that skill: the gap describes what the run
   collected, not what the registry offers.
-- **Where the skill has no corpus at all**, `just eval-record` says so instead
-  of recording something. State that gap in the pull request. Do not substitute
-  the skill's unit tests: they cannot observe `SKILL.md` prose, so a summary
-  built from them would carry no cases, no totals, and no diff.
+- **Where `just eval-record <skill>` has no corpus registered for that target**,
+  it says so instead of recording something — that gap describes what the
+  recorder can drive, not whether a corpus exists at all. `review-code-change`,
+  `review-correctness`, `review-code-simplicity`, and
+  `review-solution-simplicity` are the current example:
+  `review-suite/scripts/evals/` ships six corpora that load each of those
+  skills' `SKILL.md` as `target_skill`, but its runner exposes `--artifact-dir`,
+  `--attempts-out`, and `--report-out` rather than the `--output-dir` the
+  recorder appends, and its exit codes report evaluation integrity rather than
+  case outcomes — so `just eval-record` can't drive it until that interface is
+  adapted. State the gap in the pull request, naming the corpus that already
+  exists when one does rather than reporting it as absent. Do not substitute the
+  skill's unit tests: they cannot observe `SKILL.md` prose, so a summary built
+  from them would carry no cases, no totals, and no diff.
 
 Record a run with:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,32 +4,49 @@ summary: Chronological history of repository and skill changes.
 
 # Changelog
 
+## 2026-08-13 — Corrected the eval-evidence norm's scope statement for the review-lens skills
+
+- docs: correct the eval-evidence norm's scope statement for the review-lens
+  skills — `AGENTS.md` told an author editing `review-code-change`,
+  `review-correctness`, `review-code-simplicity`, or
+  `review-solution-simplicity` that the skill had no corpus at all, when
+  `review-suite/scripts/evals/` ships six corpora that load each of those skills
+  as `target_skill`; the recorder just can't drive them, because the runner's
+  `--artifact-dir`, `--attempts-out`, and `--report-out` don't match the
+  `--output-dir` interface `just eval-record` appends, and its exit codes report
+  evaluation integrity rather than case outcomes. The bullet now names that
+  interface gap instead of asserting a false absence, so a review-lens author is
+  told the accurate reason `just eval-record` can't record a run rather than
+  instructed to assert a corpus doesn't exist. Adapting the runner to the
+  recorder's interface remains unregistered follow-up work, not done here.
+
 ## 2026-08-12 — Ran the writing-plans altitude experiment and found the peer preserves surface altitude rather than translating it down, closed the last gap between what the eval harness asserts and what any skill's prose defines, and settled how the shaping doctrine gets its authority: a bundled synced contract, not a new skill
 
-- docs: record the writing-plans behavioral-altitude experiment — the design
-  document posted this run as owed rather than answered, and it is now answered
-  for one session at pin `44c9b2d6e889982ac18c27d05a19fefe335194e1`. Handed a
-  greenfield spec whose seven acceptance criteria are stated purely as exit
-  codes and stdout text, `superpowers:writing-plans` returned a 1,363-line plan
-  that misses the approved criterion, which is conjunctive: all six Interfaces
-  blocks name internal function signatures with parameter and return types. That
-  half is a fixed property of the skill's own task template, which specifies the
-  block as "exact function names, parameter and return types" for a subagent
-  executor that sees only its own task — so no better-written spec removes it.
-  The second half came back mixed, and the distinction carries the finding: 8 of
-  24 planned tests drive the installed console script through a subprocess and
-  16 call imported functions, but every one of the spec's seven criteria landed
-  in those 8, confirmed by a criterion-to-test table the plan's own self-review
-  produced. The peer did not translate the spec down to unit altitude; it
-  preserved that altitude and added a lower tier beneath it, which is the
-  hypothesis the design document recorded. The run was dispatched into a context
-  told nothing about the experiment or its criterion, because a context that
-  knows what is being measured returns confirmation rather than observation. The
-  spec and the full returned plan are committed beside the report: a rerun
-  re-tests the question but will not regenerate this artifact, so the claims are
-  auditable only against what actually returned. Take-it-as-is, post-process,
-  and structure-only remain unselected — one run does not decide between them,
-  and this ticket did not authorize the choice.
+- docs: record the writing-plans behavioral-altitude experiment
+  (60092411e2e5cf8edeea938a0077047e524d60be) — the design document posted this
+  run as owed rather than answered, and it is now answered for one session at
+  pin `44c9b2d6e889982ac18c27d05a19fefe335194e1`. Handed a greenfield spec whose
+  seven acceptance criteria are stated purely as exit codes and stdout text,
+  `superpowers:writing-plans` returned a 1,363-line plan that misses the
+  approved criterion, which is conjunctive: all six Interfaces blocks name
+  internal function signatures with parameter and return types. That half is a
+  fixed property of the skill's own task template, which specifies the block as
+  "exact function names, parameter and return types" for a subagent executor
+  that sees only its own task — so no better-written spec removes it. The second
+  half came back mixed, and the distinction carries the finding: 8 of 24 planned
+  tests drive the installed console script through a subprocess and 16 call
+  imported functions, but every one of the spec's seven criteria landed in those
+  8, confirmed by a criterion-to-test table the plan's own self-review produced.
+  The peer did not translate the spec down to unit altitude; it preserved that
+  altitude and added a lower tier beneath it, which is the hypothesis the design
+  document recorded. The run was dispatched into a context told nothing about
+  the experiment or its criterion, because a context that knows what is being
+  measured returns confirmation rather than observation. The spec and the full
+  returned plan are committed beside the report: a rerun re-tests the question
+  but will not regenerate this artifact, so the claims are auditable only
+  against what actually returned. Take-it-as-is, post-process, and
+  structure-only remain unselected — one run does not decide between them, and
+  this ticket did not authorize the choice.
 
 - test: hold every eval corpus to the terminal states its skill's prose defines
   (a78141587b923d140fa41c5ca3c876ca2d740861) — a corpus state no prose names is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,12 @@ summary: Chronological history of repository and skill changes.
   skills — `AGENTS.md` told an author editing `review-code-change`,
   `review-correctness`, `review-code-simplicity`, or
   `review-solution-simplicity` that the skill had no corpus at all, when
-  `review-suite/scripts/evals/` ships six corpora that load each of those skills
-  as `target_skill`; the recorder just can't drive them, because the runner's
+  `review-suite/evals/` ships seven corpora (one under `corpus/`, six under
+  `strata/`) naming `review-code-change`, `review-code-simplicity`, or
+  `review-solution-simplicity` as `target_skill` — `review-correctness`'s prose
+  reaches the reviewer as a `target_skill_dependency` of the
+  `review-code-change`-targeted corpora rather than as a directly named target.
+  The recorder just can't drive any of them, because the runner's
   `--artifact-dir`, `--attempts-out`, and `--report-out` don't match the
   `--output-dir` interface `just eval-record` appends, and its exit codes report
   evaluation integrity rather than case outcomes. The bullet now names that


### PR DESCRIPTION
## Summary
- Reword the `AGENTS.md` eval-evidence bullet: it told a review-lens author
  their skill "has no corpus at all," when `review-suite/evals/` ships seven
  corpora (one under `corpus/`, six under `strata/`) that load
  `review-code-change`, `review-code-simplicity`, or
  `review-solution-simplicity` as `target_skill` (`review-correctness`'s prose
  reaches the reviewer as a `target_skill_dependency` of the
  `review-code-change`-targeted corpora, not as a directly named target)
- Name the actual gap instead: the recorder can't drive any of them yet,
  because `review-suite/scripts/evals/runner.py` exposes `--artifact-dir`,
  `--attempts-out`, and `--report-out` rather than the `--output-dir`
  `just eval-record` appends, and its exit codes report evaluation integrity
  rather than case outcomes — an interface gap, not a corpus gap
- Add the 2026-08-13 changelog entry and backfill the prior day's top entry
  with its full SHA per the changelog convention

## Why
Refs #149. A review-lens author was being told to assert a false gap ("no
corpus") when a corpus exists but isn't wired to the recorder's interface.
Adapting `runner.py` to that interface (the ticket's optional second half)
is left as unregistered follow-up work; this PR does the required reword and
states that remaining gap accurately with its reason.

## Test plan
- [x] `just format`
- [x] `just lint`
- [x] `just test`
- [x] Fresh read-only `review-code-change` pass on the final candidate
      (`cd1d46e` vs base `6009241`): clean aggregate verdict across
      solution-simplicity, correctness, and code-simplicity lenses, with every
      factual claim in the new prose independently verified against the repo
