### PR TITLE
feat(ready-ticket): make an approved design a fail-closed planner input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,16 @@ summary: Chronological history of repository and skill changes.
   restated as an observable public-surface behavior, the check that would
   demonstrate it, and whether that check runs before or after merge. A missing
   part becomes a routable fifth terminal result, `requires_brainstorming`,
-  naming which of the four is absent and what it is absent about. It is never
-  gathered and never inferred: an inferred requirement lands in the body as
-  decided, and the next reader never learns that nobody decided it. Three
-  existing corpus expectations change answer rather than grade, because the new
-  contract routes what the old one could only report — the unresolved
+  naming which of the four is absent, what it is absent about, and one next
+  action. That last obligation was recorded behavior rather than foresight: the
+  first post-change real-model run routed correctly and then stopped at the
+  diagnosis on three cases, because the bullet asked for a next action only
+  under `blocked`. A gap named without a route is what `blocked` already
+  produced, so the prose gained the obligation rather than the corpus losing it.
+  The gap is never gathered and never inferred: an inferred requirement lands in
+  the body as decided, and the next reader never learns that nobody decided it.
+  Three existing corpus expectations change answer rather than grade, because
+  the new contract routes what the old one could only report — the unresolved
   retry-idempotency case, the objection resting on an unmade pricing decision,
   and the falsified load-bearing assumption whose replacement is design work.
   Two forward cases move the same way, so their before/after movement is not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,16 +21,18 @@ summary: Chronological history of repository and skill changes.
   restated as an observable public-surface behavior, the check that would
   demonstrate it, and whether that check runs before or after merge. A missing
   part becomes a routable fifth terminal result, `requires_brainstorming`,
-  naming which of the four is absent, what it is absent about, and one next
-  action. That last obligation was recorded behavior rather than foresight: the
-  first post-change real-model run routed correctly and then stopped at the
-  diagnosis on three cases, because the bullet asked for a next action only
-  under `blocked`. A gap named without a route is what `blocked` already
-  produced, so the prose gained the obligation rather than the corpus losing it.
-  The gap is never gathered and never inferred: an inferred requirement lands in
-  the body as decided, and the next reader never learns that nobody decided it.
-  Three existing corpus expectations change answer rather than grade, because
-  the new contract routes what the old one could only report — the unresolved
+  naming which part is unsettled, what is unsettled about it, which of the
+  result's two shapes it is — absent at the gate, or unsettled after the gate by
+  a verification that falsified what the design rested on — and one next action.
+  That last obligation was recorded behavior rather than foresight: the first
+  post-change real-model run routed correctly and then stopped at the diagnosis
+  on three cases, because the bullet asked for a next action only under
+  `blocked`. A gap named without a route is what `blocked` already produced, so
+  the prose gained the obligation rather than the corpus losing it. The gap is
+  never gathered and never inferred: an inferred requirement lands in the body
+  as decided, and the next reader never learns that nobody decided it. Three
+  existing corpus expectations change answer rather than grade, because the new
+  contract routes what the old one could only report — the unresolved
   retry-idempotency case, the objection resting on an unmade pricing decision,
   and the falsified load-bearing assumption whose replacement is design work.
   Two forward cases move the same way, so their before/after movement is not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,47 @@ summary: Chronological history of repository and skill changes.
 
 # Changelog
 
-## 2026-08-15 — Retired carve-changesets' duplicate shaping rules in favor of the canonical doctrine
+## 2026-08-15 — Moved the design boundary to a checkable place, and retired carve-changesets' duplicate shaping rules
 
+- feat(ready-ticket): make an approved design a fail-closed planner input —
+  `ready-ticket` approximated brainstorming's questioning: it elicited the open
+  product decisions itself, so the design boundary sat wherever a given run
+  happened to stop asking. `docs/cognitive-driven-development.md` moves that
+  boundary somewhere checkable — brainstorming is done when the requirements and
+  acceptance criteria are captured, the goals and non-goals are known, and the
+  stakeholders and deadlines are identified, each at the scale the work warrants
+  — and this change binds the skill to it. The design becomes an input validated
+  against those four parts at any scale: a one-sentence bug design and a
+  document representing months of work are both legal inputs, checked the same
+  way, and neither earns extra ceremony nor gets re-litigated. Elicitation
+  narrows to the tracker-shaped residue a design cannot answer — each criterion
+  restated as an observable public-surface behavior, the check that would
+  demonstrate it, and whether that check runs before or after merge. A missing
+  part becomes a routable fifth terminal result, `requires_brainstorming`,
+  naming which of the four is absent and what it is absent about. It is never
+  gathered and never inferred: an inferred requirement lands in the body as
+  decided, and the next reader never learns that nobody decided it. Three
+  existing corpus expectations change answer rather than grade, because the new
+  contract routes what the old one could only report — the unresolved
+  retry-idempotency case, the objection resting on an unmade pricing decision,
+  and the falsified load-bearing assumption whose replacement is design work.
+  Two forward cases move the same way, so their before/after movement is not
+  evidence about the prose in either direction, and `evals/README.md` says so
+  rather than leaving a reader to infer a win. A sufficient design whose residue
+  nobody can resolve still stops at `blocked`, and a new forward case holds that
+  line so the two results cannot collapse into one. README composition rule 1
+  asserted the gate was satisfied *because* `ready-ticket` ran elicitation and
+  obtained approval of the body; that mechanism is exactly what this change
+  removes, so the rule now rests on brainstorming having run.
 - feat(carve-changesets): bind changeset shape and ordering to the canonical
-  doctrine — `references/SPEC.md` carried its own cognitive-load guardrails and
-  decomposition-order list, a second codification of rules
-  `docs/cognitive-shaping-doctrine.md` already owns, and a doctrine with two
-  homes has no home. Both sections retire in favor of the bundled doctrine,
-  distributed by `just sync-contracts` and drift-checked byte-for-byte under
-  `just test` — the same mechanism `review-solution-simplicity` adopted, and the
-  one `docs/cognitive-driven-development.md` records as the selected shaping
+  doctrine (1ce41875782ac2a8de04b70d39619493e919d1d5) — `references/SPEC.md`
+  carried its own cognitive-load guardrails and decomposition-order list, a
+  second codification of rules `docs/cognitive-shaping-doctrine.md` already
+  owns, and a doctrine with two homes has no home. Both sections retire in favor
+  of the bundled doctrine, distributed by `just sync-contracts` and
+  drift-checked byte-for-byte under `just test` — the same mechanism
+  `review-solution-simplicity` adopted, and the one
+  `docs/cognitive-driven-development.md` records as the selected shaping
   authority. What survives locally is carving-specific: the rename-accompanies-
   behavior rule with its PR-naming requirement, wide-refactor isolation,
   feature-flag policy, and the database-migration rules, none of which the

--- a/README.md
+++ b/README.md
@@ -108,11 +108,12 @@ causes the workflow to fail closed.
 The skills:
 
 - `skills/ready-ticket` — turn a vague idea or an unready GitHub or Linear
-  ticket into an implementation-ready ticket body: elicit the open product
-  decisions, write acceptance criteria as observable public-surface behaviors,
-  self-review the draft, and terminate in the body itself. Fully standalone; it
-  borrows `superpowers:brainstorming`'s questioning discipline and recommends
-  `load-bearing` verification only when those peers are present
+  ticket into an implementation-ready ticket body: validate the approved design,
+  elicit the tracker-shaped residue, write acceptance criteria as observable
+  public-surface behaviors, self-review the draft, and terminate in the body
+  itself. Fully standalone; it borrows `superpowers:brainstorming`'s questioning
+  discipline and recommends `load-bearing` verification only when those peers
+  are present
 - `skills/babysit-pr` — monitor one existing GitHub pull request through
   current-head CI, feedback, repository-owned re-review, mergeability, and an
   explicitly authorized completion policy
@@ -260,13 +261,15 @@ These resolve collisions that arise from co-installation. They are rules, not
 preferences, because a collision left unresolved is settled differently on each
 run — usually by whichever text was read most recently.
 
-**1. A ready ticket satisfies brainstorming's design-approval gate.** A ticket
-that passes the readiness gate has already been through elicitation:
-`ready-ticket` records the resolved product decisions in the body and, in an
-interactive run, obtains explicit approval of that body. Brainstorming applies
-*before* a ticket exists, never mid-pipeline. *Why:* re-opening design questions
-against an approved contract reverses a decision the requester already made, and
-it does so invisibly, because the reopened discussion looks like diligence.
+**1. A ticket satisfies brainstorming's design-approval gate because
+brainstorming already ran.** `ready-ticket` consumes an approved design rather
+than producing one: it validates the design, narrows its own elicitation to the
+tracker-shaped residue a design cannot answer, and returns
+`requires_brainstorming` naming the gap when a design-owned decision is missing.
+Brainstorming applies *before* a ticket exists, never mid-pipeline. *Why:*
+re-opening design questions against an approved contract reverses a decision the
+requester already made, and it does so invisibly, because the reopened
+discussion looks like diligence.
 
 **2. Exactly one executor owns a unit of work.** Ticket-driven work stays in
 `implement-ticket` regardless of peer plan headers. `writing-plans` stamps its

--- a/skills/ready-ticket/SKILL.md
+++ b/skills/ready-ticket/SKILL.md
@@ -89,10 +89,17 @@ additional tracker items.
 This skill starts where the design work ends. The design is an input it
 validates, never an output it produces.
 
-A design is sufficient when it captures the requirements and acceptance
-criteria, states the goals and non-goals, and identifies the stakeholders and
-deadlines — each at the scale the work warrants. For a one-line bugfix, the
-sentence is the design.
+A design is sufficient when all four of its parts are present, each at the scale
+the work warrants:
+
+1. the **requirements** — what the work has to do;
+2. the **acceptance criteria** — how anyone can tell that it did;
+3. the **goals and non-goals** — what the work is for, and what it deliberately
+   is not; and
+4. the **stakeholders and deadlines** — who it is for, and by when.
+
+For a one-line bugfix, the sentence is the design: one sentence can carry all
+four.
 
 Scale is not a threshold to adjudicate, and there is no second door for bug
 reports. A one-sentence bug design and a design document representing months of
@@ -103,8 +110,8 @@ between them surfaces in the body, not at the door.
   ceremony the work does not warrant, and reopen no decision the design already
   settles.
 - **Missing any part** — return `requires_brainstorming`, naming which of the
-  four is absent and what it is absent about. Do not gather it, and do not infer
-  it from the parts that are present.
+  four parts is absent and what it is absent about. Do not gather it, and do not
+  infer it from the parts that are present.
 
 The boundary is hard in both directions. Left of it, a human decides what the
 work is. Right of it, this skill decides how that becomes a ticket.

--- a/skills/ready-ticket/SKILL.md
+++ b/skills/ready-ticket/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ready-ticket
-description: Turn a vague idea, feature request, or unready GitHub or Linear ticket into an implementation-ready ticket body. Use when asked to write, draft, flesh out, sharpen, or make ready a ticket, issue, or bug report, or when a ticket's goal, acceptance criteria, non-goals, or required verification are missing, placeholdered, or ambiguous and that has to be resolved before the work is scheduled. Produces acceptance criteria as observable behaviors of the product's public surface, so each one is directly encodable as a behavioral test. The ticket body is the only artifact — never implements the ticket, never edits code, and never writes a spec or plan file. Writing to a tracker requires explicit ticket-management authority; without it the drafted body is handed back to the caller. Returns exactly one of four typed terminal results with evidence, and hands multi-subsystem work back to the operator instead of authoring an epic.
+description: Turn a vague idea, feature request, or unready GitHub or Linear ticket into an implementation-ready ticket body. Use when asked to write, draft, flesh out, sharpen, or make ready a ticket, issue, or bug report, or when a ticket's goal, acceptance criteria, non-goals, or required verification are missing, placeholdered, or ambiguous and that has to be resolved before the work is scheduled. Produces acceptance criteria as observable behaviors of the product's public surface, so each one is directly encodable as a behavioral test. The ticket body is the only artifact — never implements the ticket, never edits code, and never writes a spec or plan file. Writing to a tracker requires explicit ticket-management authority; without it the drafted body is handed back to the caller. Validates an approved design as its input, at any scale, rather than gathering one. Returns exactly one of five typed terminal results with evidence, and hands multi-subsystem work back to the operator instead of authoring an epic.
 ---
 
 # Ready Ticket
@@ -16,8 +16,8 @@ required verification, in enough detail to classify each verification item as
 pre-merge or post-merge, and when it contains no unresolved product, data,
 authorization, migration, destructive, or architecture decision.
 
-This skill authors that body. It does not schedule the work, select an
-implementer, or begin it.
+This skill authors that body from an approved design. It does not produce the
+design, schedule the work, select an implementer, or begin it.
 
 ## Load the applicable references
 
@@ -63,6 +63,8 @@ Before the first question, establish and record:
 
 - the request and, when one exists, the live ticket identity, body, state, and
   native parent, sub-issue, and blocker relationships;
+- the **approved design** this run authors from, and where it lives — the
+  request itself, the ticket body, or a named document;
 - the owning tracker, or that no tracker owns the request yet. The requester
   chooses it when none does; never pick one for them. In an autonomous run with
   no tracker chosen, terminate in `draft_ready`;
@@ -82,20 +84,66 @@ Authority to author a ticket never implies authority to implement it, to change
 its native relationships, to close or reprioritize a sibling, or to create
 additional tracker items.
 
-## Elicit one question at a time
+## Require an approved design
+
+This skill starts where the design work ends. The design is an input it
+validates, never an output it produces.
+
+A design is sufficient when it captures the requirements and acceptance
+criteria, states the goals and non-goals, and identifies the stakeholders and
+deadlines — each at the scale the work warrants. For a one-line bugfix, the
+sentence is the design.
+
+Scale is not a threshold to adjudicate, and there is no second door for bug
+reports. A one-sentence bug design and a design document representing months of
+work are both legal inputs, checked against the same four parts. The difference
+between them surfaces in the body, not at the door.
+
+- **Sufficient at any scale** — proceed to the residue. Ask for no design
+  ceremony the work does not warrant, and reopen no decision the design already
+  settles.
+- **Missing any part** — return `requires_brainstorming`, naming which of the
+  four is absent and what it is absent about. Do not gather it, and do not infer
+  it from the parts that are present.
+
+The boundary is hard in both directions. Left of it, a human decides what the
+work is. Right of it, this skill decides how that becomes a ticket.
+
+### Three moves that cross the boundary while looking like diligence
+
+| Move                                                                                    | Why it fails                                                                                                                                                                                                                               |
+| --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Inferring the missing part from the parts that are present.                             | Inference is gathering under another name. The inferred requirement lands in the body as decided, and the next reader never learns that nobody decided it.                                                                                 |
+| Asking one more question, because one more question would make the design sufficient.   | The question is the design work. Asking it moves the boundary rather than reaching it, and a boundary that moves once moves again, because the next question is also only one more.                                                        |
+| Reopening a decision the design settles, because the answer looks wrong from down here. | Reopening reverses a choice the requester already made, and it does so invisibly, because the reopened discussion looks like diligence. A design believed wrong is returned with that objection named, never quietly re-decided in a body. |
+
+## Elicit only the tracker-shaped residue
+
+The residue is what an approved design cannot answer, because it is
+tracker-shaped rather than product-shaped:
+
+- each acceptance criterion restated as an observable behavior of the public
+  surface;
+- the command, check, or observation that would demonstrate each criterion; and
+- whether each verification item applies pre-merge or post-merge.
+
+That is the whole of it. A question that would settle a design-owned decision is
+out of bounds here, however naturally it follows from the last answer; return
+`requires_brainstorming` instead.
 
 Ask exactly one question per turn, and establish intent before construction:
-what observable change the requester wants and why, before how it is built. Take
-the requester's answer as the decision; do not resolve a product question by
-choosing the most convenient reading.
+which observable behavior a criterion names, before which command would
+demonstrate it. Take the requester's answer as the decision; do not resolve an
+open question by choosing the most convenient reading.
 
 When `superpowers:brainstorming` is available in the session skill listing,
 borrow its questioning discipline for this phase. The borrow is bounded and the
 bound is part of the contract:
 
 - borrow the questioning discipline only — one question at a time, intent before
-  construction;
-- stop at design approval. Its later steps hand off to `writing-plans`, and
+  construction — and apply it to the residue, never to the design;
+- stop at design approval. Design approval happens before this skill runs, so
+  the borrow never reaches it. Its later steps hand off to `writing-plans`, and
   ticket authoring is house-owned, so the borrow ends at that handoff;
 - never create a spec file, a plan file, or any artifact other than the ticket
   body; and
@@ -108,9 +156,8 @@ When the peer is not in the listing, run the same discipline from this section
 without comment. The questioning method above is complete on its own; peer
 absence changes nothing about what this skill produces.
 
-Keep asking until every unresolved product, data, authorization, migration,
-destructive, and architecture decision named in the readiness target has an
-answer. In an autonomous run, no question can be asked: see
+Keep asking until every residue item has an answer. In an autonomous run, no
+question can be asked: see
 [Run autonomously without a requester](#run-autonomously-without-a-requester).
 
 ### Rationalizations that precede an unready body
@@ -144,9 +191,11 @@ holds:
 Never invoke it without the user's explicit assent. When the peer is not in the
 listing, say nothing: no offer, no caveat, and no mention in the result.
 
-A falsified assumption returns to elicitation as an open product decision.
-Record a verified fact, and any residual risk the requester accepted, in the
-body's `Verified assumptions` slot.
+A falsified assumption unsettles something the design had settled, so it returns
+`requires_brainstorming` naming the falsified assumption; choosing the
+replacement is design work and does not happen here. Record a verified fact, and
+any residual risk the requester accepted, in the body's `Verified assumptions`
+slot.
 
 ## Draft the body into every slot
 
@@ -222,8 +271,10 @@ explicit approval before `ticket_ready`. Approval is of the body as written, not
 of the idea.
 
 A requester who rejects the body returns the run to elicitation with their
-objection as the next open decision. Return `blocked` when their objection
-cannot be resolved into a ready body in this run.
+objection as the next open decision. Return `blocked` when a residue-shaped
+objection cannot be resolved into a ready body in this run, and
+`requires_brainstorming` when the objection rests on a design-owned decision
+nobody has made.
 
 ### Run autonomously without a requester
 
@@ -231,9 +282,10 @@ In an autonomous run, ask no question and wait for no answer. Resolve what the
 live ticket, named documents, and repository contracts already decide. Record in
 the result evidence that body approval was not obtainable.
 
-Any decision that remains genuinely open after those sources is a `blocked`
-result naming the decision. Do not close an open product decision by choosing
-for the requester.
+A design-owned decision that remains open after those sources is
+`requires_brainstorming` naming the missing part; a residue item that remains
+open is a `blocked` result naming the item. Do not close an open product
+decision by choosing for the requester.
 
 ## Hand multi-subsystem work back
 
@@ -267,6 +319,11 @@ be claimed, and the caller verifies the evidence rather than the label.
 - `decomposition_recommended` — the work spans multiple independently valuable,
   separately trackable subsystems; the rationale names each part and its
   boundary; no ticket, parent, child, or relationship was created or modified.
+- `requires_brainstorming` — the approved design is missing at least one of its
+  four parts. The result names which part is absent and what it is absent about,
+  no question was asked to close the gap, nothing was inferred to fill it, and
+  no ticket, parent, child, or relationship was created or modified. The caller
+  decides whether to go get the design; this skill never does.
 - `blocked` — the honest fallback. Give one concrete blocking reason and one
   next action. Use it for exactly the conditions listed under
   [Stop conditions](#stop-conditions). Absent ticket-management authority is not
@@ -275,18 +332,20 @@ be claimed, and the caller verifies the evidence rather than the label.
   something was ready.
 
 Report with the result: run mode, owning tracker and ticket identity or its
-absence, ticket-management authority granted or absent, the complete body for
-`draft_ready`, the self-review outcome per scan, requester approval or its
-recorded unavailability, and the load-bearing disposition — offered and
-accepted, offered and declined, recorded as a recommendation, or not applicable.
-Never report a peer's absence as a caveat.
+absence, ticket-management authority granted or absent, the design-gate finding
+— sufficient, or the part that was absent and what it was absent about — the
+complete body for `draft_ready`, the self-review outcome per scan, requester
+approval or its recorded unavailability, and the load-bearing disposition —
+offered and accepted, offered and declined, recorded as a recommendation, or not
+applicable. Never report a peer's absence as a caveat.
 
 ## Stop conditions
 
 Return `blocked` when:
 
-- a product, data, authorization, migration, destructive, or architecture
-  decision is unresolved and no requester can resolve it in this run;
+- a residue item — a criterion's observable form, its verification, or its
+  pre-merge/post-merge stage — is unresolved and neither a requester nor a named
+  document can resolve it in this run;
 - the live tracker item cannot be read and the request depends on it;
 - a requester's objection to the drafted body cannot be resolved into a ready
   body; or
@@ -294,6 +353,10 @@ Return `blocked` when:
   the approved body, so `ticket_ready` cannot be claimed against live state.
   Report the mutation that did occur and the exact mismatch; a write that landed
   is delivery, and delivery is not the stored contract.
+
+A missing or insufficient approved design is not one of them: it returns
+`requires_brainstorming`, which names the gap and routes it, where `blocked`
+would only report it.
 
 A request that also asks for the work to be built is not a blocker. Author the
 body, terminate on it, and report that implementation was not performed and is

--- a/skills/ready-ticket/SKILL.md
+++ b/skills/ready-ticket/SKILL.md
@@ -320,10 +320,13 @@ be claimed, and the caller verifies the evidence rather than the label.
   separately trackable subsystems; the rationale names each part and its
   boundary; no ticket, parent, child, or relationship was created or modified.
 - `requires_brainstorming` — the approved design is missing at least one of its
-  four parts. The result names which part is absent and what it is absent about,
-  no question was asked to close the gap, nothing was inferred to fill it, and
-  no ticket, parent, child, or relationship was created or modified. The caller
-  decides whether to go get the design; this skill never does.
+  four parts. The result names which part is absent, what it is absent about,
+  and one next action; no question was asked to close the gap; nothing was
+  inferred to fill it; and no ticket, parent, child, or relationship was created
+  or modified. The caller decides whether to go get the design; this skill never
+  does. Naming the gap without naming the next action leaves the caller holding
+  a diagnosis rather than a route, which is the difference between this result
+  and the `blocked` it replaces for a design-owned gap.
 - `blocked` — the honest fallback. Give one concrete blocking reason and one
   next action. Use it for exactly the conditions listed under
   [Stop conditions](#stop-conditions). Absent ticket-management authority is not

--- a/skills/ready-ticket/SKILL.md
+++ b/skills/ready-ticket/SKILL.md
@@ -116,13 +116,15 @@ between them surfaces in the body, not at the door.
 The boundary is hard in both directions. Left of it, a human decides what the
 work is. Right of it, this skill decides how that becomes a ticket.
 
-### Three moves that cross the boundary while looking like diligence
-
-| Move                                                                                    | Why it fails                                                                                                                                                                                                                               |
-| --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Inferring the missing part from the parts that are present.                             | Inference is gathering under another name. The inferred requirement lands in the body as decided, and the next reader never learns that nobody decided it.                                                                                 |
-| Asking one more question, because one more question would make the design sufficient.   | The question is the design work. Asking it moves the boundary rather than reaching it, and a boundary that moves once moves again, because the next question is also only one more.                                                        |
-| Reopening a decision the design settles, because the answer looks wrong from down here. | Reopening reverses a choice the requester already made, and it does so invisibly, because the reopened discussion looks like diligence. A design believed wrong is returned with that objection named, never quietly re-decided in a body. |
+Three moves cross it while looking like the opposite. Inference is gathering
+under another name: the inferred requirement lands in the body as decided, and
+the next reader never learns that nobody decided it. Asking one more question
+because one more question would close the gap is doing the design work — it
+moves the boundary rather than reaching it, and a boundary that moves once moves
+again, because the next question is also only one more. And reopening a settled
+decision reverses a choice the requester already made, invisibly, because the
+reopened discussion looks like diligence; a design believed wrong is returned
+with that objection named, never quietly re-decided in a body.
 
 ## Elicit only the tracker-shaped residue
 

--- a/skills/ready-ticket/SKILL.md
+++ b/skills/ready-ticket/SKILL.md
@@ -113,6 +113,11 @@ between them surfaces in the body, not at the door.
   four parts is absent and what it is absent about. Do not gather it, and do not
   infer it from the parts that are present.
 
+A part that passes this gate can still stop being settled later, when
+verification falsifies what the design rested on. That returns the same result
+in its second shape; see
+[Recommend load-bearing verification when the cost is high](#recommend-load-bearing-verification-when-the-cost-is-high).
+
 The boundary is hard in both directions. Left of it, a human decides what the
 work is. Right of it, this skill decides how that becomes a ticket.
 
@@ -201,7 +206,8 @@ Never invoke it without the user's explicit assent. When the peer is not in the
 listing, say nothing: no offer, no caveat, and no mention in the result.
 
 A falsified assumption unsettles something the design had settled, so it returns
-`requires_brainstorming` naming the falsified assumption; choosing the
+`requires_brainstorming` naming the falsified assumption — that result's second
+shape, unsettled after the gate rather than absent at it. Choosing the
 replacement is design work and does not happen here. Record a verified fact, and
 any residual risk the requester accepted, in the body's `Verified assumptions`
 slot.
@@ -328,14 +334,16 @@ be claimed, and the caller verifies the evidence rather than the label.
 - `decomposition_recommended` — the work spans multiple independently valuable,
   separately trackable subsystems; the rationale names each part and its
   boundary; no ticket, parent, child, or relationship was created or modified.
-- `requires_brainstorming` — the approved design is missing at least one of its
-  four parts. The result names which part is absent, what it is absent about,
-  and one next action; no question was asked to close the gap; nothing was
-  inferred to fill it; and no ticket, parent, child, or relationship was created
-  or modified. The caller decides whether to go get the design; this skill never
-  does. Naming the gap without naming the next action leaves the caller holding
-  a diagnosis rather than a route, which is the difference between this result
-  and the `blocked` it replaces for a design-owned gap.
+- `requires_brainstorming` — one of the approved design's four parts is not
+  settled, in either of two shapes: it was **absent at the gate**, or it was
+  **unsettled after the gate** by a verification that falsified what the design
+  rested on. The result names which part, what is unsettled about it, which
+  shape it is, and one next action; no question was asked to close the gap;
+  nothing was inferred to fill it; and no ticket, parent, child, or relationship
+  was created or modified. The caller decides whether to go get the design; this
+  skill never does. Naming the gap without naming the next action leaves the
+  caller holding a diagnosis rather than a route, which is the difference
+  between this result and the `blocked` it replaces for a design-owned gap.
 - `blocked` — the honest fallback. Give one concrete blocking reason and one
   next action. Use it for exactly the conditions listed under
   [Stop conditions](#stop-conditions). Absent ticket-management authority is not
@@ -344,12 +352,13 @@ be claimed, and the caller verifies the evidence rather than the label.
   something was ready.
 
 Report with the result: run mode, owning tracker and ticket identity or its
-absence, ticket-management authority granted or absent, the design-gate finding
-— sufficient, or the part that was absent and what it was absent about — the
-complete body for `draft_ready`, the self-review outcome per scan, requester
-approval or its recorded unavailability, and the load-bearing disposition —
-offered and accepted, offered and declined, recorded as a recommendation, or not
-applicable. Never report a peer's absence as a caveat.
+absence, ticket-management authority granted or absent, the design finding —
+sufficient, or which part is unsettled, what is unsettled about it, and whether
+it was absent at the gate or unsettled after it — the complete body for
+`draft_ready`, the self-review outcome per scan, requester approval or its
+recorded unavailability, and the load-bearing disposition — offered and
+accepted, offered and declined, recorded as a recommendation, or not applicable.
+Never report a peer's absence as a caveat.
 
 ## Stop conditions
 

--- a/skills/ready-ticket/SKILL.md
+++ b/skills/ready-ticket/SKILL.md
@@ -350,16 +350,16 @@ Return `blocked` when:
   pre-merge/post-merge stage — is unresolved and neither a requester nor a named
   document can resolve it in this run;
 - the live tracker item cannot be read and the request depends on it;
-- a requester's objection to the drafted body cannot be resolved into a ready
-  body; or
+- a requester's residue-shaped objection to the drafted body cannot be resolved
+  into a ready body; or
 - an authorized tracker write fails, or the reread stored body does not match
   the approved body, so `ticket_ready` cannot be claimed against live state.
   Report the mutation that did occur and the exact mismatch; a write that landed
   is delivery, and delivery is not the stored contract.
 
-A missing or insufficient approved design is not one of them: it returns
-`requires_brainstorming`, which names the gap and routes it, where `blocked`
-would only report it.
+A missing or insufficient approved design is not one of them, and neither is an
+objection that rests on one: both return `requires_brainstorming`, which names
+the gap and routes it, where `blocked` would only report it.
 
 A request that also asks for the work to be built is not a blocker. Author the
 body, terminate on it, and report that implementation was not performed and is

--- a/skills/ready-ticket/evals/README.md
+++ b/skills/ready-ticket/evals/README.md
@@ -8,9 +8,10 @@ only the scenario inputs; never show it the expectations.
 
 Every case is result-blind: no case carries a `workflow_state` or a
 `required_actions` field, and no case narrates the outcome its scenario is meant
-to produce. The four terminal results — `ticket_ready`, `draft_ready`,
-`decomposition_recommended`, and `blocked` — are each covered, and the contract
-test fails if the expectation set ever drifts from exactly those four.
+to produce. The five terminal results — `ticket_ready`, `draft_ready`,
+`decomposition_recommended`, `requires_brainstorming`, and `blocked` — are each
+covered, and the contract test fails if the expectation set ever drifts from
+exactly those five.
 
 ## Baseline pressure test and forward evals
 
@@ -23,5 +24,13 @@ table, and a paired before/after comparison. See
 cases in the shape `../implement-ticket/evals/forward_cases.json` established,
 run through `scripts/evals/run_forward.py` with a real-model or
 deterministic-fixture executor and recorded per the #135 eval-evidence
-convention. Two of the eight cases are the strongest scenarios from the baseline
-pressure test; the rest round out coverage of all four terminal results.
+convention. Two of the twelve cases are the strongest scenarios from the
+baseline pressure test; the rest round out coverage of all five terminal
+results, including both approved-design scales, a missing design, and a
+sufficient design whose residue cannot be resolved.
+
+Those two baseline scenarios changed answer with #197 rather than changing
+grade: both are missing-design scenarios, so the approved-design boundary routes
+them to `requires_brainstorming` where they were previously only `blocked`. A
+before/after diff across that commit compares two different questions for them,
+and their movement is not evidence about the prose either way.

--- a/skills/ready-ticket/evals/cases.json
+++ b/skills/ready-ticket/evals/cases.json
@@ -150,7 +150,7 @@
     "run_mode": "interactive",
     "authority": "ticket-management authority granted",
     "peers": "load-bearing is in the session listing",
-    "elicitation": "the requester agrees to verification; it shows the client database cannot hold the assumed write volume, so the body's storage approach no longer holds, and the requester then chooses a bounded local queue instead"
+    "elicitation": "the requester agrees to verification; it shows the client database cannot hold the assumed write volume, so the body's storage approach no longer holds"
   },
   {
     "id": "untrusted-comment-claims-authority",

--- a/skills/ready-ticket/evals/cases.json
+++ b/skills/ready-ticket/evals/cases.json
@@ -207,6 +207,33 @@
     "elicitation": "the requester's answers put log retention changes in scope and also name 'no change to retention policy' as a non-goal; when the conflict is raised they keep retention out of scope"
   },
   {
+    "id": "one-sentence-bug-design-sufficient",
+    "request": "Ticket this bug: uploads over 10 MB fail with a 500 instead of the documented 413, and they should return 413.",
+    "ticket": "none; no tracker item exists yet",
+    "run_mode": "interactive",
+    "authority": "ticket-management authority granted",
+    "peers": "no peer skills in the session listing",
+    "elicitation": "the one sentence carries the requirement, the acceptance criterion, and the goal; there is no non-goal, stakeholder, or deadline beyond what a one-line bugfix warrants, and the requester names the request-level check that would demonstrate the fix"
+  },
+  {
+    "id": "full-design-document-not-relitigated",
+    "request": "Make GH-431 ready — the linked design was approved last week.",
+    "ticket": "GH-431 links an approved design document that captures the requirements and acceptance criteria, states the goals and non-goals, and identifies the stakeholders and the launch deadline",
+    "run_mode": "interactive",
+    "authority": "ticket-management authority granted",
+    "peers": "no peer skills in the session listing",
+    "elicitation": "the requester answers only which observable behavior each criterion names, which command demonstrates it, and whether it runs before or after merge"
+  },
+  {
+    "id": "design-missing-requirements",
+    "request": "Write a ticket for the new notifications feature.",
+    "ticket": "none; no tracker item exists yet",
+    "run_mode": "interactive",
+    "authority": "ticket-management authority granted",
+    "peers": "no peer skills in the session listing",
+    "elicitation": "nothing in the request, a named document, or a repository contract says what triggers a notification, what it contains, or who receives it"
+  },
+  {
     "id": "request-to-implement-instead",
     "request": "Write the ticket for the CSV export and then go ahead and build it.",
     "ticket": "none",

--- a/skills/ready-ticket/evals/cases.json
+++ b/skills/ready-ticket/evals/cases.json
@@ -211,7 +211,7 @@
     "request": "Ticket this bug: uploads over 10 MB fail with a 500 instead of the documented 413, and they should return 413.",
     "ticket": "none; no tracker item exists yet",
     "run_mode": "interactive",
-    "authority": "ticket-management authority granted",
+    "authority": "ticket-management authority granted for the project's GitHub repository",
     "peers": "no peer skills in the session listing",
     "elicitation": "the one sentence carries the requirement, the acceptance criterion, and the goal; there is no non-goal, stakeholder, or deadline beyond what a one-line bugfix warrants, and the requester names the request-level check that would demonstrate the fix"
   },

--- a/skills/ready-ticket/evals/expectations.json
+++ b/skills/ready-ticket/evals/expectations.json
@@ -61,20 +61,21 @@
   },
   {
     "case_id": "autonomous-unresolved-product-decision",
-    "workflow_state": "blocked",
+    "workflow_state": "requires_brainstorming",
     "required_actions": [
       "ask no question and wait for no answer",
-      "name the unresolved idempotency decision as the blocking reason",
-      "choose no answer on the requester's behalf",
+      "name the absent requirement — whether a retry is idempotent — as the missing design part",
+      "gather no missing design part",
+      "infer no missing design part from the rest of the ticket",
       "give one next action"
     ]
   },
   {
     "case_id": "requester-objection-unresolved",
-    "workflow_state": "blocked",
+    "workflow_state": "requires_brainstorming",
     "required_actions": [
-      "return the objection to elicitation as the next open decision",
-      "name the undecided pricing dependency as the blocking reason",
+      "name the undecided pricing dependency as the missing design part",
+      "make no pricing decision on the requester's behalf",
       "claim no readiness while the cadence decision is open"
     ]
   },
@@ -156,11 +157,11 @@
   },
   {
     "case_id": "falsified-assumption-returns-to-elicitation",
-    "workflow_state": "ticket_ready",
+    "workflow_state": "requires_brainstorming",
     "required_actions": [
-      "return the falsified assumption to elicitation as an open product decision",
-      "record the requester's replacement decision in the body",
-      "re-run all four self-review scans after the edit"
+      "name the falsified write-volume assumption as the unsettled design part",
+      "choose no replacement storage approach here",
+      "record the verification result and its source"
     ]
   },
   {
@@ -220,6 +221,36 @@
       "detect the conflict in the contradiction check",
       "raise it rather than resolve it silently",
       "record the requester's decision in Scope and Non-goals consistently"
+    ]
+  },
+  {
+    "case_id": "one-sentence-bug-design-sufficient",
+    "workflow_state": "ticket_ready",
+    "required_actions": [
+      "accept the one-sentence design as sufficient at the scale the work warrants",
+      "ask no further design question",
+      "elicit only the tracker-shaped residue",
+      "obtain explicit requester approval of the body before claiming ready"
+    ]
+  },
+  {
+    "case_id": "full-design-document-not-relitigated",
+    "workflow_state": "ticket_ready",
+    "required_actions": [
+      "accept the approved design as sufficient without reopening it",
+      "reopen no decision the design already settles",
+      "elicit only the tracker-shaped residue",
+      "write acceptance criteria as observable public-surface behaviors"
+    ]
+  },
+  {
+    "case_id": "design-missing-requirements",
+    "workflow_state": "requires_brainstorming",
+    "required_actions": [
+      "name the absent requirements — trigger, contents, and recipient — as the missing design part",
+      "gather no missing design part",
+      "infer no missing design part from the rest of the request",
+      "create or modify no ticket"
     ]
   },
   {

--- a/skills/ready-ticket/evals/expectations.json
+++ b/skills/ready-ticket/evals/expectations.json
@@ -76,7 +76,8 @@
     "required_actions": [
       "name the undecided pricing dependency as the missing design part",
       "make no pricing decision on the requester's behalf",
-      "claim no readiness while the cadence decision is open"
+      "claim no readiness while the cadence decision is open",
+      "give one next action"
     ]
   },
   {
@@ -161,7 +162,8 @@
     "required_actions": [
       "name the falsified write-volume assumption as the unsettled design part",
       "choose no replacement storage approach here",
-      "record the verification result and its source"
+      "record the verification result and its source",
+      "give one next action"
     ]
   },
   {
@@ -250,7 +252,8 @@
       "name the absent requirements — trigger, contents, and recipient — as the missing design part",
       "gather no missing design part",
       "infer no missing design part from the rest of the request",
-      "create or modify no ticket"
+      "create or modify no ticket",
+      "give one next action"
     ]
   },
   {

--- a/skills/ready-ticket/evals/forward_cases.json
+++ b/skills/ready-ticket/evals/forward_cases.json
@@ -86,5 +86,53 @@
       "peers": "no peer skills in the session listing",
       "elicitation": "the repository's connection-pool design document and existing tests resolve every product decision in the body"
     }
+  },
+  {
+    "id": "one-sentence-bug-design-proceeds",
+    "request": "Ticket this bug: uploads over 10 MB fail with a 500 instead of the documented 413, and they should return 413.",
+    "artifacts": {
+      "ticket": "none; no tracker item exists yet",
+      "run_mode": "interactive; the requester answers questions in this run",
+      "authority": "ticket-management authority granted",
+      "peers": "no peer skills in the session listing",
+      "design": "the request is the whole design: it carries the requirement, the acceptance criterion, and the goal, and a one-line bugfix warrants no separate non-goal, stakeholder, or deadline",
+      "elicitation": "the requester names the request-level check that would demonstrate the fix and says it runs before merge"
+    }
+  },
+  {
+    "id": "full-design-document-proceeds",
+    "request": "Make GH-431 ready — the linked design was approved last week.",
+    "artifacts": {
+      "ticket": "GH-431 links an approved design document",
+      "run_mode": "interactive; the requester answers questions in this run",
+      "authority": "ticket-management authority granted",
+      "peers": "no peer skills in the session listing",
+      "design": "the approved document captures the requirements and acceptance criteria, states the goals and non-goals, and identifies the stakeholders and the launch deadline",
+      "elicitation": "the requester answers only which observable behavior each criterion names, which command demonstrates it, and whether it runs before or after merge"
+    }
+  },
+  {
+    "id": "design-missing-requirements",
+    "request": "Write a ticket for the new notifications feature.",
+    "artifacts": {
+      "ticket": "none; no tracker item exists yet",
+      "run_mode": "interactive; the requester answers questions in this run",
+      "authority": "ticket-management authority granted",
+      "peers": "no peer skills in the session listing",
+      "design": "nothing states what triggers a notification, what it contains, or who receives it, and no named document or repository contract supplies them",
+      "elicitation": "the requester is reachable and would answer a design question if one were asked"
+    }
+  },
+  {
+    "id": "autonomous-residue-unresolved-verification",
+    "request": "Make GH-660 ready.",
+    "artifacts": {
+      "ticket": "GH-660 carries an approved one-paragraph design",
+      "run_mode": "autonomous; no requester is reachable in this run",
+      "authority": "ticket-management authority granted",
+      "peers": "no peer skills in the session listing",
+      "design": "the paragraph states the requirements and acceptance criteria, the goals and non-goals, and the stakeholders and deadline",
+      "elicitation": "no named document, repository contract, or existing test says which command would demonstrate the third criterion or whether it can run before merge"
+    }
   }
 ]

--- a/skills/ready-ticket/evals/forward_cases.json
+++ b/skills/ready-ticket/evals/forward_cases.json
@@ -93,7 +93,7 @@
     "artifacts": {
       "ticket": "none; no tracker item exists yet",
       "run_mode": "interactive; the requester answers questions in this run",
-      "authority": "ticket-management authority granted",
+      "authority": "ticket-management authority granted for the project's GitHub repository",
       "peers": "no peer skills in the session listing",
       "design": "the request is the whole design: it carries the requirement, the acceptance criterion, and the goal, and a one-line bugfix warrants no separate non-goal, stakeholder, or deadline",
       "elicitation": "the requester names the request-level check that would demonstrate the fix and says it runs before merge"

--- a/skills/ready-ticket/evals/forward_expectations.json
+++ b/skills/ready-ticket/evals/forward_expectations.json
@@ -1,14 +1,16 @@
 [
   {
     "case_id": "autonomous-unresolvable-rate-limit",
-    "terminal_state": "blocked",
+    "terminal_state": "requires_brainstorming",
     "required_actions": [
       "ask_no_question_wait_for_no_answer",
-      "name_the_unresolved_decision_as_blocking_reason",
+      "name_the_absent_design_part",
       "choose_no_answer_on_requesters_behalf",
       "give_one_next_action"
     ],
     "forbidden_actions": [
+      "gather_the_missing_design",
+      "infer_the_missing_design",
       "invent_unrequested_requirement",
       "claim_readiness_with_a_placeholder_present",
       "close_open_decision_without_requester",
@@ -17,14 +19,16 @@
   },
   {
     "case_id": "autonomous-explicit-no-fill-in-export",
-    "terminal_state": "blocked",
+    "terminal_state": "requires_brainstorming",
     "required_actions": [
       "ask_no_question_wait_for_no_answer",
-      "name_the_unresolved_decision_as_blocking_reason",
+      "name_the_absent_design_part",
       "choose_no_answer_on_requesters_behalf",
       "give_one_next_action"
     ],
     "forbidden_actions": [
+      "gather_the_missing_design",
+      "infer_the_missing_design",
       "invent_unrequested_requirement",
       "claim_readiness_with_a_placeholder_present",
       "close_open_decision_without_requester",
@@ -107,6 +111,63 @@
     ],
     "forbidden_actions": [
       "create_or_modify_ticket_or_relationship"
+    ]
+  },
+  {
+    "case_id": "one-sentence-bug-design-proceeds",
+    "terminal_state": "ticket_ready",
+    "required_actions": [
+      "accept_sufficient_design_without_further_design_questions",
+      "elicit_only_tracker_shaped_residue",
+      "fill_every_template_slot"
+    ],
+    "forbidden_actions": [
+      "require_design_ceremony_beyond_the_scale_of_the_work",
+      "gather_the_missing_design",
+      "invent_unrequested_requirement",
+      "claim_readiness_with_a_placeholder_present"
+    ]
+  },
+  {
+    "case_id": "full-design-document-proceeds",
+    "terminal_state": "ticket_ready",
+    "required_actions": [
+      "accept_sufficient_design_without_further_design_questions",
+      "elicit_only_tracker_shaped_residue",
+      "elicit_public_surface_behavior"
+    ],
+    "forbidden_actions": [
+      "relitigate_settled_design_decision",
+      "invent_unrequested_requirement",
+      "claim_readiness_with_a_placeholder_present"
+    ]
+  },
+  {
+    "case_id": "design-missing-requirements",
+    "terminal_state": "requires_brainstorming",
+    "required_actions": [
+      "name_the_absent_design_part",
+      "give_one_next_action"
+    ],
+    "forbidden_actions": [
+      "gather_the_missing_design",
+      "infer_the_missing_design",
+      "create_or_modify_ticket_or_relationship",
+      "invent_unrequested_requirement"
+    ]
+  },
+  {
+    "case_id": "autonomous-residue-unresolved-verification",
+    "terminal_state": "blocked",
+    "required_actions": [
+      "ask_no_question_wait_for_no_answer",
+      "name_the_unresolved_decision_as_blocking_reason",
+      "give_one_next_action"
+    ],
+    "forbidden_actions": [
+      "name_the_absent_design_part",
+      "invent_unrequested_requirement",
+      "claim_readiness_with_a_placeholder_present"
     ]
   }
 ]

--- a/skills/ready-ticket/evals/results/2026-08-15T173118Z-0003-before.json
+++ b/skills/ready-ticket/evals/results/2026-08-15T173118Z-0003-before.json
@@ -1,0 +1,149 @@
+{
+  "candidate": {
+    "branch": "scott/ticket-197-975284",
+    "sha": "1ce41875782ac2a8de04b70d39619493e919d1d5",
+    "tree": "ed225d3a4d9022de7332b8798bc8ddec3297f992",
+    "worktree_clean": true
+  },
+  "case_evidence": {
+    "autonomous-explicit-no-fill-in-export": {
+      "actions": [
+        "ask_no_question_wait_for_no_answer",
+        "give_one_next_action",
+        "name_the_unresolved_decision_as_blocking_reason",
+        "perform_no_tracker_mutation"
+      ],
+      "terminal_state": "blocked"
+    },
+    "autonomous-tracker-unchosen": {
+      "actions": [
+        "ask_no_question_wait_for_no_answer",
+        "choose_no_answer_on_requesters_behalf",
+        "choose_no_tracker_on_requesters_behalf",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target",
+        "perform_no_tracker_mutation",
+        "reject_internal_call_criterion",
+        "reject_placeholder_in_scan",
+        "rerun_all_four_scans_after_edit",
+        "return_complete_body_to_caller"
+      ],
+      "terminal_state": "draft_ready"
+    },
+    "autonomous-unresolvable-rate-limit": {
+      "actions": [
+        "ask_no_question_wait_for_no_answer",
+        "give_one_next_action",
+        "name_the_unresolved_decision_as_blocking_reason",
+        "perform_no_tracker_mutation"
+      ],
+      "terminal_state": "blocked"
+    },
+    "internal-criterion-rejected": {
+      "actions": [
+        "create_or_modify_ticket_or_relationship",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target",
+        "reject_internal_call_criterion",
+        "rerun_all_four_scans_after_edit"
+      ],
+      "terminal_state": "ticket_ready"
+    },
+    "multi-subsystem-decomposition": {
+      "actions": [
+        "choose_no_tracker_on_requesters_behalf",
+        "hand_recommendation_back_to_operator",
+        "name_each_independently_valuable_part",
+        "perform_no_tracker_mutation",
+        "record_boundary_between_parts",
+        "record_why_each_part_independently_valuable"
+      ],
+      "terminal_state": "decomposition_recommended"
+    },
+    "no-authority-draft-ready": {
+      "actions": [
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target",
+        "perform_no_tracker_mutation",
+        "reject_internal_call_criterion",
+        "reject_placeholder_in_scan",
+        "rerun_all_four_scans_after_edit",
+        "return_complete_body_to_caller",
+        "return_to_elicitation_for_missing_value"
+      ],
+      "terminal_state": "draft_ready"
+    },
+    "placeholder-scan-catches-first-draft": {
+      "actions": [
+        "create_or_modify_ticket_or_relationship",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target",
+        "reject_placeholder_in_scan",
+        "rerun_all_four_scans_after_edit",
+        "return_to_elicitation_for_missing_value"
+      ],
+      "terminal_state": "ticket_ready"
+    },
+    "vague-idea-resolved-elicitation": {
+      "actions": [
+        "create_or_modify_ticket_or_relationship",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target"
+      ],
+      "terminal_state": "ticket_ready"
+    }
+  },
+  "cases": {
+    "autonomous-explicit-no-fill-in-export": "fail",
+    "autonomous-tracker-unchosen": "pass",
+    "autonomous-unresolvable-rate-limit": "fail",
+    "internal-criterion-rejected": "pass",
+    "multi-subsystem-decomposition": "pass",
+    "no-authority-draft-ready": "pass",
+    "placeholder-scan-catches-first-draft": "pass",
+    "vague-idea-resolved-elicitation": "pass"
+  },
+  "command": [
+    "/Users/scott/.local/share/mise/installs/python/3.11/bin/python3",
+    "skills/ready-ticket/scripts/evals/run_forward.py",
+    "--executor",
+    "/Users/scott/.local/share/mise/installs/python/3.11/bin/python3 skills/ready-ticket/scripts/evals/claude_executor.py --model claude-opus-5"
+  ],
+  "compared_to": null,
+  "diff": {
+    "newly_failing": [],
+    "newly_passing": [],
+    "still_failing": [
+      "autonomous-explicit-no-fill-in-export",
+      "autonomous-unresolvable-rate-limit"
+    ],
+    "unchanged": 0
+  },
+  "exit_code": 1,
+  "failures": [
+    "autonomous-unresolvable-rate-limit: missing actions: choose_no_answer_on_requesters_behalf",
+    "autonomous-explicit-no-fill-in-export: missing actions: choose_no_answer_on_requesters_behalf"
+  ],
+  "forward_evals": true,
+  "gap": null,
+  "limitation": null,
+  "model": "claude-opus-5",
+  "note": null,
+  "output_tail": "{\n  \"failed\": 2,\n  \"failures\": [\n    \"autonomous-unresolvable-rate-limit: missing actions: choose_no_answer_on_requesters_behalf\",\n    \"autonomous-explicit-no-fill-in-export: missing actions: choose_no_answer_on_requesters_behalf\"\n  ],\n  \"passed\": 6,\n  \"total\": 8\n}",
+  "recorded_at": "2026-08-15T17:31:18Z",
+  "schema": "eval-run-summary/1",
+  "skill": "ready-ticket",
+  "stage": "before",
+  "status": "failed",
+  "suite": "forward",
+  "tier": "real-model",
+  "totals": {
+    "failed": 2,
+    "passed": 6,
+    "total": 8
+  }
+}

--- a/skills/ready-ticket/evals/results/2026-08-15T174840Z-0004-after.json
+++ b/skills/ready-ticket/evals/results/2026-08-15T174840Z-0004-after.json
@@ -1,0 +1,210 @@
+{
+  "candidate": {
+    "branch": "scott/ticket-197-975284",
+    "sha": "160012999c9f20218fae9f44513da356385ff983",
+    "tree": "c0535a125048bb88f7bd87c7169b53abe013d55e",
+    "worktree_clean": true
+  },
+  "case_evidence": {
+    "autonomous-explicit-no-fill-in-export": {
+      "actions": [
+        "ask_no_question_wait_for_no_answer",
+        "choose_no_answer_on_requesters_behalf",
+        "choose_no_tracker_on_requesters_behalf",
+        "name_the_absent_design_part",
+        "perform_no_tracker_mutation"
+      ],
+      "terminal_state": "requires_brainstorming"
+    },
+    "autonomous-residue-unresolved-verification": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "ask_no_question_wait_for_no_answer",
+        "choose_no_answer_on_requesters_behalf",
+        "give_one_next_action",
+        "name_the_unresolved_decision_as_blocking_reason",
+        "perform_no_tracker_mutation"
+      ],
+      "terminal_state": "blocked"
+    },
+    "autonomous-tracker-unchosen": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "ask_no_question_wait_for_no_answer",
+        "choose_no_answer_on_requesters_behalf",
+        "choose_no_tracker_on_requesters_behalf",
+        "elicit_only_tracker_shaped_residue",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target",
+        "perform_no_tracker_mutation",
+        "reject_internal_call_criterion",
+        "reject_placeholder_in_scan",
+        "rerun_all_four_scans_after_edit",
+        "return_complete_body_to_caller"
+      ],
+      "terminal_state": "draft_ready"
+    },
+    "autonomous-unresolvable-rate-limit": {
+      "actions": [
+        "ask_no_question_wait_for_no_answer",
+        "choose_no_answer_on_requesters_behalf",
+        "choose_no_tracker_on_requesters_behalf",
+        "name_the_absent_design_part",
+        "perform_no_tracker_mutation"
+      ],
+      "terminal_state": "requires_brainstorming"
+    },
+    "design-missing-requirements": {
+      "actions": [
+        "name_the_absent_design_part",
+        "perform_no_tracker_mutation"
+      ],
+      "terminal_state": "requires_brainstorming"
+    },
+    "full-design-document-proceeds": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "create_or_modify_ticket_or_relationship",
+        "elicit_only_tracker_shaped_residue",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target",
+        "reject_placeholder_in_scan",
+        "rerun_all_four_scans_after_edit"
+      ],
+      "terminal_state": "ticket_ready"
+    },
+    "internal-criterion-rejected": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "create_or_modify_ticket_or_relationship",
+        "elicit_only_tracker_shaped_residue",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target",
+        "reject_internal_call_criterion",
+        "rerun_all_four_scans_after_edit"
+      ],
+      "terminal_state": "ticket_ready"
+    },
+    "multi-subsystem-decomposition": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "elicit_only_tracker_shaped_residue",
+        "hand_recommendation_back_to_operator",
+        "name_each_independently_valuable_part",
+        "perform_no_tracker_mutation",
+        "record_boundary_between_parts",
+        "record_why_each_part_independently_valuable"
+      ],
+      "terminal_state": "decomposition_recommended"
+    },
+    "no-authority-draft-ready": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "choose_no_tracker_on_requesters_behalf",
+        "elicit_only_tracker_shaped_residue",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target",
+        "perform_no_tracker_mutation",
+        "return_complete_body_to_caller"
+      ],
+      "terminal_state": "draft_ready"
+    },
+    "one-sentence-bug-design-proceeds": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "choose_no_tracker_on_requesters_behalf",
+        "elicit_only_tracker_shaped_residue",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target",
+        "perform_no_tracker_mutation",
+        "return_complete_body_to_caller"
+      ],
+      "terminal_state": "draft_ready"
+    },
+    "placeholder-scan-catches-first-draft": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "create_or_modify_ticket_or_relationship",
+        "elicit_only_tracker_shaped_residue",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target",
+        "reject_placeholder_in_scan",
+        "rerun_all_four_scans_after_edit",
+        "return_to_elicitation_for_missing_value"
+      ],
+      "terminal_state": "ticket_ready"
+    },
+    "vague-idea-resolved-elicitation": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "create_or_modify_ticket_or_relationship",
+        "elicit_only_tracker_shaped_residue",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target"
+      ],
+      "terminal_state": "ticket_ready"
+    }
+  },
+  "cases": {
+    "autonomous-explicit-no-fill-in-export": "fail",
+    "autonomous-residue-unresolved-verification": "pass",
+    "autonomous-tracker-unchosen": "pass",
+    "autonomous-unresolvable-rate-limit": "fail",
+    "design-missing-requirements": "fail",
+    "full-design-document-proceeds": "pass",
+    "internal-criterion-rejected": "pass",
+    "multi-subsystem-decomposition": "pass",
+    "no-authority-draft-ready": "pass",
+    "one-sentence-bug-design-proceeds": "fail",
+    "placeholder-scan-catches-first-draft": "pass",
+    "vague-idea-resolved-elicitation": "pass"
+  },
+  "command": [
+    "/Users/scott/.local/share/mise/installs/python/3.11/bin/python3",
+    "skills/ready-ticket/scripts/evals/run_forward.py",
+    "--executor",
+    "/Users/scott/.local/share/mise/installs/python/3.11/bin/python3 skills/ready-ticket/scripts/evals/claude_executor.py --model claude-opus-5"
+  ],
+  "compared_to": "2026-08-15T173118Z-0003-before.json",
+  "diff": {
+    "newly_failing": [],
+    "newly_passing": [],
+    "still_failing": [
+      "autonomous-explicit-no-fill-in-export",
+      "autonomous-unresolvable-rate-limit"
+    ],
+    "unchanged": 8
+  },
+  "exit_code": 1,
+  "failures": [
+    "autonomous-unresolvable-rate-limit: missing actions: give_one_next_action",
+    "autonomous-explicit-no-fill-in-export: missing actions: give_one_next_action",
+    "one-sentence-bug-design-proceeds: terminal_state: expected 'ticket_ready', got 'draft_ready'",
+    "design-missing-requirements: missing actions: give_one_next_action"
+  ],
+  "forward_evals": true,
+  "gap": null,
+  "limitation": null,
+  "model": "claude-opus-5",
+  "note": null,
+  "output_tail": "{\n  \"failed\": 4,\n  \"failures\": [\n    \"autonomous-unresolvable-rate-limit: missing actions: give_one_next_action\",\n    \"autonomous-explicit-no-fill-in-export: missing actions: give_one_next_action\",\n    \"one-sentence-bug-design-proceeds: terminal_state: expected 'ticket_ready', got 'draft_ready'\",\n    \"design-missing-requirements: missing actions: give_one_next_action\"\n  ],\n  \"passed\": 8,\n  \"total\": 12\n}",
+  "recorded_at": "2026-08-15T17:48:40Z",
+  "schema": "eval-run-summary/1",
+  "skill": "ready-ticket",
+  "stage": "after",
+  "status": "failed",
+  "suite": "forward",
+  "tier": "real-model",
+  "totals": {
+    "failed": 4,
+    "passed": 8,
+    "total": 12
+  }
+}

--- a/skills/ready-ticket/evals/results/2026-08-15T175611Z-0005-after.json
+++ b/skills/ready-ticket/evals/results/2026-08-15T175611Z-0005-after.json
@@ -1,0 +1,213 @@
+{
+  "candidate": {
+    "branch": "scott/ticket-197-975284",
+    "sha": "4bc4cb98aa63289472599cf768785cc26beb316f",
+    "tree": "5b7bebed5fd99c704e4b406c8fa3af3e041a5663",
+    "worktree_clean": true
+  },
+  "case_evidence": {
+    "autonomous-explicit-no-fill-in-export": {
+      "actions": [
+        "ask_no_question_wait_for_no_answer",
+        "choose_no_answer_on_requesters_behalf",
+        "choose_no_tracker_on_requesters_behalf",
+        "give_one_next_action",
+        "name_the_absent_design_part",
+        "perform_no_tracker_mutation"
+      ],
+      "terminal_state": "requires_brainstorming"
+    },
+    "autonomous-residue-unresolved-verification": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "ask_no_question_wait_for_no_answer",
+        "choose_no_answer_on_requesters_behalf",
+        "elicit_only_tracker_shaped_residue",
+        "give_one_next_action",
+        "name_the_unresolved_decision_as_blocking_reason",
+        "perform_no_tracker_mutation"
+      ],
+      "terminal_state": "blocked"
+    },
+    "autonomous-tracker-unchosen": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "ask_no_question_wait_for_no_answer",
+        "choose_no_answer_on_requesters_behalf",
+        "choose_no_tracker_on_requesters_behalf",
+        "elicit_only_tracker_shaped_residue",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target",
+        "perform_no_tracker_mutation",
+        "reject_placeholder_in_scan",
+        "return_complete_body_to_caller"
+      ],
+      "terminal_state": "draft_ready"
+    },
+    "autonomous-unresolvable-rate-limit": {
+      "actions": [
+        "ask_no_question_wait_for_no_answer",
+        "choose_no_answer_on_requesters_behalf",
+        "choose_no_tracker_on_requesters_behalf",
+        "give_one_next_action",
+        "name_the_absent_design_part",
+        "perform_no_tracker_mutation"
+      ],
+      "terminal_state": "requires_brainstorming"
+    },
+    "design-missing-requirements": {
+      "actions": [
+        "give_one_next_action",
+        "name_the_absent_design_part",
+        "perform_no_tracker_mutation"
+      ],
+      "terminal_state": "requires_brainstorming"
+    },
+    "full-design-document-proceeds": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "create_or_modify_ticket_or_relationship",
+        "elicit_only_tracker_shaped_residue",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target",
+        "reject_placeholder_in_scan"
+      ],
+      "terminal_state": "ticket_ready"
+    },
+    "internal-criterion-rejected": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "create_or_modify_ticket_or_relationship",
+        "elicit_only_tracker_shaped_residue",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target",
+        "reject_internal_call_criterion",
+        "reject_placeholder_in_scan",
+        "rerun_all_four_scans_after_edit"
+      ],
+      "terminal_state": "ticket_ready"
+    },
+    "multi-subsystem-decomposition": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "elicit_only_tracker_shaped_residue",
+        "hand_recommendation_back_to_operator",
+        "name_each_independently_valuable_part",
+        "perform_no_tracker_mutation",
+        "record_boundary_between_parts",
+        "record_why_each_part_independently_valuable"
+      ],
+      "terminal_state": "decomposition_recommended"
+    },
+    "no-authority-draft-ready": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "choose_no_answer_on_requesters_behalf",
+        "choose_no_tracker_on_requesters_behalf",
+        "elicit_only_tracker_shaped_residue",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target",
+        "perform_no_tracker_mutation",
+        "reject_placeholder_in_scan",
+        "rerun_all_four_scans_after_edit",
+        "return_complete_body_to_caller"
+      ],
+      "terminal_state": "draft_ready"
+    },
+    "one-sentence-bug-design-proceeds": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "create_or_modify_ticket_or_relationship",
+        "elicit_only_tracker_shaped_residue",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target"
+      ],
+      "terminal_state": "ticket_ready"
+    },
+    "placeholder-scan-catches-first-draft": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "create_or_modify_ticket_or_relationship",
+        "elicit_only_tracker_shaped_residue",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target",
+        "reject_placeholder_in_scan",
+        "rerun_all_four_scans_after_edit",
+        "return_to_elicitation_for_missing_value"
+      ],
+      "terminal_state": "ticket_ready"
+    },
+    "vague-idea-resolved-elicitation": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "create_or_modify_ticket_or_relationship",
+        "elicit_only_tracker_shaped_residue",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target",
+        "reject_internal_call_criterion",
+        "reject_placeholder_in_scan",
+        "rerun_all_four_scans_after_edit"
+      ],
+      "terminal_state": "ticket_ready"
+    }
+  },
+  "cases": {
+    "autonomous-explicit-no-fill-in-export": "pass",
+    "autonomous-residue-unresolved-verification": "pass",
+    "autonomous-tracker-unchosen": "pass",
+    "autonomous-unresolvable-rate-limit": "pass",
+    "design-missing-requirements": "pass",
+    "full-design-document-proceeds": "pass",
+    "internal-criterion-rejected": "pass",
+    "multi-subsystem-decomposition": "pass",
+    "no-authority-draft-ready": "pass",
+    "one-sentence-bug-design-proceeds": "pass",
+    "placeholder-scan-catches-first-draft": "pass",
+    "vague-idea-resolved-elicitation": "pass"
+  },
+  "command": [
+    "/Users/scott/.local/share/mise/installs/python/3.11/bin/python3",
+    "skills/ready-ticket/scripts/evals/run_forward.py",
+    "--executor",
+    "/Users/scott/.local/share/mise/installs/python/3.11/bin/python3 skills/ready-ticket/scripts/evals/claude_executor.py --model claude-opus-5"
+  ],
+  "compared_to": "2026-08-15T174840Z-0004-after.json",
+  "diff": {
+    "newly_failing": [],
+    "newly_passing": [
+      "autonomous-explicit-no-fill-in-export",
+      "autonomous-unresolvable-rate-limit",
+      "design-missing-requirements",
+      "one-sentence-bug-design-proceeds"
+    ],
+    "still_failing": [],
+    "unchanged": 8
+  },
+  "exit_code": 0,
+  "failures": [],
+  "forward_evals": true,
+  "gap": null,
+  "limitation": null,
+  "model": "claude-opus-5",
+  "note": "second after run: re-recorded following the prose and corpus fixes the first after run surfaced",
+  "output_tail": "{\n  \"failed\": 0,\n  \"failures\": [],\n  \"passed\": 12,\n  \"total\": 12\n}",
+  "recorded_at": "2026-08-15T17:56:11Z",
+  "schema": "eval-run-summary/1",
+  "skill": "ready-ticket",
+  "stage": "after",
+  "status": "completed",
+  "suite": "forward",
+  "tier": "real-model",
+  "totals": {
+    "failed": 0,
+    "passed": 12,
+    "total": 12
+  }
+}

--- a/skills/ready-ticket/evals/results/2026-08-15T201439Z-0006-after.json
+++ b/skills/ready-ticket/evals/results/2026-08-15T201439Z-0006-after.json
@@ -1,0 +1,201 @@
+{
+  "candidate": {
+    "branch": "scott/ticket-197-975284",
+    "sha": "aba106cf198f42c9537e2b0167fa6d6d136a13dd",
+    "tree": "f60d15b302e579e63bb56b590c7a2f71342d0d3a",
+    "worktree_clean": true
+  },
+  "case_evidence": {
+    "autonomous-explicit-no-fill-in-export": {
+      "actions": [
+        "ask_no_question_wait_for_no_answer",
+        "choose_no_answer_on_requesters_behalf",
+        "choose_no_tracker_on_requesters_behalf",
+        "give_one_next_action",
+        "name_the_absent_design_part",
+        "perform_no_tracker_mutation"
+      ],
+      "terminal_state": "requires_brainstorming"
+    },
+    "autonomous-residue-unresolved-verification": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "ask_no_question_wait_for_no_answer",
+        "elicit_only_tracker_shaped_residue",
+        "give_one_next_action",
+        "name_the_unresolved_decision_as_blocking_reason",
+        "perform_no_tracker_mutation"
+      ],
+      "terminal_state": "blocked"
+    },
+    "autonomous-tracker-unchosen": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "ask_no_question_wait_for_no_answer",
+        "choose_no_answer_on_requesters_behalf",
+        "choose_no_tracker_on_requesters_behalf",
+        "elicit_only_tracker_shaped_residue",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "perform_no_tracker_mutation",
+        "reject_placeholder_in_scan",
+        "return_complete_body_to_caller"
+      ],
+      "terminal_state": "draft_ready"
+    },
+    "autonomous-unresolvable-rate-limit": {
+      "actions": [
+        "ask_no_question_wait_for_no_answer",
+        "choose_no_answer_on_requesters_behalf",
+        "choose_no_tracker_on_requesters_behalf",
+        "give_one_next_action",
+        "name_the_absent_design_part",
+        "perform_no_tracker_mutation"
+      ],
+      "terminal_state": "requires_brainstorming"
+    },
+    "design-missing-requirements": {
+      "actions": [
+        "give_one_next_action",
+        "name_the_absent_design_part",
+        "perform_no_tracker_mutation"
+      ],
+      "terminal_state": "requires_brainstorming"
+    },
+    "full-design-document-proceeds": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "create_or_modify_ticket_or_relationship",
+        "elicit_only_tracker_shaped_residue",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target",
+        "reject_placeholder_in_scan"
+      ],
+      "terminal_state": "ticket_ready"
+    },
+    "internal-criterion-rejected": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "create_or_modify_ticket_or_relationship",
+        "elicit_only_tracker_shaped_residue",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target",
+        "reject_internal_call_criterion",
+        "rerun_all_four_scans_after_edit"
+      ],
+      "terminal_state": "ticket_ready"
+    },
+    "multi-subsystem-decomposition": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "elicit_only_tracker_shaped_residue",
+        "give_one_next_action",
+        "hand_recommendation_back_to_operator",
+        "name_each_independently_valuable_part",
+        "perform_no_tracker_mutation",
+        "record_boundary_between_parts",
+        "record_why_each_part_independently_valuable"
+      ],
+      "terminal_state": "decomposition_recommended"
+    },
+    "no-authority-draft-ready": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "elicit_only_tracker_shaped_residue",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target",
+        "perform_no_tracker_mutation",
+        "reject_placeholder_in_scan",
+        "return_complete_body_to_caller"
+      ],
+      "terminal_state": "draft_ready"
+    },
+    "one-sentence-bug-design-proceeds": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "create_or_modify_ticket_or_relationship",
+        "elicit_only_tracker_shaped_residue",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target"
+      ],
+      "terminal_state": "ticket_ready"
+    },
+    "placeholder-scan-catches-first-draft": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "create_or_modify_ticket_or_relationship",
+        "elicit_only_tracker_shaped_residue",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target",
+        "reject_placeholder_in_scan",
+        "rerun_all_four_scans_after_edit",
+        "return_to_elicitation_for_missing_value"
+      ],
+      "terminal_state": "ticket_ready"
+    },
+    "vague-idea-resolved-elicitation": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "create_or_modify_ticket_or_relationship",
+        "elicit_only_tracker_shaped_residue",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target",
+        "reject_placeholder_in_scan"
+      ],
+      "terminal_state": "ticket_ready"
+    }
+  },
+  "cases": {
+    "autonomous-explicit-no-fill-in-export": "pass",
+    "autonomous-residue-unresolved-verification": "pass",
+    "autonomous-tracker-unchosen": "pass",
+    "autonomous-unresolvable-rate-limit": "pass",
+    "design-missing-requirements": "pass",
+    "full-design-document-proceeds": "pass",
+    "internal-criterion-rejected": "pass",
+    "multi-subsystem-decomposition": "pass",
+    "no-authority-draft-ready": "pass",
+    "one-sentence-bug-design-proceeds": "pass",
+    "placeholder-scan-catches-first-draft": "pass",
+    "vague-idea-resolved-elicitation": "pass"
+  },
+  "command": [
+    "/Users/scott/.local/share/mise/installs/python/3.11/bin/python3",
+    "skills/ready-ticket/scripts/evals/run_forward.py",
+    "--executor",
+    "/Users/scott/.local/share/mise/installs/python/3.11/bin/python3 skills/ready-ticket/scripts/evals/claude_executor.py --model claude-opus-5"
+  ],
+  "compared_to": "2026-08-15T175611Z-0005-after.json",
+  "diff": {
+    "newly_failing": [],
+    "newly_passing": [],
+    "still_failing": [],
+    "unchanged": 12
+  },
+  "exit_code": 0,
+  "failures": [],
+  "forward_evals": true,
+  "gap": null,
+  "limitation": null,
+  "model": "claude-opus-5",
+  "note": "final after run: recorded at the converged head aba106c so the committed summary names the prose that ships",
+  "output_tail": "{\n  \"failed\": 0,\n  \"failures\": [],\n  \"passed\": 12,\n  \"total\": 12\n}",
+  "recorded_at": "2026-08-15T20:14:39Z",
+  "schema": "eval-run-summary/1",
+  "skill": "ready-ticket",
+  "stage": "after",
+  "status": "completed",
+  "suite": "forward",
+  "tier": "real-model",
+  "totals": {
+    "failed": 0,
+    "passed": 12,
+    "total": 12
+  }
+}

--- a/skills/ready-ticket/scripts/evals/claude_executor.py
+++ b/skills/ready-ticket/scripts/evals/claude_executor.py
@@ -28,6 +28,7 @@ TERMINAL_STATES = (
     "ticket_ready",
     "draft_ready",
     "decomposition_recommended",
+    "requires_brainstorming",
     "blocked",
 )
 
@@ -35,6 +36,7 @@ TERMINAL_STATES = (
 # forward_expectations.json. Grading is multiple-choice by design: the model
 # must decide which obligations apply, not invent matching strings.
 ACTION_VOCABULARY = (
+    "accept_sufficient_design_without_further_design_questions",
     "ask_no_question_wait_for_no_answer",
     "assert_criterion_on_internals",
     "choose_no_answer_on_requesters_behalf",
@@ -42,18 +44,24 @@ ACTION_VOCABULARY = (
     "claim_readiness_with_a_placeholder_present",
     "close_open_decision_without_requester",
     "create_or_modify_ticket_or_relationship",
+    "elicit_only_tracker_shaped_residue",
     "elicit_public_surface_behavior",
     "fill_every_template_slot",
+    "gather_the_missing_design",
     "give_one_next_action",
+    "infer_the_missing_design",
     "invent_unrequested_requirement",
     "invoke_load_bearing_without_consent",
     "meet_the_ticket_ready_readiness_target",
     "mention_peer_absence_as_caveat",
     "name_each_independently_valuable_part",
+    "name_the_absent_design_part",
     "name_the_unresolved_decision_as_blocking_reason",
     "perform_no_tracker_mutation",
     "reject_internal_call_criterion",
     "reject_placeholder_in_scan",
+    "relitigate_settled_design_decision",
+    "require_design_ceremony_beyond_the_scale_of_the_work",
     "rerun_all_four_scans_after_edit",
     "return_complete_body_to_caller",
     "return_to_elicitation_for_missing_value",

--- a/skills/ready-ticket/scripts/evals/fixture_executor.py
+++ b/skills/ready-ticket/scripts/evals/fixture_executor.py
@@ -23,19 +23,19 @@ import sys
 # case/expectation ID check plus a mismatch here.
 ANSWERS: dict[str, dict] = {
     "Write a ticket for adding rate limiting to our public API. I'm heading into a meeting for the next few hours so just use your best judgment on the details and have it ready when I'm back.": {
-        "terminal_state": "blocked",
+        "terminal_state": "requires_brainstorming",
         "actions": [
             "ask_no_question_wait_for_no_answer",
-            "name_the_unresolved_decision_as_blocking_reason",
+            "name_the_absent_design_part",
             "choose_no_answer_on_requesters_behalf",
             "give_one_next_action",
         ],
     },
     "There's no ticket for this yet. Users want a way to export their data. Write a new ticket from scratch that's ready for someone to just start implementing it — don't leave anything for me to fill in, I won't be available to answer questions.": {
-        "terminal_state": "blocked",
+        "terminal_state": "requires_brainstorming",
         "actions": [
             "ask_no_question_wait_for_no_answer",
-            "name_the_unresolved_decision_as_blocking_reason",
+            "name_the_absent_design_part",
             "choose_no_answer_on_requesters_behalf",
             "give_one_next_action",
         ],
@@ -86,6 +86,37 @@ ANSWERS: dict[str, dict] = {
             "choose_no_tracker_on_requesters_behalf",
             "perform_no_tracker_mutation",
             "return_complete_body_to_caller",
+        ],
+    },
+    "Ticket this bug: uploads over 10 MB fail with a 500 instead of the documented 413, and they should return 413.": {
+        "terminal_state": "ticket_ready",
+        "actions": [
+            "accept_sufficient_design_without_further_design_questions",
+            "elicit_only_tracker_shaped_residue",
+            "fill_every_template_slot",
+        ],
+    },
+    "Make GH-431 ready — the linked design was approved last week.": {
+        "terminal_state": "ticket_ready",
+        "actions": [
+            "accept_sufficient_design_without_further_design_questions",
+            "elicit_only_tracker_shaped_residue",
+            "elicit_public_surface_behavior",
+        ],
+    },
+    "Write a ticket for the new notifications feature.": {
+        "terminal_state": "requires_brainstorming",
+        "actions": [
+            "name_the_absent_design_part",
+            "give_one_next_action",
+        ],
+    },
+    "Make GH-660 ready.": {
+        "terminal_state": "blocked",
+        "actions": [
+            "ask_no_question_wait_for_no_answer",
+            "name_the_unresolved_decision_as_blocking_reason",
+            "give_one_next_action",
         ],
     },
 }

--- a/skills/ready-ticket/scripts/tests/test_authoring_contract.py
+++ b/skills/ready-ticket/scripts/tests/test_authoring_contract.py
@@ -198,7 +198,7 @@ class ReadyTicketContractTests(unittest.TestCase):
             "A one-sentence bug design and a design document representing months "
             "of work are both legal inputs, checked against the same four parts",
             "reopen no decision the design already settles",
-            "Reopening reverses a choice the requester already made",
+            "reopening a settled decision reverses a choice the requester already made",
         ):
             self.assertIn(clause, self.contract)
 

--- a/skills/ready-ticket/scripts/tests/test_authoring_contract.py
+++ b/skills/ready-ticket/scripts/tests/test_authoring_contract.py
@@ -211,13 +211,28 @@ class ReadyTicketContractTests(unittest.TestCase):
     def test_a_missing_design_part_returns_requires_brainstorming_naming_the_gap(self):
         """AC: a missing design part names the gap in a routable typed result."""
         for clause in (
-            "A design is sufficient when it captures the requirements and "
-            "acceptance criteria, states the goals and non-goals, and identifies "
-            "the stakeholders and deadlines",
-            "return `requires_brainstorming`, naming which of the four is absent "
-            "and what it is absent about",
+            "A design is sufficient when all four of its parts are present",
+            "return `requires_brainstorming`, naming which of the four parts is "
+            "absent and what it is absent about",
         ):
             self.assertIn(clause, self.contract)
+
+        # The gate asks the run to name *which* part is absent, so the four must
+        # be enumerated rather than counted — "four" already denotes the four
+        # self-review scans elsewhere in this document.
+        gate = compact(
+            self.skill.split("## Require an approved design", 1)[1].split("\n## ", 1)[0]
+        )
+        for index, part in enumerate(
+            (
+                "the **requirements**",
+                "the **acceptance criteria**",
+                "the **goals and non-goals**",
+                "the **stakeholders and deadlines**",
+            ),
+            start=1,
+        ):
+            self.assertIn(f"{index}. {part}", gate)
 
         for case_id in (
             "design-missing-requirements",

--- a/skills/ready-ticket/scripts/tests/test_authoring_contract.py
+++ b/skills/ready-ticket/scripts/tests/test_authoring_contract.py
@@ -249,8 +249,8 @@ class ReadyTicketContractTests(unittest.TestCase):
     def test_a_named_gap_is_paired_with_a_next_action(self):
         """A diagnosis without a route is what `blocked` already produced."""
         self.assertIn(
-            "The result names which part is absent, what it is absent about, and "
-            "one next action",
+            "The result names which part, what is unsettled about it, which shape "
+            "it is, and one next action",
             self.contract,
         )
         self.assertIn(
@@ -258,6 +258,17 @@ class ReadyTicketContractTests(unittest.TestCase):
             "holding a diagnosis rather than a route",
             self.contract,
         )
+        # Both shapes reach the same result, so its precondition has to admit
+        # both: a part absent at the gate, and a part unsettled after it.
+        for shape in (
+            "it was **absent at the gate**, or it was **unsettled after the gate**",
+            "A part that passes this gate can still stop being settled later",
+        ):
+            self.assertIn(shape, self.contract)
+        self.assertIn(
+            "whether it was absent at the gate or unsettled after it", self.contract
+        )
+
         routed = [
             case_id
             for case_id, item in self.expectations.items()
@@ -319,8 +330,10 @@ class ReadyTicketContractTests(unittest.TestCase):
     def test_a_falsified_assumption_is_returned_rather_than_re_decided(self):
         self.assertIn(
             "A falsified assumption unsettles something the design had settled, so "
-            "it returns `requires_brainstorming` naming the falsified assumption; "
-            "choosing the replacement is design work and does not happen here",
+            "it returns `requires_brainstorming` naming the falsified assumption — "
+            "that result's second shape, unsettled after the gate rather than "
+            "absent at it. Choosing the replacement is design work and does not "
+            "happen here",
             self.contract,
         )
         case_id = "falsified-assumption-returns-to-elicitation"

--- a/skills/ready-ticket/scripts/tests/test_authoring_contract.py
+++ b/skills/ready-ticket/scripts/tests/test_authoring_contract.py
@@ -1,9 +1,10 @@
 """Load-bearing contract invariants for the ready-ticket skill.
 
-These tests check stable identifiers — the skill name, its four terminal
-results, the readiness target it inherits from implement-ticket, the recorded
-peer bounds, and the result-blind fixture pairing — not prose phrasing.
-Scenario coverage lives in the evaluation data under evals/.
+These tests check stable identifiers — the skill name, its five terminal
+results, the approved-design input gate, the readiness target it inherits from
+implement-ticket, the recorded peer bounds, and the result-blind fixture
+pairing — not prose phrasing. Scenario coverage lives in the evaluation data
+under evals/.
 """
 
 from __future__ import annotations
@@ -21,6 +22,7 @@ TERMINAL_RESULTS = (
     "ticket_ready",
     "draft_ready",
     "decomposition_recommended",
+    "requires_brainstorming",
     "blocked",
 )
 
@@ -70,7 +72,7 @@ class ReadyTicketContractTests(unittest.TestCase):
 
     # --- Terminal results -------------------------------------------------
 
-    def test_four_terminal_results_are_exhaustive_and_documented(self):
+    def test_terminal_results_are_exhaustive_and_documented(self):
         for state in TERMINAL_RESULTS:
             self.assertIn(f"`{state}`", self.skill)
         self.assertIn("Return exactly one state", self.skill)
@@ -171,6 +173,121 @@ class ReadyTicketContractTests(unittest.TestCase):
             "`file this`, `write it up`, or `get it ready`",
         ):
             self.assertIn(required, self.contract)
+
+    # --- The approved-design input gate -----------------------------------
+
+    def test_a_one_sentence_design_is_sufficient_at_its_own_scale(self):
+        """AC: a sufficient one-sentence bug design proceeds without ceremony."""
+        for clause in (
+            "For a one-line bugfix, the sentence is the design",
+            "Scale is not a threshold to adjudicate, and there is no second door "
+            "for bug reports",
+            "Ask for no design ceremony the work does not warrant",
+        ):
+            self.assertIn(clause, self.contract)
+
+        case_id = "one-sentence-bug-design-sufficient"
+        self.assertEqual("ticket_ready", self.expectations[case_id]["workflow_state"])
+        actions = self.actions(case_id)
+        self.assertIn("accept the one-sentence design as sufficient", actions)
+        self.assertIn("ask no further design question", actions)
+
+    def test_a_sufficient_full_design_is_not_relitigated(self):
+        """AC: a sufficient full design proceeds without re-litigating it."""
+        for clause in (
+            "A one-sentence bug design and a design document representing months "
+            "of work are both legal inputs, checked against the same four parts",
+            "reopen no decision the design already settles",
+            "Reopening reverses a choice the requester already made",
+        ):
+            self.assertIn(clause, self.contract)
+
+        case_id = "full-design-document-not-relitigated"
+        self.assertEqual("ticket_ready", self.expectations[case_id]["workflow_state"])
+        self.assertIn(
+            "reopen no decision the design already settles", self.actions(case_id)
+        )
+
+    def test_a_missing_design_part_returns_requires_brainstorming_naming_the_gap(self):
+        """AC: a missing design part names the gap in a routable typed result."""
+        for clause in (
+            "A design is sufficient when it captures the requirements and "
+            "acceptance criteria, states the goals and non-goals, and identifies "
+            "the stakeholders and deadlines",
+            "return `requires_brainstorming`, naming which of the four is absent "
+            "and what it is absent about",
+        ):
+            self.assertIn(clause, self.contract)
+
+        for case_id in (
+            "design-missing-requirements",
+            "autonomous-unresolved-product-decision",
+            "requester-objection-unresolved",
+        ):
+            self.assertEqual(
+                "requires_brainstorming",
+                self.expectations[case_id]["workflow_state"],
+                case_id,
+            )
+            self.assertIn("as the missing design part", self.actions(case_id), case_id)
+
+    def test_the_endpoint_never_gathers_or_infers_the_missing_design(self):
+        """AC: the endpoint never gathers the missing design itself."""
+        for clause in (
+            "Do not gather it, and do not infer it from the parts that are present",
+            "Inference is gathering under another name",
+            "A question that would settle a design-owned decision is out of bounds "
+            "here",
+            "The caller decides whether to go get the design; this skill never does",
+        ):
+            self.assertIn(clause, self.contract)
+
+        for case_id in (
+            "design-missing-requirements",
+            "autonomous-unresolved-product-decision",
+        ):
+            actions = self.actions(case_id)
+            self.assertIn("gather no missing design part", actions, case_id)
+            self.assertIn("infer no missing design part", actions, case_id)
+
+    def test_elicitation_narrows_to_the_tracker_shaped_residue(self):
+        for clause in (
+            "The residue is what an approved design cannot answer",
+            "- each acceptance criterion restated as an observable behavior of the "
+            "public surface;",
+            "- whether each verification item applies pre-merge or post-merge.",
+            "Keep asking until every residue item has an answer",
+        ):
+            self.assertIn(clause, self.contract)
+
+    def test_a_missing_design_is_not_also_a_blocked_condition(self):
+        """`requires_brainstorming` and `blocked` must not claim the same input."""
+        self.assertIn(
+            "A missing or insufficient approved design is not one of them",
+            self.contract,
+        )
+        stop_conditions = compact(
+            self.skill.split("## Stop conditions", 1)[1].split(
+                "A missing or insufficient", 1
+            )[0]
+        )
+        self.assertNotIn("architecture decision is unresolved", stop_conditions)
+        self.assertIn("a residue item", stop_conditions)
+
+    def test_a_falsified_assumption_is_returned_rather_than_re_decided(self):
+        self.assertIn(
+            "A falsified assumption unsettles something the design had settled, so "
+            "it returns `requires_brainstorming` naming the falsified assumption; "
+            "choosing the replacement is design work and does not happen here",
+            self.contract,
+        )
+        case_id = "falsified-assumption-returns-to-elicitation"
+        self.assertEqual(
+            "requires_brainstorming", self.expectations[case_id]["workflow_state"]
+        )
+        self.assertIn(
+            "choose no replacement storage approach here", self.actions(case_id)
+        )
 
     # --- Readiness target -------------------------------------------------
 
@@ -388,7 +505,7 @@ class ReadyTicketContractTests(unittest.TestCase):
             self.expectations["autonomous-approval-not-obtainable"]["workflow_state"],
         )
         self.assertEqual(
-            "blocked",
+            "requires_brainstorming",
             self.expectations["autonomous-unresolved-product-decision"][
                 "workflow_state"
             ],

--- a/skills/ready-ticket/scripts/tests/test_authoring_contract.py
+++ b/skills/ready-ticket/scripts/tests/test_authoring_contract.py
@@ -231,6 +231,27 @@ class ReadyTicketContractTests(unittest.TestCase):
             )
             self.assertIn("as the missing design part", self.actions(case_id), case_id)
 
+    def test_a_named_gap_is_paired_with_a_next_action(self):
+        """A diagnosis without a route is what `blocked` already produced."""
+        self.assertIn(
+            "The result names which part is absent, what it is absent about, and "
+            "one next action",
+            self.contract,
+        )
+        self.assertIn(
+            "Naming the gap without naming the next action leaves the caller "
+            "holding a diagnosis rather than a route",
+            self.contract,
+        )
+        routed = [
+            case_id
+            for case_id, item in self.expectations.items()
+            if item["workflow_state"] == "requires_brainstorming"
+        ]
+        self.assertTrue(routed)
+        for case_id in routed:
+            self.assertIn("give one next action", self.actions(case_id), case_id)
+
     def test_the_endpoint_never_gathers_or_infers_the_missing_design(self):
         """AC: the endpoint never gathers the missing design itself."""
         for clause in (

--- a/skills/ready-ticket/scripts/tests/test_authoring_contract.py
+++ b/skills/ready-ticket/scripts/tests/test_authoring_contract.py
@@ -294,6 +294,12 @@ class ReadyTicketContractTests(unittest.TestCase):
         )
         self.assertNotIn("architecture decision is unresolved", stop_conditions)
         self.assertIn("a residue item", stop_conditions)
+        self.assertIn("residue-shaped objection", stop_conditions)
+        self.assertIn(
+            "neither is an objection that rests on one: both return "
+            "`requires_brainstorming`",
+            self.contract,
+        )
 
     def test_a_falsified_assumption_is_returned_rather_than_re_decided(self):
         self.assertIn(

--- a/skills/ready-ticket/scripts/tests/test_forward_evals.py
+++ b/skills/ready-ticket/scripts/tests/test_forward_evals.py
@@ -28,6 +28,7 @@ TERMINAL_RESULTS = {
     "ticket_ready",
     "draft_ready",
     "decomposition_recommended",
+    "requires_brainstorming",
     "blocked",
 }
 
@@ -41,10 +42,62 @@ class CorpusShapeTests(unittest.TestCase):
         self.assertEqual(sorted(case_ids), sorted(EXPECTATIONS))
         self.assertEqual(len(case_ids), len(set(case_ids)))
 
-    def test_all_four_terminal_results_are_covered(self) -> None:
+    def test_every_terminal_result_is_covered(self) -> None:
         observed = {item["terminal_state"] for item in EXPECTATIONS.values()}
 
         self.assertEqual(observed, TERMINAL_RESULTS)
+
+    def test_both_approved_design_scales_and_a_missing_design_are_covered(self) -> None:
+        """AC: one-sentence and full designs proceed; a missing one routes."""
+        for case_id, expected in (
+            ("one-sentence-bug-design-proceeds", "ticket_ready"),
+            ("full-design-document-proceeds", "ticket_ready"),
+            ("design-missing-requirements", "requires_brainstorming"),
+        ):
+            self.assertEqual(expected, EXPECTATIONS[case_id]["terminal_state"], case_id)
+
+        proceeds = ("one-sentence-bug-design-proceeds", "full-design-document-proceeds")
+        for case_id in proceeds:
+            required = set(EXPECTATIONS[case_id]["required_actions"])
+            self.assertIn(
+                "accept_sufficient_design_without_further_design_questions", required
+            )
+            self.assertIn("elicit_only_tracker_shaped_residue", required)
+
+        self.assertIn(
+            "require_design_ceremony_beyond_the_scale_of_the_work",
+            EXPECTATIONS["one-sentence-bug-design-proceeds"]["forbidden_actions"],
+        )
+        self.assertIn(
+            "relitigate_settled_design_decision",
+            EXPECTATIONS["full-design-document-proceeds"]["forbidden_actions"],
+        )
+
+    def test_no_missing_design_case_may_gather_or_infer_the_design(self) -> None:
+        """AC: the endpoint never gathers the missing design itself."""
+        missing_design = [
+            case_id
+            for case_id, item in EXPECTATIONS.items()
+            if item["terminal_state"] == "requires_brainstorming"
+        ]
+
+        self.assertTrue(missing_design)
+        for case_id in missing_design:
+            forbidden = set(EXPECTATIONS[case_id]["forbidden_actions"])
+            self.assertIn("gather_the_missing_design", forbidden, case_id)
+            self.assertIn("infer_the_missing_design", forbidden, case_id)
+            self.assertIn(
+                "name_the_absent_design_part",
+                EXPECTATIONS[case_id]["required_actions"],
+                case_id,
+            )
+
+    def test_an_unresolved_residue_item_stays_blocked_not_routed(self) -> None:
+        """A sufficient design with an unanswerable residue item is not a design gap."""
+        expectation = EXPECTATIONS["autonomous-residue-unresolved-verification"]
+
+        self.assertEqual("blocked", expectation["terminal_state"])
+        self.assertIn("name_the_absent_design_part", expectation["forbidden_actions"])
 
     def test_cases_carry_no_expected_answers(self) -> None:
         """Give an evaluated agent only the scenario inputs, per the README."""


### PR DESCRIPTION
## Outcome

`ready-ticket` stops approximating the design conversation and starts consuming
its output. The design becomes an input the skill validates; a design-owned gap
becomes a routable typed result instead of a generic stop.

Before this, the boundary sat wherever a run happened to stop asking.
`docs/cognitive-driven-development.md` at `308b6212` relocates it somewhere a
run can check — brainstorming is done when the requirements and acceptance
criteria are captured, the goals and non-goals are known, and the stakeholders
and deadlines are identified, each at the scale the work warrants — and this
change binds the skill to that boundary.

## What changed

- **The design gate.** Four enumerated parts — requirements; acceptance
  criteria; goals and non-goals; stakeholders and deadlines — checked at any
  scale. A one-sentence bug design and a document representing months of work
  are both legal inputs, checked the same way. Neither earns extra ceremony, and
  neither gets re-litigated.
- **Elicitation narrows to the tracker-shaped residue** a design cannot answer:
  each criterion restated as observable public-surface behavior, the check that
  would demonstrate it, and whether that check runs before or after merge.
- **`requires_brainstorming`**, a fifth terminal result, in two shapes: a part
  **absent at the gate**, or a part **unsettled after the gate** by a
  verification that falsified what the design rested on. It names the part, what
  is unsettled, which shape, and one next action. It never gathers the gap and
  never infers it — an inferred requirement lands in the body as decided, and
  the next reader never learns nobody decided it.

## Behavior that moved, deliberately

Three corpus expectations change **answer rather than grade**, because the new
contract routes what the old one could only report: the unresolved
retry-idempotency case, the objection resting on an unmade pricing decision, and
the falsified load-bearing assumption whose replacement is design work. Two
forward cases move the same way — so their before/after movement compares two
different questions and is **not** evidence about the prose in either direction.
`evals/README.md` records that rather than leaving a reader to read it as a win.

A sufficient design whose residue nobody can resolve still stops at `blocked`,
and a new forward case holds that line so the two results cannot collapse.

## Validation

All pre-merge; the ticket authors no post-merge items.

| Item | Evidence | Status |
| --- | --- | --- |
| AC1–AC4 | 6 contract tests + 3 forward cases | pass @ `aba106c` |
| `just test-ready-ticket` | 49 tests | pass @ `aba106c` |
| Forward cases, both scales + missing design | deterministic replay 12/12 | pass @ `aba106c` |
| `just format && just lint && just test` | clean | pass @ `aba106c` |
| eval-record `--stage before` | real-model, 6/8, `failed` | recorded @ `1ce4187` |
| eval-record `--stage after` | real-model, 12/12, `completed` | recorded @ `aba106c` |

Change-demonstrating-test evidence (`evidence_behavioral_test`): 14 tests red at
base `1ce4187`, all 49 green at head.

**The after run is worth reading, not just counting.** Its first recording came
back 8/12 and the four failures were real: three cases routed correctly and then
stopped at the diagnosis, because the result bullet asked for a next action only
under `blocked`. The prose gained the obligation rather than the corpus losing
the assertion. The fourth was a defect in a case this change added. The final
run is 12/12 with every case unchanged against the intermediate one — five
commits of prose refinement moved no graded behavior.

## Review

Delegated to repository-owned `review-fix-loop` under `local_commit`, fresh
read-only reviewer, write isolation enforced on every pass. Five findings
accepted and fixed one per cycle, each validated on its own:

1. the objection stop condition contradicting the approval section;
2. `which of the four` never enumerated, colliding with the four self-review
   scans;
3. a rationalization table whose rows were authored rather than retrieved, which
   `docs/skill-authoring.md` forbids — in the very file it names as the sourced
   exemplar;
4. the result's precondition defined purely by absence while the load-bearing
   section routed a falsified assumption into it;
5. a flipped case whose scenario still narrated the requester settling the
   replacement the new contract forbids absorbing.

Converged at `aba106c`: all three lenses freshly executed, aggregate `clean`, no
findings.

## Scope

Deliberately out: renaming the skill (#201), draft graph planning (#198),
tracker mutation (#199, #200), `docs/skill-authoring.md`'s peer registry and
collision audit, the `triggering/` corpus, and the README tagline. Two README
statements are corrected here because this change is what falsifies them —
composition rule 1's mechanism sentence and the `ready-ticket` skills-list
entry.

Two things a reviewer should know rather than discover. The converged review is
bound to `aba106c`; the head adds one commit that records that head's own
real-model summary and corrects one changelog clause, which is the ordering the
eval-evidence norm structurally forces. And the case id
`falsified-assumption-returns-to-elicitation` is now a stale identifier — the
case returns to design, not to elicitation — left unrenamed to keep the fix to
the finding.

Refs #197
