### PR TITLE
feat(carve-changesets): bind changeset shape and ordering to the canonical shaping doctrine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,11 @@ summary: Chronological history of repository and skill changes.
   behavior rule with its PR-naming requirement, wide-refactor isolation,
   feature-flag policy, and the database-migration rules, none of which the
   doctrine carries because they constrain an ordered sequence of merges rather
-  than shape in general. Two of the doctrine's breakdown rules are scoped out as
-  planning-time rather than carving-time; the rest apply directly. The binding
+  than shape in general. Three of the doctrine's eight breakdown rules are
+  scoped out of boundary selection — two addressed to planning, and the one the
+  doctrine itself calls downstream, which a carve discharges by surfacing new
+  scope through its stop conditions rather than by mutating a tracker it has no
+  authority to touch — leaving five that govern boundaries directly. The binding
   reaches an evaluated run rather than stopping at prose: the eval runner now
   ships the doctrine as a contract document and the fixture gate requires its
   text, so a run that does not receive it blocks instead of carving to an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,13 @@ summary: Chronological history of repository and skill changes.
   improvised standard — verified by driving the executor with and without it.
   Two provisions the local guardrails never had now apply to carving: mechanical
   change runs much larger, and recorded machine-generated evidence is excluded
-  from the size judgment outright.
+  from the size judgment outright. Retiring the section also retired its anchor,
+  and `implement-ticket`'s carve handoff was the one place in the tree linking
+  to it; that link is retargeted here rather than left dangling until the
+  publication-size-gate leaf rewrites the paragraph. The obligation it states is
+  unchanged, so the edit is editorial and carries no eval evidence of its own.
+  `implement-ticket`'s two remaining prose mentions of the old section name are
+  descriptions rather than links and are left to that leaf.
 
 ## 2026-08-14 — Named cognitive debt as the problem the suite exists to solve, then specified, published, and distributed the cognitive prose contract that answers its prose half
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,44 @@ summary: Chronological history of repository and skill changes.
 
 # Changelog
 
+## 2026-08-15 — Retired carve-changesets' duplicate shaping rules in favor of the canonical doctrine
+
+- feat(carve-changesets): bind changeset shape and ordering to the canonical
+  doctrine — `references/SPEC.md` carried its own cognitive-load guardrails and
+  decomposition-order list, a second codification of rules
+  `docs/cognitive-shaping-doctrine.md` already owns, and a doctrine with two
+  homes has no home. Both sections retire in favor of the bundled doctrine,
+  distributed by `just sync-contracts` and drift-checked byte-for-byte under
+  `just test` — the same mechanism `review-solution-simplicity` adopted, and the
+  one `docs/cognitive-driven-development.md` records as the selected shaping
+  authority. What survives locally is carving-specific: the rename-accompanies-
+  behavior rule with its PR-naming requirement, wide-refactor isolation,
+  feature-flag policy, and the database-migration rules, none of which the
+  doctrine carries because they constrain an ordered sequence of merges rather
+  than shape in general. Two of the doctrine's breakdown rules are scoped out as
+  planning-time rather than carving-time; the rest apply directly. The binding
+  reaches an evaluated run rather than stopping at prose: the eval runner now
+  ships the doctrine as a contract document and the fixture gate requires its
+  text, so a run that does not receive it blocks instead of carving to an
+  improvised standard — verified by driving the executor with and without it.
+  Two provisions the local guardrails never had now apply to carving: mechanical
+  change runs much larger, and recorded machine-generated evidence is excluded
+  from the size judgment outright.
+
 ## 2026-08-14 — Named cognitive debt as the problem the suite exists to solve, then specified, published, and distributed the cognitive prose contract that answers its prose half
 
 - test: bind the prose contract's sync recipe to the skills its drift check
-  names — every drift failure tells a reader to run `just sync-contracts`, and
-  nothing held that recipe to the skill list the check asserts, so dropping a
-  skill from it left a stale bundled copy no test would catch. The new assertion
-  is scoped to the block that copies `docs/cognitive-prose.md` rather than
-  searching the whole recipe, because every bundling skill is named in other
-  blocks too: a whole-file substring check — the form the sibling
-  `test_cognitive_shaping_doctrine.py` uses — still passes after a skill is
-  dropped from the prose block, which was verified rather than assumed. The
-  guard was verified capable of failing on that exact mutation. The sibling
-  module carries the same latent weakness; it is not touched here.
+  names (cb712926c7090d12e18d180c81d219c1c03db600) — every drift failure tells a
+  reader to run `just sync-contracts`, and nothing held that recipe to the skill
+  list the check asserts, so dropping a skill from it left a stale bundled copy
+  no test would catch. The new assertion is scoped to the block that copies
+  `docs/cognitive-prose.md` rather than searching the whole recipe, because
+  every bundling skill is named in other blocks too: a whole-file substring
+  check — the form the sibling `test_cognitive_shaping_doctrine.py` uses — still
+  passes after a skill is dropped from the prose block, which was verified
+  rather than assumed. The guard was verified capable of failing on that exact
+  mutation. The sibling module carries the same latent weakness; it is not
+  touched here.
 
 - docs: complete the changelog's record of its own repair
   (e9c8cc59cc288103f308b1da54cc630dae4d19f3) — the previous commit added the

--- a/justfile
+++ b/justfile
@@ -38,7 +38,7 @@ sync-contracts:
     cp review-suite/scripts/tests/test_review_gate.py "$tests_dest/test_review_gate.py"; \
     echo "Synced $scripts_dest/review_gate.py and $tests_dest/test_review_gate.py"; \
   done
-  @for skill in review-solution-simplicity; do \
+  @for skill in review-solution-simplicity carve-changesets; do \
     dest="{{skills_dir}}/$skill/references"; \
     mkdir -p "$dest"; \
     cp docs/cognitive-shaping-doctrine.md "$dest/cognitive-shaping-doctrine.md"; \

--- a/scripts/tests/test_cognitive_shaping_doctrine.py
+++ b/scripts/tests/test_cognitive_shaping_doctrine.py
@@ -30,7 +30,7 @@ JUSTFILE = REPOSITORY_ROOT / "justfile"
 # Skills that load the doctrine rather than restating it. Each bundles the
 # canonical text so it still resolves when the skill is installed outside this
 # repository, exactly as `review-suite/` is bundled today.
-BUNDLING_SKILLS = ("review-solution-simplicity",)
+BUNDLING_SKILLS = ("review-solution-simplicity", "carve-changesets")
 BUNDLED_NAME = "cognitive-shaping-doctrine.md"
 
 # The doctrine is compris's own claim. It names no upstream project, because

--- a/scripts/validate_plugins.py
+++ b/scripts/validate_plugins.py
@@ -37,7 +37,7 @@ REVIEW_BUNDLE_FILES = {
 }
 # The lenses that judge shape load the canonical doctrine rather than restating
 # it, so a package that ships one without the other ships a dangling citation.
-DOCTRINE_BUNDLING_SKILLS = {"review-solution-simplicity"}
+DOCTRINE_BUNDLING_SKILLS = {"review-solution-simplicity", "carve-changesets"}
 DOCTRINE_NAME = "cognitive-shaping-doctrine.md"
 
 

--- a/skills/carve-changesets/SKILL.md
+++ b/skills/carve-changesets/SKILL.md
@@ -21,6 +21,14 @@ without copying either skill's workflow.
 
 - Always read [the normative contract](references/SPEC.md) before planning or
   mutating a chain.
+- Always read
+  [the cognitive shaping doctrine](references/cognitive-shaping-doctrine.md)
+  before proposing or revising a changeset boundary. It is compris's canonical
+  statement of when a unit of work is correctly shaped, bundled here from the
+  repository-root `docs/` copy and kept byte-identical to it. Cite it for every
+  shape and ordering judgment; this skill does not restate, extend, or locally
+  override the standard. Return `blocked` with the missing dependency when the
+  doctrine is unavailable, and do not invent or copy a local replacement.
 - Read [the plan schema](references/plan-schema.md) before creating or editing
   `.carve-changesets/plan.json`.
 - Read [the CLI reference](references/cli.md) before invoking a subcommand or
@@ -73,9 +81,9 @@ Before mutation, discover or receive and verify:
   interfaces, migrations, and rollout properties the final chain must preserve;
 - explicitly approved argv arrays for tests and any required database, build,
   integration, or manual validation commands;
-- cognitive-load guardrails, acceptable intermediate states, decomposition
-  order, feature-flag policy, and database-migration requirements from the
-  normative contract;
+- changeset shape and decomposition order from the bundled doctrine, and
+  acceptable intermediate states, feature-flag policy, and database-migration
+  requirements from the normative contract;
 - the requested terminal boundary: proposal only, local chain, published PRs, or
   fully merged chain; and
 - authority for local decomposition, validation execution, publication,

--- a/skills/carve-changesets/evals/results/2026-08-15T154025Z-0014-before.json
+++ b/skills/carve-changesets/evals/results/2026-08-15T154025Z-0014-before.json
@@ -1,0 +1,166 @@
+{
+  "candidate": {
+    "branch": "scott/ticket-187-shaping-doctrine",
+    "sha": "cb712926c7090d12e18d180c81d219c1c03db600",
+    "tree": "4595192a3d818b38e1d36f1c561223220cd2bd70",
+    "worktree_clean": true
+  },
+  "case_evidence": {
+    "decompose-independent-subsystems": {
+      "actions": [
+        "split_by_subsystem"
+      ],
+      "executor_pid": 70177,
+      "target_skill": "carve-changesets",
+      "terminal_state": "plan_ready"
+    },
+    "mechanical-guardrail-exception": {
+      "actions": [
+        "accept_mechanical_exception",
+        "document_exception_evidence"
+      ],
+      "executor_pid": 70180,
+      "target_skill": "carve-changesets",
+      "terminal_state": "plan_ready"
+    },
+    "oversized-guardrail-negotiation": {
+      "actions": [
+        "request_guardrail_decision",
+        "stop_for_oversized_changeset"
+      ],
+      "executor_pid": 70179,
+      "target_skill": "carve-changesets",
+      "terminal_state": "blocked"
+    },
+    "publish-with-merge-withheld": {
+      "actions": [
+        "publish_without_merge",
+        "withhold_merge"
+      ],
+      "executor_pid": 70184,
+      "target_skill": "carve-changesets",
+      "terminal_state": "prs_open"
+    },
+    "recover-successor-suffix": {
+      "actions": [
+        "create_successor_lineage",
+        "invalidate_candidate_evidence",
+        "recover_owned_suffix_with_exact_lease",
+        "rehandoff_babysit_pr",
+        "verify_merged_prefix",
+        "verify_successor_equivalence"
+      ],
+      "executor_pid": 70187,
+      "target_skill": "carve-changesets",
+      "terminal_state": "all_merged"
+    },
+    "refuse-dirty-source": {
+      "actions": [
+        "diagnose_dirty_tree",
+        "refuse_dirty_source"
+      ],
+      "executor_pid": 70185,
+      "target_skill": "carve-changesets",
+      "terminal_state": "blocked"
+    },
+    "refuse-source-behind-base": {
+      "actions": [
+        "diagnose_source_behind_base",
+        "refuse_source_behind_base"
+      ],
+      "executor_pid": 70186,
+      "target_skill": "carve-changesets",
+      "terminal_state": "blocked"
+    },
+    "refuse-validated-reorder": {
+      "actions": [
+        "preserve_validated_order",
+        "refuse_reorder_or_renumber"
+      ],
+      "executor_pid": 70181,
+      "target_skill": "carve-changesets",
+      "terminal_state": "blocked"
+    },
+    "reject-conflicting-successor-lineage": {
+      "actions": [
+        "preserve_partial_chain",
+        "reject_conflicting_lineage",
+        "reject_unexpected_suffix_head"
+      ],
+      "executor_pid": 70188,
+      "target_skill": "carve-changesets",
+      "terminal_state": "blocked"
+    },
+    "reject-original-source-mutation": {
+      "actions": [
+        "reject_original_source_mutation",
+        "require_distinct_successor_source"
+      ],
+      "executor_pid": 70189,
+      "target_skill": "carve-changesets",
+      "terminal_state": "blocked"
+    },
+    "separate-mechanical-rename": {
+      "actions": [
+        "separate_rename_from_behavior"
+      ],
+      "executor_pid": 70178,
+      "target_skill": "carve-changesets",
+      "terminal_state": "plan_ready"
+    },
+    "validated-plan-conflict": {
+      "actions": [
+        "escalate_material_decision",
+        "stop_on_plan_conflict"
+      ],
+      "executor_pid": 70183,
+      "target_skill": "carve-changesets",
+      "terminal_state": "blocked"
+    }
+  },
+  "cases": {
+    "decompose-independent-subsystems": "pass",
+    "mechanical-guardrail-exception": "pass",
+    "oversized-guardrail-negotiation": "pass",
+    "publish-with-merge-withheld": "pass",
+    "recover-successor-suffix": "pass",
+    "refuse-dirty-source": "pass",
+    "refuse-source-behind-base": "pass",
+    "refuse-validated-reorder": "pass",
+    "reject-conflicting-successor-lineage": "pass",
+    "reject-original-source-mutation": "pass",
+    "separate-mechanical-rename": "pass",
+    "validated-plan-conflict": "pass"
+  },
+  "command": [
+    "/Users/scott/.local/share/mise/installs/python/3.11/bin/python3",
+    "skills/carve-changesets/scripts/evals/runner.py"
+  ],
+  "compared_to": "2026-08-08T145453Z-0013-after.json",
+  "diff": {
+    "newly_failing": [],
+    "newly_passing": [],
+    "still_failing": [],
+    "unchanged": 12
+  },
+  "exit_code": 0,
+  "failures": [],
+  "forward_evals": false,
+  "gap": "recorded tier is deterministic, so no model read the prose and the model-behavior evidence is absent No real-model executor is registered for this skill, so this tier is the only one available here.",
+  "limitation": null,
+  "model": null,
+  "note": null,
+  "output_tail": "{\n  \"failed\": 0,\n  \"failures\": [],\n  \"mode\": \"forward\",\n  \"passed\": 12,\n  \"total\": 12\n}",
+  "recorded_at": "2026-08-15T15:40:25Z",
+  "schema": "eval-run-summary/1",
+  "skill": "carve-changesets",
+  "stage": "before",
+  "status": "completed",
+  "suite": "forward",
+  "tier": "deterministic",
+  "totals": {
+    "failed": 0,
+    "passed": 12,
+    "total": 12
+  }
+}

--- a/skills/carve-changesets/evals/results/2026-08-15T154924Z-0015-after.json
+++ b/skills/carve-changesets/evals/results/2026-08-15T154924Z-0015-after.json
@@ -1,0 +1,166 @@
+{
+  "candidate": {
+    "branch": "scott/ticket-187-shaping-doctrine",
+    "sha": "0520f8676773108a57506c44f68724859ca5fd0e",
+    "tree": "9db3f1e551768aa5b6cca81f23829b993b32765f",
+    "worktree_clean": true
+  },
+  "case_evidence": {
+    "decompose-independent-subsystems": {
+      "actions": [
+        "split_by_subsystem"
+      ],
+      "executor_pid": 99339,
+      "target_skill": "carve-changesets",
+      "terminal_state": "plan_ready"
+    },
+    "mechanical-guardrail-exception": {
+      "actions": [
+        "accept_mechanical_exception",
+        "document_exception_evidence"
+      ],
+      "executor_pid": 99342,
+      "target_skill": "carve-changesets",
+      "terminal_state": "plan_ready"
+    },
+    "oversized-guardrail-negotiation": {
+      "actions": [
+        "request_guardrail_decision",
+        "stop_for_oversized_changeset"
+      ],
+      "executor_pid": 99341,
+      "target_skill": "carve-changesets",
+      "terminal_state": "blocked"
+    },
+    "publish-with-merge-withheld": {
+      "actions": [
+        "publish_without_merge",
+        "withhold_merge"
+      ],
+      "executor_pid": 99345,
+      "target_skill": "carve-changesets",
+      "terminal_state": "prs_open"
+    },
+    "recover-successor-suffix": {
+      "actions": [
+        "create_successor_lineage",
+        "invalidate_candidate_evidence",
+        "recover_owned_suffix_with_exact_lease",
+        "rehandoff_babysit_pr",
+        "verify_merged_prefix",
+        "verify_successor_equivalence"
+      ],
+      "executor_pid": 99348,
+      "target_skill": "carve-changesets",
+      "terminal_state": "all_merged"
+    },
+    "refuse-dirty-source": {
+      "actions": [
+        "diagnose_dirty_tree",
+        "refuse_dirty_source"
+      ],
+      "executor_pid": 99346,
+      "target_skill": "carve-changesets",
+      "terminal_state": "blocked"
+    },
+    "refuse-source-behind-base": {
+      "actions": [
+        "diagnose_source_behind_base",
+        "refuse_source_behind_base"
+      ],
+      "executor_pid": 99347,
+      "target_skill": "carve-changesets",
+      "terminal_state": "blocked"
+    },
+    "refuse-validated-reorder": {
+      "actions": [
+        "preserve_validated_order",
+        "refuse_reorder_or_renumber"
+      ],
+      "executor_pid": 99343,
+      "target_skill": "carve-changesets",
+      "terminal_state": "blocked"
+    },
+    "reject-conflicting-successor-lineage": {
+      "actions": [
+        "preserve_partial_chain",
+        "reject_conflicting_lineage",
+        "reject_unexpected_suffix_head"
+      ],
+      "executor_pid": 99349,
+      "target_skill": "carve-changesets",
+      "terminal_state": "blocked"
+    },
+    "reject-original-source-mutation": {
+      "actions": [
+        "reject_original_source_mutation",
+        "require_distinct_successor_source"
+      ],
+      "executor_pid": 99350,
+      "target_skill": "carve-changesets",
+      "terminal_state": "blocked"
+    },
+    "separate-mechanical-rename": {
+      "actions": [
+        "separate_rename_from_behavior"
+      ],
+      "executor_pid": 99340,
+      "target_skill": "carve-changesets",
+      "terminal_state": "plan_ready"
+    },
+    "validated-plan-conflict": {
+      "actions": [
+        "escalate_material_decision",
+        "stop_on_plan_conflict"
+      ],
+      "executor_pid": 99344,
+      "target_skill": "carve-changesets",
+      "terminal_state": "blocked"
+    }
+  },
+  "cases": {
+    "decompose-independent-subsystems": "pass",
+    "mechanical-guardrail-exception": "pass",
+    "oversized-guardrail-negotiation": "pass",
+    "publish-with-merge-withheld": "pass",
+    "recover-successor-suffix": "pass",
+    "refuse-dirty-source": "pass",
+    "refuse-source-behind-base": "pass",
+    "refuse-validated-reorder": "pass",
+    "reject-conflicting-successor-lineage": "pass",
+    "reject-original-source-mutation": "pass",
+    "separate-mechanical-rename": "pass",
+    "validated-plan-conflict": "pass"
+  },
+  "command": [
+    "/Users/scott/.local/share/mise/installs/python/3.11/bin/python3",
+    "skills/carve-changesets/scripts/evals/runner.py"
+  ],
+  "compared_to": "2026-08-15T154025Z-0014-before.json",
+  "diff": {
+    "newly_failing": [],
+    "newly_passing": [],
+    "still_failing": [],
+    "unchanged": 12
+  },
+  "exit_code": 0,
+  "failures": [],
+  "forward_evals": false,
+  "gap": "recorded tier is deterministic, so no model read the prose and the model-behavior evidence is absent No real-model executor is registered for this skill, so this tier is the only one available here.",
+  "limitation": null,
+  "model": null,
+  "note": null,
+  "output_tail": "{\n  \"failed\": 0,\n  \"failures\": [],\n  \"mode\": \"forward\",\n  \"passed\": 12,\n  \"total\": 12\n}",
+  "recorded_at": "2026-08-15T15:49:24Z",
+  "schema": "eval-run-summary/1",
+  "skill": "carve-changesets",
+  "stage": "after",
+  "status": "completed",
+  "suite": "forward",
+  "tier": "deterministic",
+  "totals": {
+    "failed": 0,
+    "passed": 12,
+    "total": 12
+  }
+}

--- a/skills/carve-changesets/evals/results/2026-08-15T164921Z-0016-after.json
+++ b/skills/carve-changesets/evals/results/2026-08-15T164921Z-0016-after.json
@@ -1,0 +1,166 @@
+{
+  "candidate": {
+    "branch": "scott/ticket-187-shaping-doctrine",
+    "sha": "ada40a586eb4d5dca87eb91e78874f50a003873e",
+    "tree": "e406264a9a98278af2c8e066d7f392de0f8220b9",
+    "worktree_clean": true
+  },
+  "case_evidence": {
+    "decompose-independent-subsystems": {
+      "actions": [
+        "split_by_subsystem"
+      ],
+      "executor_pid": 31684,
+      "target_skill": "carve-changesets",
+      "terminal_state": "plan_ready"
+    },
+    "mechanical-guardrail-exception": {
+      "actions": [
+        "accept_mechanical_exception",
+        "document_exception_evidence"
+      ],
+      "executor_pid": 31687,
+      "target_skill": "carve-changesets",
+      "terminal_state": "plan_ready"
+    },
+    "oversized-guardrail-negotiation": {
+      "actions": [
+        "request_guardrail_decision",
+        "stop_for_oversized_changeset"
+      ],
+      "executor_pid": 31686,
+      "target_skill": "carve-changesets",
+      "terminal_state": "blocked"
+    },
+    "publish-with-merge-withheld": {
+      "actions": [
+        "publish_without_merge",
+        "withhold_merge"
+      ],
+      "executor_pid": 31690,
+      "target_skill": "carve-changesets",
+      "terminal_state": "prs_open"
+    },
+    "recover-successor-suffix": {
+      "actions": [
+        "create_successor_lineage",
+        "invalidate_candidate_evidence",
+        "recover_owned_suffix_with_exact_lease",
+        "rehandoff_babysit_pr",
+        "verify_merged_prefix",
+        "verify_successor_equivalence"
+      ],
+      "executor_pid": 31693,
+      "target_skill": "carve-changesets",
+      "terminal_state": "all_merged"
+    },
+    "refuse-dirty-source": {
+      "actions": [
+        "diagnose_dirty_tree",
+        "refuse_dirty_source"
+      ],
+      "executor_pid": 31691,
+      "target_skill": "carve-changesets",
+      "terminal_state": "blocked"
+    },
+    "refuse-source-behind-base": {
+      "actions": [
+        "diagnose_source_behind_base",
+        "refuse_source_behind_base"
+      ],
+      "executor_pid": 31692,
+      "target_skill": "carve-changesets",
+      "terminal_state": "blocked"
+    },
+    "refuse-validated-reorder": {
+      "actions": [
+        "preserve_validated_order",
+        "refuse_reorder_or_renumber"
+      ],
+      "executor_pid": 31688,
+      "target_skill": "carve-changesets",
+      "terminal_state": "blocked"
+    },
+    "reject-conflicting-successor-lineage": {
+      "actions": [
+        "preserve_partial_chain",
+        "reject_conflicting_lineage",
+        "reject_unexpected_suffix_head"
+      ],
+      "executor_pid": 31694,
+      "target_skill": "carve-changesets",
+      "terminal_state": "blocked"
+    },
+    "reject-original-source-mutation": {
+      "actions": [
+        "reject_original_source_mutation",
+        "require_distinct_successor_source"
+      ],
+      "executor_pid": 31695,
+      "target_skill": "carve-changesets",
+      "terminal_state": "blocked"
+    },
+    "separate-mechanical-rename": {
+      "actions": [
+        "separate_rename_from_behavior"
+      ],
+      "executor_pid": 31685,
+      "target_skill": "carve-changesets",
+      "terminal_state": "plan_ready"
+    },
+    "validated-plan-conflict": {
+      "actions": [
+        "escalate_material_decision",
+        "stop_on_plan_conflict"
+      ],
+      "executor_pid": 31689,
+      "target_skill": "carve-changesets",
+      "terminal_state": "blocked"
+    }
+  },
+  "cases": {
+    "decompose-independent-subsystems": "pass",
+    "mechanical-guardrail-exception": "pass",
+    "oversized-guardrail-negotiation": "pass",
+    "publish-with-merge-withheld": "pass",
+    "recover-successor-suffix": "pass",
+    "refuse-dirty-source": "pass",
+    "refuse-source-behind-base": "pass",
+    "refuse-validated-reorder": "pass",
+    "reject-conflicting-successor-lineage": "pass",
+    "reject-original-source-mutation": "pass",
+    "separate-mechanical-rename": "pass",
+    "validated-plan-conflict": "pass"
+  },
+  "command": [
+    "/Users/scott/.local/share/mise/installs/python/3.11/bin/python3",
+    "skills/carve-changesets/scripts/evals/runner.py"
+  ],
+  "compared_to": "2026-08-15T154924Z-0015-after.json",
+  "diff": {
+    "newly_failing": [],
+    "newly_passing": [],
+    "still_failing": [],
+    "unchanged": 12
+  },
+  "exit_code": 0,
+  "failures": [],
+  "forward_evals": false,
+  "gap": "recorded tier is deterministic, so no model read the prose and the model-behavior evidence is absent No real-model executor is registered for this skill, so this tier is the only one available here.",
+  "limitation": null,
+  "model": null,
+  "note": null,
+  "output_tail": "{\n  \"failed\": 0,\n  \"failures\": [],\n  \"mode\": \"forward\",\n  \"passed\": 12,\n  \"total\": 12\n}",
+  "recorded_at": "2026-08-15T16:49:21Z",
+  "schema": "eval-run-summary/1",
+  "skill": "carve-changesets",
+  "stage": "after",
+  "status": "completed",
+  "suite": "forward",
+  "tier": "deterministic",
+  "totals": {
+    "failed": 0,
+    "passed": 12,
+    "total": 12
+  }
+}

--- a/skills/carve-changesets/references/SPEC.md
+++ b/skills/carve-changesets/references/SPEC.md
@@ -94,12 +94,18 @@ machine-generated evidence is excluded outright, so a changeset carrying
 committed eval results, generated fixtures, or lockfiles is measured by its
 reviewable remainder.
 
-Two of its breakdown rules are addressed to planning rather than to carving:
-identifying re-split triggers before implementation, and keeping an initiative
-executable as one ticket when it is already reviewable. A carve begins after
-both were decided upstream. Every other rule governs changeset boundaries
-directly, and never decomposing to a single child is the floor for a chain — a
-one-changeset chain is not a decomposition.
+Three of its breakdown rules are not boundary-selection rules here. Identifying
+re-split triggers before implementation and keeping an initiative executable as
+one ticket when it is already reviewable are addressed to planning, and a carve
+begins after both were decided upstream. Creating follow-up work when
+implementation or review reveals new scope is the doctrine's one downstream
+rule: a carve discharges it by surfacing the new scope through the stop
+conditions below, never by creating or editing tracker work, which no authority
+level in this contract permits.
+
+The remaining five govern changeset boundaries directly, and never decomposing
+to a single child is the floor for a chain — a one-changeset chain is not a
+decomposition.
 
 The rest of this section is carving-specific. It constrains an ordered sequence
 of merges rather than shape in general, so it has no canonical home elsewhere.

--- a/skills/carve-changesets/references/SPEC.md
+++ b/skills/carve-changesets/references/SPEC.md
@@ -70,29 +70,39 @@ file-complete policy must include every hunk for a selected file. Pure
 rename-only changes should use a rename-aware path or patch mechanism rather
 than a textual-hunk mechanism that loses rename intent.
 
-#### Cognitive-load guardrails
+#### Changeset shape and decomposition order
 
-Changesets are sized to minimize reviewer cognitive load, not to meet an
-arbitrary line-count target.
+[The cognitive shaping doctrine](cognitive-shaping-doctrine.md) is compris's
+canonical statement of when a unit of work is correctly shaped, and it decides
+both how large a changeset may be and what order the chain runs in. It is
+bundled here from the repository-root `docs/` copy and kept byte-identical to
+it. Apply its standard, its scale calibration, and its breakdown rules as
+written. This contract does not restate, extend, or locally override them, and a
+boundary defended by a size figure supplied here is defending a rule that no
+longer exists.
 
-- A few hundred new or changed lines is the preferred range.
-- Raw deletion volume carries less cognitive cost when the reason for removal
-  and the replacement or obsoleting behavior are clear.
-- Larger changesets are acceptable for demonstrably mechanical refactors,
-  systematic renames, or low-semantic-impact changes.
-- Cohesiveness and independent reviewability override line count.
+Its standard is what a reviewer can hold: a changeset is correctly shaped when a
+reviewer can construct an accurate mental model of it and evaluate it
+independently. Size informs that judgment and never decides it, so justify each
+boundary by the concepts, states, and ownership it asks a reviewer to hold.
 
-#### Decomposition order
+Two of the doctrine's scale provisions decide most carving questions and are the
+easiest to lose. Mechanical change — a systematic rename, a codemod, a
+formatting pass — runs much larger without violating the standard, because the
+reviewer verifies one transformation instead of reading every line. And recorded
+machine-generated evidence is excluded outright, so a changeset carrying
+committed eval results, generated fixtures, or lockfiles is measured by its
+reviewable remainder.
 
-Decomposition must prefer:
+Two of its breakdown rules are addressed to planning rather than to carving:
+identifying re-split triggers before implementation, and keeping an initiative
+executable as one ticket when it is already reviewable. A carve begins after
+both were decided upstream. Every other rule governs changeset boundaries
+directly, and never decomposing to a single child is the floor for a chain — a
+one-changeset chain is not a decomposition.
 
-1. additive foundations before consumers, modifications, removals, or
-   user-visible cutovers;
-2. rename-only or mechanical changes before behavioral changes when doing so
-   materially reduces diff noise;
-3. internal, non-exposed behavior before public API or user-visible behavior;
-   and
-4. one concern per changeset over mixed unrelated work.
+The rest of this section is carving-specific. It constrains an ordered sequence
+of merges rather than shape in general, so it has no canonical home elsewhere.
 
 Renames may accompany behavior only when separation would increase cognitive
 load or create an incoherent intermediate state. The affected PR must then name

--- a/skills/carve-changesets/references/cognitive-shaping-doctrine.md
+++ b/skills/carve-changesets/references/cognitive-shaping-doctrine.md
@@ -1,0 +1,112 @@
+# Cognitive shaping doctrine
+
+This is compris's doctrine of cognitive shaping: work is broken apart by what a
+reviewer can understand, and that is the binding constraint rather than a nicety
+observed when there is time.
+
+[cognitive-debt.md] states the problem this answers — the theory of a program
+decaying out of human minds while agents write the code. This document is the
+statement of the standard itself, and [cognitive-driven-development.md] records
+the program behind it and the decisions that shaped it.
+
+## The standard
+
+A unit of work is correctly shaped when a reviewer can construct an accurate
+mental model of the change and evaluate it independently.
+
+Line counts inform that judgment. They never decide it.
+
+The mental model is the reason for the standard, not the receipt for it. It is
+what lets a reviewer approve the change in front of them, and it is also what
+lets them direct the work that comes next — a human without a current theory of
+the system can only accept or reject what is proposed to them. Shape is judged
+against the first use because that one is observable. It is worth having for
+both.
+
+## Scale
+
+A changeset is sized to be read in one sitting, and most that meet the standard
+run to a few hundred changed lines. Both figures are calibration, not a gate:
+they say where the standard usually lands, not where it is enforced.
+
+Three things move the number without moving the standard.
+
+- Deletion costs less than addition, once the reason for the removal and the
+  behavior replacing it are clear.
+- Mechanical change — a systematic rename, a codemod, a formatting pass — runs
+  much larger, because the reviewer verifies one transformation instead of
+  reading every line.
+- Recorded machine-generated evidence is excluded outright. Committed eval
+  results, generated fixtures, and lockfiles are part of the change and part of
+  nothing anyone reads. A change carrying 177 reviewable lines and 4,538 lines
+  of recorded eval results is a 177-line change.
+
+Falling outside the range is not itself a defect. It is where the standard's
+question stops being rhetorical and has to be asked deliberately.
+
+## The breakdown rules
+
+- Keep an initiative executable as one ticket when it is already reviewable.
+- Never decompose to a single child.
+- Separate unrelated concern domains.
+- Prefer additive foundations before disruptive transitions.
+- Separate mechanical restructuring from behavioral change when that helps
+  review.
+- Keep validation with the behavior it proves.
+- Identify re-split triggers before implementation.
+- Create follow-up work when implementation or review reveals new scope.
+
+One ticket is a legal outcome, and it is the whole of the single-unit case. A
+leaf is a unit of work; a parent groups leaves into a milestone, a goal, or a
+larger initiative. A parent holding one child is neither — it represents nothing
+its child does not already represent, and it costs a level of indirection to say
+so. Where the work fits one ticket the first rule applies and no parent is
+created, which leaves the second nothing to permit.
+
+Both rules exist to outrank the impulse to decompose. A breakdown that splits
+because splitting is what a breakdown does buys review overhead and nothing
+else.
+
+Creating follow-up work is the one rule that applies downstream. It is
+discharged when implementation or review reveals the new scope, not when the
+breakdown is authored.
+
+## Vocabulary
+
+| Logical    | Realized     |
+| ---------- | ------------ |
+| initiative | epic         |
+| changeset  | pull request |
+
+A leaf ticket is a child of an epic, scoped to one changeset. Doctrine,
+contracts, and handoffs speak in the logical nouns; descriptions and tracker
+items use the realized ones, because that is what people type.
+
+## Enforcement
+
+Shape is always judged. Whether the judgment gates anything is the consuming
+project's decision — judging is read-only, and acting on a verdict is policy.
+
+The obligation is asymmetric, deliberately. Planning always aims at a shaped
+plan: every leaf ticket is scoped to what is predicted to be one changeset,
+realized as one pull request. Correcting that prediction once implementation is
+under way is not required. Carving an oversized branch into a reviewable chain
+is available and never automatic — a decision the project makes deliberately or
+declines, never one taken silently on its behalf.
+
+So a carved stack is a falsified prediction, recorded. Developers are bad at
+estimating; the answer is measurement, not accuracy — and a project that
+measures without correcting still gets the measurement.
+
+## Consumers
+
+This doctrine governs shape judgment in:
+
+- `carve-changesets`, for changeset boundaries;
+- `review-solution-simplicity`, for whole-solution complexity; and
+- `implement-ticket`, at the publication size gate.
+
+<!-- inline reference link definitions. please keep alphabetized -->
+
+[cognitive-debt.md]: https://github.com/shaug/compris/blob/main/docs/cognitive-debt.md
+[cognitive-driven-development.md]: https://github.com/shaug/compris/blob/main/docs/cognitive-driven-development.md

--- a/skills/carve-changesets/scripts/evals/fixture_executor.py
+++ b/skills/carve-changesets/scripts/evals/fixture_executor.py
@@ -22,7 +22,10 @@ def action_result(payload: dict) -> dict:
     )
     required_contract = (
         "independently reviewable",
-        "mechanical refactors",
+        # Unique to the canonical doctrine. Shape and ordering rules live there
+        # now, so a payload without this fragment is a run carving to no
+        # standard at all — which must block rather than improvise one.
+        "line counts inform that judgment. they never decide it.",
         "not silently reordered or renumbered",
         "publish authority does not permit merging",
         "source is behind the base",

--- a/skills/carve-changesets/scripts/evals/runner.py
+++ b/skills/carve-changesets/scripts/evals/runner.py
@@ -39,6 +39,12 @@ def skill_prompt() -> str:
 def contract_documents() -> dict[str, str]:
     return {
         "SPEC.md": (SKILL_ROOT / "references" / "SPEC.md").read_text(),
+        # SPEC.md cites the doctrine for shape and ordering rather than
+        # restating it, so a run that does not receive the doctrine is missing
+        # the rules it is graded against, not merely a reference.
+        "cognitive-shaping-doctrine.md": (
+            SKILL_ROOT / "references" / "cognitive-shaping-doctrine.md"
+        ).read_text(),
         "suite-handoffs.md": (
             SKILL_ROOT / "references" / "suite-handoffs.md"
         ).read_text(),

--- a/skills/carve-changesets/scripts/tests/test_skill_contract.py
+++ b/skills/carve-changesets/scripts/tests/test_skill_contract.py
@@ -174,6 +174,22 @@ class CarveChangesetsContractTests(unittest.TestCase):
             with self.subTest(constraint=constraint):
                 self.assertIn(constraint, self.spec)
 
+    def test_the_downstream_breakdown_rule_is_not_scoped_into_boundary_choice(self):
+        """The doctrine calls creating follow-up work its one downstream rule.
+        Sweeping it in with the boundary rules both contradicts the bundled
+        text and points a carve at a tracker mutation no authority level here
+        grants."""
+        doctrine = (SKILL_ROOT / "references" / DOCTRINE_NAME).read_text()
+        self.assertIn(
+            "Creating follow-up work is the one rule that applies downstream",
+            compact(doctrine),
+        )
+        self.assertIn("the doctrine's one downstream rule", self.spec)
+        self.assertIn("never by creating or editing tracker work", self.spec)
+        self.assertNotIn(
+            "Every other rule governs changeset boundaries directly", self.spec
+        )
+
     def test_an_evaluated_run_receives_the_doctrine_as_a_contract_document(self):
         """A citation the run never loads is not a binding. The eval harness is
         where 'a run applies the doctrine' becomes observable."""

--- a/skills/carve-changesets/scripts/tests/test_skill_contract.py
+++ b/skills/carve-changesets/scripts/tests/test_skill_contract.py
@@ -13,6 +13,40 @@ from pathlib import Path
 
 SKILL_ROOT = Path(__file__).resolve().parents[2]
 
+DOCTRINE_NAME = "cognitive-shaping-doctrine.md"
+
+# The generic rules the contract codified before the doctrine was bound. Each
+# one now has a canonical home; leaving any behind rebuilds the second home the
+# binding exists to remove, and a second home drifts.
+RETIRED_GENERIC_RULES = (
+    "A few hundred new or changed lines is the preferred range",
+    "Raw deletion volume carries less cognitive cost",
+    "Larger changesets are acceptable for demonstrably mechanical refactors",
+    "Cohesiveness and independent reviewability override line count",
+    "additive foundations before consumers, modifications, removals, or"
+    " user-visible cutovers",
+    "internal, non-exposed behavior before public API or user-visible behavior",
+)
+
+# Calibration figures belong to the doctrine. Any line-count figure left in the
+# contract is a second copy whether it reads as a gate or as a preference, so
+# this matches the figure itself rather than the enforcing verb.
+LINE_COUNT_FIGURES = (
+    r"(?:a few|several|couple of)\s+hundred",
+    r"[\d,]+\s+(?:new or changed |changed |added )?lines\b",
+    r"line[- ]count",
+)
+
+# What the doctrine does not carry and the chain still needs. These are
+# properties of an ordered chain of merges, not of shape in general.
+CARVING_SPECIFIC_CONSTRAINTS = (
+    "safe intermediate state",
+    "Feature-flag policy",
+    "Database migration rules",
+    "excluded from the chain",
+    "name the rename and the minimal accompanying behavior",
+)
+
 
 def compact(value: str) -> str:
     return re.sub(r"\s+", " ", value).strip()
@@ -22,6 +56,7 @@ class CarveChangesetsContractTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.skill = compact((SKILL_ROOT / "SKILL.md").read_text())
+        cls.spec = compact((SKILL_ROOT / "references" / "SPEC.md").read_text())
         cls.handoff = compact(
             (SKILL_ROOT / "references" / "review-fix-loop-handoff.md").read_text()
         )
@@ -97,6 +132,53 @@ class CarveChangesetsContractTests(unittest.TestCase):
                 / "consumption-disciplines.md"
             ).is_file()
         )
+
+    def test_the_skill_loads_the_bundled_canonical_doctrine(self):
+        self.assertIn(DOCTRINE_NAME, self.skill)
+        self.assertTrue(
+            (SKILL_ROOT / "references" / DOCTRINE_NAME).is_file(),
+            f"references/{DOCTRINE_NAME} is missing; run `just sync-contracts`",
+        )
+
+    def test_a_missing_doctrine_fails_closed_rather_than_falling_back(self):
+        """Without this the skill degrades silently to no shape standard at
+        all, which is worse than the local heuristics it replaced."""
+        self.assertIn("doctrine is unavailable", self.skill)
+        for improvisation in (
+            "restate",
+            "local replacement",
+        ):
+            self.assertIn(improvisation, self.skill.lower())
+
+    def test_generic_shape_and_ordering_judgment_defers_to_the_doctrine(self):
+        self.assertIn(DOCTRINE_NAME, self.spec)
+        self.assertIn("canonical", self.spec)
+
+    def test_no_retired_generic_rule_survives_in_the_contract(self):
+        for rule in RETIRED_GENERIC_RULES:
+            with self.subTest(rule=rule):
+                self.assertNotIn(rule, self.spec)
+
+    def test_the_contract_states_no_line_count_figure_of_its_own(self):
+        for pattern in LINE_COUNT_FIGURES:
+            with self.subTest(pattern=pattern):
+                self.assertIsNone(
+                    re.search(pattern, self.spec, flags=re.IGNORECASE),
+                    f"the contract restates a size figure matching {pattern!r}",
+                )
+
+    def test_carving_specific_constraints_survive_the_retirement(self):
+        """The doctrine judges shape. It says nothing about keeping each
+        intermediate merge safe, which is the whole of carving."""
+        for constraint in CARVING_SPECIFIC_CONSTRAINTS:
+            with self.subTest(constraint=constraint):
+                self.assertIn(constraint, self.spec)
+
+    def test_an_evaluated_run_receives_the_doctrine_as_a_contract_document(self):
+        """A citation the run never loads is not a binding. The eval harness is
+        where 'a run applies the doctrine' becomes observable."""
+        runner = (SKILL_ROOT / "scripts" / "evals" / "runner.py").read_text()
+        self.assertIn(DOCTRINE_NAME, runner)
 
     def test_rationalization_table_covers_the_certified_seed_entry(self):
         self.assertIn("The equivalence check passed last time", self.skill)

--- a/skills/implement-ticket/references/carve-changesets-handoff.md
+++ b/skills/implement-ticket/references/carve-changesets-handoff.md
@@ -37,10 +37,10 @@ close a parent, or perform caller-owned mainline and tracker closeout.
 ## Publication decision and authority gate
 
 Evaluate the exact clean candidate against the live
-[cognitive-load guardrails](../../carve-changesets/references/SPEC.md#cognitive-load-guardrails).
-Record the effective diff, semantic shape, mechanical exceptions, cohesive
-intent, and independent-reviewability evidence. Never reduce this decision to a
-duplicated numeric threshold.
+[changeset shape and decomposition order](../../carve-changesets/references/SPEC.md#changeset-shape-and-decomposition-order)
+rules. Record the effective diff, semantic shape, mechanical exceptions,
+cohesive intent, and independent-reviewability evidence. Never reduce this
+decision to a duplicated numeric threshold.
 
 When the candidate is oversized, recommend tracker-level ticket decomposition if
 its parts are independently valuable and trackable. Recommend branch carving


### PR DESCRIPTION
## Summary

`carve-changesets`' normative contract carried its own answer to a question
`docs/cognitive-shaping-doctrine.md` already owns canonically — how large a
changeset may be, and what order a decomposition runs in. Two homes for one
doctrine is the drift this program exists to stop. Both sections retire in
favor of the bundled doctrine.

- The doctrine is bundled into the skill by `just sync-contracts` and
  drift-checked byte-for-byte under `just test` — the same distribution pair
  `review-suite/` and `review-solution-simplicity` already use, and the
  mechanism `docs/cognitive-driven-development.md` records as the selected
  shaping authority ("a bundled synced contract, not a new skill").
- `SKILL.md` loads and cites it and fails closed when it is absent.
- `scripts/validate_plugins.py` requires the bundled copy, so packaging cannot
  ship the citation without its target.
- Contract tests cover the citation, the retirement of every generic rule, the
  absence of any line-count figure, and the survival of the carving-specific
  rules.

## What survives locally, and why

The retained rules constrain an *ordered sequence of merges* rather than shape
in general, so the doctrine does not carry them: the rename-accompanies-behavior
rule with its PR-naming requirement, wide-refactor isolation, the feature-flag
policy, and the database-migration rules.

Three of the doctrine's eight breakdown rules are scoped out of boundary
selection — two addressed to planning, and the one the doctrine itself calls
downstream. That third one matters: creating follow-up work is a tracker
mutation, and **no authority level in this contract permits it** (decompose-only
forbids issue changes outright; merge-and-propagate "does not imply issue
mutation"). A carve discharges it by surfacing new scope through its existing
stop conditions instead. The remaining five govern boundaries directly.

Carving also *gains* two provisions the local guardrails never had: mechanical
change runs much larger without violating the standard, and recorded
machine-generated evidence is excluded from the size judgment outright.

## The binding reaches behavior, not just prose

A citation the run never loads is not a binding. The eval runner now ships the
doctrine as a contract document and the fixture gate requires a fragment that
exists **only** in the doctrine, so a run that does not receive it blocks
instead of carving to an improvised standard. Verified by driving the executor
both ways: `plan_ready` with it, `blocked` without.

## Acceptance

| Criterion (#187) | Evidence |
| --- | --- |
| A run names and applies the canonical doctrine rather than local heuristics | `SKILL.md` "Load the references"; `SPEC.md` "Changeset shape and decomposition order"; `test_the_skill_loads_the_bundled_canonical_doctrine`, `test_a_missing_doctrine_fails_closed_rather_than_falling_back`, `test_an_evaluated_run_receives_the_doctrine_as_a_contract_document` |
| No duplicate numeric or generic decomposition policy remains in the contract | `test_no_retired_generic_rule_survives_in_the_contract` (six retired rules), `test_the_contract_states_no_line_count_figure_of_its_own` |
| Carving-specific constraints remain available | `test_carving_specific_constraints_survive_the_retirement` |

All three are pre-merge; #187 states no post-merge verification is required.

## Validation

- `just format`, `just lint`, `just test` — all pass (14 suites).
- `just test-carve-changesets` — 155 tests pass.
- `just eval-carve-changesets` — 12/12 forward, 3/3 integration self-test.
- Change-demonstrating evidence (`evidence_behavioral_test`): seven of the eight
  new contract assertions were run against the base tree and failed there, and
  pass at head. The eighth,
  `test_carving_specific_constraints_survive_the_retirement`, passes at both by
  design — AC3 is a preservation criterion, so a base-green guard is the correct
  shape for it.

## Model-behavior evidence

Deterministic corpus replay, which is the tier `AGENTS.md` names for this skill:
`just eval-record carve-changesets` before and after, 12/12 both sides with an
empty per-case diff. Behavior is unchanged, which is the intended result — the
non-goals forbid moving chain topology, publication, recovery, or equivalence
behavior, so the binding should move where shape judgment *comes from* without
moving any graded outcome.

Both summaries carry the recorder's standing gap text: the tier is
deterministic, so **no model read the retired sections or the doctrine that
replaced them**. The prose-level evidence here is the contract suite, not this
replay.

The after-stage run was recorded twice on purpose. The first is bound to the
branch's opening commit; two later commits changed `SPEC.md`'s normative text,
so it was re-recorded at `ada40a5` to bind the evidence to the prose that ships.
Both are kept — the record of what was replayed against which tree is what these
files exist to supply.

## Review

Repository-owned `review-code-change` ran three times. The second pass returned
`changes_required` on a real defect in this change's core deliverable: the
breakdown-rule partition swept the doctrine's downstream rule into the rules
said to govern boundaries, contradicting the bundled text and pointing at a
forbidden tracker mutation. Fixed in `b45b9b2`, with a guard binding the
partition to the doctrine's own sentence, verified red against the defective
prose before being written green. The final pass at `b45b9b2` returned `clean`.

Two deferred findings are left as follow-up rather than expanding this PR:

- `scripts/tests/test_cognitive_shaping_doctrine.py`'s sync-recipe guard asserts
  a skill name appears anywhere in the justfile, so it cannot fail for either
  bundling skill. Pre-existing, and recorded as knowingly untouched by the base
  commit; this change extends its blast radius from one skill to two.
- `implement-ticket`'s `SKILL.md` and one eval case still name the retired
  section in prose. Neither is a link, and `docs/cognitive-driven-development.md`
  assigns that rewrite to the publication-size-gate leaf. The one actual dangling
  anchor this change created — in `carve-changesets-handoff.md` — is repaired
  here, since this change broke it.

Refs #187
