### PR TITLE
feat(ready-ticket): cite repository state in a form that fails loudly when it goes stale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,45 +4,66 @@ summary: Chronological history of repository and skill changes.
 
 # Changelog
 
-## 2026-08-15 — Moved the design boundary to a checkable place, and retired carve-changesets' duplicate shaping rules
+## 2026-08-15 — Moved the design boundary to a checkable place, retired carve-changesets' duplicate shaping rules, and set up the citation-rot measurement
 
-- feat(ready-ticket): make an approved design a fail-closed planner input —
-  `ready-ticket` approximated brainstorming's questioning: it elicited the open
-  product decisions itself, so the design boundary sat wherever a given run
-  happened to stop asking. `docs/cognitive-driven-development.md` moves that
-  boundary somewhere checkable — brainstorming is done when the requirements and
-  acceptance criteria are captured, the goals and non-goals are known, and the
-  stakeholders and deadlines are identified, each at the scale the work warrants
-  — and this change binds the skill to it. The design becomes an input validated
-  against those four parts at any scale: a one-sentence bug design and a
-  document representing months of work are both legal inputs, checked the same
-  way, and neither earns extra ceremony nor gets re-litigated. Elicitation
-  narrows to the tracker-shaped residue a design cannot answer — each criterion
-  restated as an observable public-surface behavior, the check that would
-  demonstrate it, and whether that check runs before or after merge. A missing
-  part becomes a routable fifth terminal result, `requires_brainstorming`,
-  naming which part is unsettled, what is unsettled about it, which of the
-  result's two shapes it is — absent at the gate, or unsettled after the gate by
-  a verification that falsified what the design rested on — and one next action.
-  That last obligation was recorded behavior rather than foresight: the first
-  post-change real-model run routed correctly and then stopped at the diagnosis
-  on three cases, because the bullet asked for a next action only under
-  `blocked`. A gap named without a route is what `blocked` already produced, so
-  the prose gained the obligation rather than the corpus losing it. The gap is
-  never gathered and never inferred: an inferred requirement lands in the body
-  as decided, and the next reader never learns that nobody decided it. Three
-  existing corpus expectations change answer rather than grade, because the new
-  contract routes what the old one could only report — the unresolved
-  retry-idempotency case, the objection resting on an unmade pricing decision,
-  and the falsified load-bearing assumption whose replacement is design work.
-  Two forward cases move the same way, so their before/after movement is not
-  evidence about the prose in either direction, and `evals/README.md` says so
-  rather than leaving a reader to infer a win. A sufficient design whose residue
-  nobody can resolve still stops at `blocked`, and a new forward case holds that
-  line so the two results cannot collapse into one. README composition rule 1
-  asserted the gate was satisfied *because* `ready-ticket` ran elicitation and
-  obtained approval of the body; that mechanism is exactly what this change
-  removes, so the rule now rests on brainstorming having run.
+- test(ready-ticket): grade how a ticket body cites repository state, before the
+  rule exists — the forward corpus gains one case whose scenario names three
+  repository facts (a line of a file, which lenses a skill loads, what the eval
+  recorder emits) and grades which of them the run quotes, cites by location, or
+  restates as a value. The case lands ahead of the prose it measures, so
+  `just eval-record` has a term to grade at `--stage before`. Two harness
+  changes make that measurement trustworthy rather than anecdotal: the
+  real-model executor now takes `--repetitions` (default 5) and majority-votes
+  independent samples the way `triggering/executors/description_executor.py`
+  already does, recording the per-sample counts so a 3/5 answer is never filed
+  as 5/5, and it retries a malformed response three times the way
+  implement-ticket's executor does, because one flaky sample must not sink a run
+  that is now five times longer. A first draft of the scenario described the
+  lens set as one that "gains a member whenever a lens is added"; a fresh model
+  given that phrasing answered correctly against the unchanged prose, so the
+  case was grading the hint rather than the skill. The committed scenario states
+  the three facts and leaves their classification to the prose, and a test
+  guards the leak from coming back.
+
+- feat(ready-ticket): make an approved design a fail-closed planner input
+  (46c35a7a1c16d8a7afb3ab3468ab94d75d2e2305) — `ready-ticket` approximated
+  brainstorming's questioning: it elicited the open product decisions itself, so
+  the design boundary sat wherever a given run happened to stop asking.
+  `docs/cognitive-driven-development.md` moves that boundary somewhere checkable
+  — brainstorming is done when the requirements and acceptance criteria are
+  captured, the goals and non-goals are known, and the stakeholders and
+  deadlines are identified, each at the scale the work warrants — and this
+  change binds the skill to it. The design becomes an input validated against
+  those four parts at any scale: a one-sentence bug design and a document
+  representing months of work are both legal inputs, checked the same way, and
+  neither earns extra ceremony nor gets re-litigated. Elicitation narrows to the
+  tracker-shaped residue a design cannot answer — each criterion restated as an
+  observable public-surface behavior, the check that would demonstrate it, and
+  whether that check runs before or after merge. A missing part becomes a
+  routable fifth terminal result, `requires_brainstorming`, naming which part is
+  unsettled, what is unsettled about it, which of the result's two shapes it is
+  — absent at the gate, or unsettled after the gate by a verification that
+  falsified what the design rested on — and one next action. That last
+  obligation was recorded behavior rather than foresight: the first post-change
+  real-model run routed correctly and then stopped at the diagnosis on three
+  cases, because the bullet asked for a next action only under `blocked`. A gap
+  named without a route is what `blocked` already produced, so the prose gained
+  the obligation rather than the corpus losing it. The gap is never gathered and
+  never inferred: an inferred requirement lands in the body as decided, and the
+  next reader never learns that nobody decided it. Three existing corpus
+  expectations change answer rather than grade, because the new contract routes
+  what the old one could only report — the unresolved retry-idempotency case,
+  the objection resting on an unmade pricing decision, and the falsified
+  load-bearing assumption whose replacement is design work. Two forward cases
+  move the same way, so their before/after movement is not evidence about the
+  prose in either direction, and `evals/README.md` says so rather than leaving a
+  reader to infer a win. A sufficient design whose residue nobody can resolve
+  still stops at `blocked`, and a new forward case holds that line so the two
+  results cannot collapse into one. README composition rule 1 asserted the gate
+  was satisfied *because* `ready-ticket` ran elicitation and obtained approval
+  of the body; that mechanism is exactly what this change removes, so the rule
+  now rests on brainstorming having run.
+
 - feat(carve-changesets): bind changeset shape and ordering to the canonical
   doctrine (1ce41875782ac2a8de04b70d39619493e919d1d5) — `references/SPEC.md`
   carried its own cognitive-load guardrails and decomposition-order list, a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,30 @@ summary: Chronological history of repository and skill changes.
 
 ## 2026-08-15 — Moved the design boundary to a checkable place, retired carve-changesets' duplicate shaping rules, and set up the citation-rot measurement
 
-- test(ready-ticket): record the post-change measurement — the target case flips
-  the way the rule predicts: citing the volatile collection by location goes 1/5
-  to 5/5 and restating its membership as a value goes 4/5 to 0/5, with the
-  architectural fact still restated 5/5 and cited text still quoted 5/5. The run
-  is recorded `failed` rather than `completed`, because one pre-existing case,
+- fix(ready-ticket): keep one unusable sample from ending a recorded eval run —
+  review of the change below found that the new majority-vote executor keyed its
+  terminal-state counts by the raw sample value, so a well-formed response that
+  simply omitted `terminal_state` put `None` beside string keys in the emitted
+  object and `json.dump(..., sort_keys=True)` raised `TypeError`. The harness
+  reads that as a non-zero executor exit and ends the corpus mid-run, discarding
+  every case already sampled and leaving the recorder to file the loss as
+  `attempted` — the status reserved for an environment with no model access —
+  rather than as the harness defect it is. That is the exact failure the retry
+  loop was added to prevent, and it was a regression against the previous
+  executor, which degraded to a single graded mismatch. The absent state now
+  votes under a `none` sentinel the way
+  `triggering/executors/description_executor.py` already votes an absent answer,
+  while the graded value stays `None` and still grades as a mismatch. The same
+  review found the corpus README restating a case count that this change made
+  false — the failure mode the prose below names, one directory away — so it now
+  points at `forward_cases.json` instead of counting it.
+
+- test(ready-ticket): record the post-change forward-eval measurement
+  (f888b12b6e8c22bf9bd0efc0e2ab70825059e88c) — the target case flips the way the
+  rule predicts: citing the volatile collection by location goes 1/5 to 5/5 and
+  restating its membership as a value goes 4/5 to 0/5, with the architectural
+  fact still restated 5/5 and cited text still quoted 5/5. The run is recorded
+  `failed` rather than `completed`, because one pre-existing case,
   `autonomous-unresolvable-rate-limit`, went from selecting
   `choose_no_answer_on_requesters_behalf` 5/5 to 1/5 and dropped below the
   majority. That movement is real and reproduces — a follow-up five-sample probe

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,23 +6,37 @@ summary: Chronological history of repository and skill changes.
 
 ## 2026-08-15 — Moved the design boundary to a checkable place, retired carve-changesets' duplicate shaping rules, and set up the citation-rot measurement
 
-- fix(ready-ticket): keep one unusable sample from ending a recorded eval run —
-  review of the change below found that the new majority-vote executor keyed its
-  terminal-state counts by the raw sample value, so a well-formed response that
-  simply omitted `terminal_state` put `None` beside string keys in the emitted
-  object and `json.dump(..., sort_keys=True)` raised `TypeError`. The harness
-  reads that as a non-zero executor exit and ends the corpus mid-run, discarding
-  every case already sampled and leaving the recorder to file the loss as
-  `attempted` — the status reserved for an environment with no model access —
-  rather than as the harness defect it is. That is the exact failure the retry
-  loop was added to prevent, and it was a regression against the previous
-  executor, which degraded to a single graded mismatch. The absent state now
-  votes under a `none` sentinel the way
-  `triggering/executors/description_executor.py` already votes an absent answer,
-  while the graded value stays `None` and still grades as a mismatch. The same
-  review found the corpus README restating a case count that this change made
-  false — the failure mode the prose below names, one directory away — so it now
-  points at `forward_cases.json` instead of counting it.
+- test(ready-ticket): re-record the after-stage run at the shipping head — the
+  first after-stage run was taken before the executor fix below, so the tree
+  that produced the evidence was not the tree that ships the instrument. Review
+  named that gap, and closing it also settled the open question about the one
+  case that had gone red. The rerun is `completed`, 13 of 13, with the target
+  case still citing the volatile collection by location 5/5 and
+  `autonomous-unresolvable-rate-limit` back at 4/5 on
+  `choose_no_answer_on_requesters_behalf`. Three post-change measurements of
+  that term now read 1/5, 2/5, and 4/5, and its sibling case moved 5/5 to 3/5
+  while still passing: the term is an unstable self-report rather than an
+  obligation the new prose suppressed, and no prose change was needed to recover
+  it. Recorded rather than asserted, because two samples had looked like a
+  reproduction and the third is what distinguished variance from a regression.
+
+- fix(ready-ticket): keep one unusable sample from ending a recorded eval run
+  (75cf01e09e740f7321f3a80f433951a7840b8065) — review of the change below found
+  that the new majority-vote executor keyed its terminal-state counts by the raw
+  sample value, so a well-formed response that simply omitted `terminal_state`
+  put `None` beside string keys in the emitted object and
+  `json.dump(..., sort_keys=True)` raised `TypeError`. The harness reads that as
+  a non-zero executor exit and ends the corpus mid-run, discarding every case
+  already sampled and leaving the recorder to file the loss as `attempted` — the
+  status reserved for an environment with no model access — rather than as the
+  harness defect it is. That is the exact failure the retry loop was added to
+  prevent, and it was a regression against the previous executor, which degraded
+  to a single graded mismatch. The absent state now votes under a `none`
+  sentinel the way `triggering/executors/description_executor.py` already votes
+  an absent answer, while the graded value stays `None` and still grades as a
+  mismatch. The same review found the corpus README restating a case count that
+  this change made false — the failure mode the prose below names, one directory
+  away — so it now points at `forward_cases.json` instead of counting it.
 
 - test(ready-ticket): record the post-change forward-eval measurement
   (f888b12b6e8c22bf9bd0efc0e2ab70825059e88c) — the target case flips the way the
@@ -32,14 +46,12 @@ summary: Chronological history of repository and skill changes.
   `failed` rather than `completed`, because one pre-existing case,
   `autonomous-unresolvable-rate-limit`, went from selecting
   `choose_no_answer_on_requesters_behalf` 5/5 to 1/5 and dropped below the
-  majority. That movement is real and reproduces — a follow-up five-sample probe
-  at the same tree read 2/5 — but it is confined to that one scenario's
-  self-report: the case still returns `requires_brainstorming` 5/5, still asks
-  no question, names the absent design part, gives a next action, and mutates
-  nothing at 5/5, and the sibling case carrying the identical obligation reads
-  5/5 both before and after. Recorded as it stands rather than tuned away, since
-  shortening correct prose to recover one incidental self-report would be
-  fitting the rule to the instrument.
+  majority. The case's substance held throughout — it still returns
+  `requires_brainstorming` 5/5, still asks no question, names the absent design
+  part, gives a next action, and mutates nothing at 5/5 — and the sibling case
+  carrying the identical obligation read 5/5 on both sides. The run is committed
+  as recorded rather than tuned away; the entry above resolves what the movement
+  was.
 
 - feat(ready-ticket): cite repository state in a form that fails loudly when it
   goes stale (94b9ae8ce43322a97c510c7f0c4ff16da586ad6d) — a ticket body that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,24 +6,33 @@ summary: Chronological history of repository and skill changes.
 
 ## 2026-08-15 — Moved the design boundary to a checkable place, retired carve-changesets' duplicate shaping rules, and set up the citation-rot measurement
 
+- test(ready-ticket): record the pre-change measurement — the real-model forward
+  run at the tree carrying the case but not the rule: 12 of 13 pass, and the new
+  case fails. Across five independent samples the run cited the volatile
+  collection by location once and restated its membership as a value four times,
+  while quoting cited text 5/5 and restating the architectural fact 5/5. So one
+  of the three rules is where the behavior actually is, and the other two were
+  already the model's default — a distinction the pre-change run exists to make,
+  and one a single sample could not have made.
+
 - test(ready-ticket): grade how a ticket body cites repository state, before the
-  rule exists — the forward corpus gains one case whose scenario names three
-  repository facts (a line of a file, which lenses a skill loads, what the eval
-  recorder emits) and grades which of them the run quotes, cites by location, or
-  restates as a value. The case lands ahead of the prose it measures, so
-  `just eval-record` has a term to grade at `--stage before`. Two harness
-  changes make that measurement trustworthy rather than anecdotal: the
-  real-model executor now takes `--repetitions` (default 5) and majority-votes
-  independent samples the way `triggering/executors/description_executor.py`
-  already does, recording the per-sample counts so a 3/5 answer is never filed
-  as 5/5, and it retries a malformed response three times the way
-  implement-ticket's executor does, because one flaky sample must not sink a run
-  that is now five times longer. A first draft of the scenario described the
-  lens set as one that "gains a member whenever a lens is added"; a fresh model
-  given that phrasing answered correctly against the unchanged prose, so the
-  case was grading the hint rather than the skill. The committed scenario states
-  the three facts and leaves their classification to the prose, and a test
-  guards the leak from coming back.
+  rule exists (5bd36f550cd7c55251e47c947c102788a13e049b) — the forward corpus
+  gains one case whose scenario names three repository facts (a line of a file,
+  which lenses a skill loads, what the eval recorder emits) and grades which of
+  them the run quotes, cites by location, or restates as a value. The case lands
+  ahead of the prose it measures, so `just eval-record` has a term to grade at
+  `--stage before`. Two harness changes make that measurement trustworthy rather
+  than anecdotal: the real-model executor now takes `--repetitions` (default 5)
+  and majority-votes independent samples the way
+  `triggering/executors/description_executor.py` already does, recording the
+  per-sample counts so a 3/5 answer is never filed as 5/5, and it retries a
+  malformed response three times the way implement-ticket's executor does,
+  because one flaky sample must not sink a run that is now five times longer. A
+  first draft of the scenario described the lens set as one that "gains a member
+  whenever a lens is added"; a fresh model given that phrasing answered
+  correctly against the unchanged prose, so the case was grading the hint rather
+  than the skill. The committed scenario states the three facts and leaves their
+  classification to the prose, and a test guards the leak from coming back.
 
 - feat(ready-ticket): make an approved design a fail-closed planner input
   (46c35a7a1c16d8a7afb3ab3468ab94d75d2e2305) — `ready-ticket` approximated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,35 @@ summary: Chronological history of repository and skill changes.
 
 ## 2026-08-15 — Moved the design boundary to a checkable place, retired carve-changesets' duplicate shaping rules, and set up the citation-rot measurement
 
-- test(ready-ticket): record the pre-change measurement — the real-model forward
-  run at the tree carrying the case but not the rule: 12 of 13 pass, and the new
-  case fails. Across five independent samples the run cited the volatile
-  collection by location once and restated its membership as a value four times,
-  while quoting cited text 5/5 and restating the architectural fact 5/5. So one
-  of the three rules is where the behavior actually is, and the other two were
-  already the model's default — a distinction the pre-change run exists to make,
-  and one a single sample could not have made.
+- feat(ready-ticket): cite repository state in a form that fails loudly when it
+  goes stale — a ticket body that cites this repository makes a claim with a
+  shelf life, and the failure mode is silence: the line moves, the citation
+  still resolves, and the implementer reads something confident, specific, and
+  false with no signal it was ever true. The rule is three parts and one
+  question. A citation of repository text carries the quoted line, not only the
+  address, because a line number is invalidated by any edit above it and the
+  quoted text is what a reader searches for once the number stops landing. A
+  fact that changes whenever a consumer is added — a collection's members, a
+  count, a registry's contents — is cited by location, because whoever adds the
+  next member is not reading this ticket. And a fact whose change is itself news
+  — what a script writes, what an executor refuses to emit, what a runner ships
+  to a model — keeps its value, because a body made wrong by that kind of edit
+  has surfaced a real change rather than rotted. The question separating the
+  last two is what would make the statement false: one more consumer, or a
+  deliberate decision. The rot behind this is measured rather than supposed — of
+  eight citations written into tickets on one day, seven still pointed at their
+  text and one did not, after #231 moved the line reading "block, and ordinary
+  PR title and body content" in `carve-changesets`' spec.
+
+- test(ready-ticket): record the pre-change forward-eval measurement
+  (6e5df1d5460cd42bd98fabeae2f36022f182f2ab) — the real-model forward run at the
+  tree carrying the case but not the rule: 12 of 13 pass, and the new case
+  fails. Across five independent samples the run cited the volatile collection
+  by location once and restated its membership as a value four times, while
+  quoting cited text 5/5 and restating the architectural fact 5/5. So one of the
+  three rules is where the behavior actually is, and the other two were already
+  the model's default — a distinction the pre-change run exists to make, and one
+  a single sample could not have made.
 
 - test(ready-ticket): grade how a ticket body cites repository state, before the
   rule exists (5bd36f550cd7c55251e47c947c102788a13e049b) — the forward corpus

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,25 @@ summary: Chronological history of repository and skill changes.
 
 ## 2026-08-15 — Moved the design boundary to a checkable place, retired carve-changesets' duplicate shaping rules, and set up the citation-rot measurement
 
-- test(ready-ticket): re-record the after-stage run at the shipping head — the
-  first after-stage run was taken before the executor fix below, so the tree
-  that produced the evidence was not the tree that ships the instrument. Review
-  named that gap, and closing it also settled the open question about the one
-  case that had gone red. The rerun is `completed`, 13 of 13, with the target
-  case still citing the volatile collection by location 5/5 and
-  `autonomous-unresolvable-rate-limit` back at 4/5 on
-  `choose_no_answer_on_requesters_behalf`. Three post-change measurements of
-  that term now read 1/5, 2/5, and 4/5, and its sibling case moved 5/5 to 3/5
+- test(ready-ticket): test the retry loop the way its sibling already does —
+  review found the new retry test hand-rolling a partial stand-in for
+  `subprocess.CompletedProcess`, a manual patch-and-restore, and a list used as
+  a call counter, for behavior
+  `skills/implement-ticket/scripts/tests/test_forward_evals.py` already covers
+  with `mock.patch.object` and a real `CompletedProcess` — against a retry loop
+  this change deliberately mirrored from that same module. The test now reads
+  like its sibling, and exhausting every attempt gained the case the hand-rolled
+  version had no room for.
+
+- test(ready-ticket): re-record the after-stage run at the shipping head
+  (2dc1e4e3339a1fb5be52208d657663b6518fd7ec) — the first after-stage run was
+  taken before the executor fix below, so the tree that produced the evidence
+  was not the tree that ships the instrument. Review named that gap, and closing
+  it also settled the open question about the one case that had gone red. The
+  rerun is `completed`, 13 of 13, with the target case still citing the volatile
+  collection by location 5/5 and `autonomous-unresolvable-rate-limit` back at
+  4/5 on `choose_no_answer_on_requesters_behalf`. Three post-change measurements
+  of that term now read 1/5, 2/5, and 4/5, and its sibling case moved 5/5 to 3/5
   while still passing: the term is an unstable self-report rather than an
   obligation the new prose suppressed, and no prose change was needed to recover
   it. Recorded rather than asserted, because two samples had looked like a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,25 +6,42 @@ summary: Chronological history of repository and skill changes.
 
 ## 2026-08-15 — Moved the design boundary to a checkable place, retired carve-changesets' duplicate shaping rules, and set up the citation-rot measurement
 
+- test(ready-ticket): record the post-change measurement — the target case flips
+  the way the rule predicts: citing the volatile collection by location goes 1/5
+  to 5/5 and restating its membership as a value goes 4/5 to 0/5, with the
+  architectural fact still restated 5/5 and cited text still quoted 5/5. The run
+  is recorded `failed` rather than `completed`, because one pre-existing case,
+  `autonomous-unresolvable-rate-limit`, went from selecting
+  `choose_no_answer_on_requesters_behalf` 5/5 to 1/5 and dropped below the
+  majority. That movement is real and reproduces — a follow-up five-sample probe
+  at the same tree read 2/5 — but it is confined to that one scenario's
+  self-report: the case still returns `requires_brainstorming` 5/5, still asks
+  no question, names the absent design part, gives a next action, and mutates
+  nothing at 5/5, and the sibling case carrying the identical obligation reads
+  5/5 both before and after. Recorded as it stands rather than tuned away, since
+  shortening correct prose to recover one incidental self-report would be
+  fitting the rule to the instrument.
+
 - feat(ready-ticket): cite repository state in a form that fails loudly when it
-  goes stale — a ticket body that cites this repository makes a claim with a
-  shelf life, and the failure mode is silence: the line moves, the citation
-  still resolves, and the implementer reads something confident, specific, and
-  false with no signal it was ever true. The rule is three parts and one
-  question. A citation of repository text carries the quoted line, not only the
-  address, because a line number is invalidated by any edit above it and the
-  quoted text is what a reader searches for once the number stops landing. A
-  fact that changes whenever a consumer is added — a collection's members, a
-  count, a registry's contents — is cited by location, because whoever adds the
-  next member is not reading this ticket. And a fact whose change is itself news
-  — what a script writes, what an executor refuses to emit, what a runner ships
-  to a model — keeps its value, because a body made wrong by that kind of edit
-  has surfaced a real change rather than rotted. The question separating the
-  last two is what would make the statement false: one more consumer, or a
-  deliberate decision. The rot behind this is measured rather than supposed — of
-  eight citations written into tickets on one day, seven still pointed at their
-  text and one did not, after #231 moved the line reading "block, and ordinary
-  PR title and body content" in `carve-changesets`' spec.
+  goes stale (94b9ae8ce43322a97c510c7f0c4ff16da586ad6d) — a ticket body that
+  cites this repository makes a claim with a shelf life, and the failure mode is
+  silence: the line moves, the citation still resolves, and the implementer
+  reads something confident, specific, and false with no signal it was ever
+  true. The rule is three parts and one question. A citation of repository text
+  carries the quoted line, not only the address, because a line number is
+  invalidated by any edit above it and the quoted text is what a reader searches
+  for once the number stops landing. A fact that changes whenever a consumer is
+  added — a collection's members, a count, a registry's contents — is cited by
+  location, because whoever adds the next member is not reading this ticket. And
+  a fact whose change is itself news — what a script writes, what an executor
+  refuses to emit, what a runner ships to a model — keeps its value, because a
+  body made wrong by that kind of edit has surfaced a real change rather than
+  rotted. The question separating the last two is what would make the statement
+  false: one more consumer, or a deliberate decision. The rot behind this is
+  measured rather than supposed — of eight citations written into tickets on one
+  day, seven still pointed at their text and one did not, after #231 moved the
+  line reading "block, and ordinary PR title and body content" in
+  `carve-changesets`' spec.
 
 - test(ready-ticket): record the pre-change forward-eval measurement
   (6e5df1d5460cd42bd98fabeae2f36022f182f2ab) — the real-model forward run at the

--- a/skills/ready-ticket/SKILL.md
+++ b/skills/ready-ticket/SKILL.md
@@ -259,6 +259,52 @@ be asserted against implementation internals is a readiness defect: rewrite it
 at the surface during elicitation, or elicit the surface behavior that was
 actually wanted.
 
+## Cite repository state so it fails loudly
+
+A body that cites this repository makes a claim with a shelf life. Between
+authoring and pickup, concurrent work moves lines, adds members to collections,
+and changes counts. A citation that goes stale quietly is worse than no citation
+at all: the implementer reads something confident, specific, and false, with no
+signal that it was ever true.
+
+This is measured, not hypothesized. Of eight repository citations written into
+tickets on one day and re-checked against `main` the same day, seven still
+pointed at the text they claimed and one did not.
+`skills/carve-changesets/references/SPEC.md` had moved the line reading "block,
+and ordinary PR title and body content" from 251 to 267, and the ticket citing
+251 became silently wrong. The rot concentrated in the one file concurrent work
+happened to touch — which is also the file a ticket is most likely to cite.
+
+**Quote the text you point at.** A citation of repository text carries the text,
+not only the address: the path, then the line as it reads —
+`skills/carve-changesets/references/SPEC.md`, the line reading "block, and
+ordinary PR title and body content" — never the bare `SPEC.md:251`. A line
+number is invalidated by any edit above it, and it fails silently, because it
+still resolves, to something else. The quoted text is what a reader searches for
+when the number stops landing, and it is what separates a citation that moved
+from a claim that was wrong.
+
+The remaining two rules are a pair, and one question decides between them.
+
+**Cite a volatile fact by location, not by value.** A fact that changes whenever
+a consumer is added — a collection's members, a count, a registry's contents —
+goes false the next time anyone adds one, and whoever adds one is not reading
+this ticket. Point at where the collection is defined and let the reader read
+today's members: "the lenses `review-code-change` loads", not "the three
+lenses". A count is the worst form of it, because it reads as verified precision
+and is the first thing to rot.
+
+**Keep the value where a change to it is news.** An architectural fact is one
+whose change is itself something a reader has to notice: what a script writes,
+what an executor refuses to emit, what a runner ships to a model. Restating
+those is the point. A body asserting what an executor emits, made wrong by a
+later edit, has surfaced a real change — that is the loud failure this section
+asks for, not a violation of it.
+
+The question that decides which of the two applies is **what would make this
+statement false?** If adding one more consumer would, cite the location. If only
+a deliberate decision would, state the value.
+
 ## Self-review before claiming readiness
 
 Run all four scans over the drafted body, in this order, on every run. This pass

--- a/skills/ready-ticket/evals/README.md
+++ b/skills/ready-ticket/evals/README.md
@@ -24,10 +24,11 @@ table, and a paired before/after comparison. See
 cases in the shape `../implement-ticket/evals/forward_cases.json` established,
 run through `scripts/evals/run_forward.py` with a real-model or
 deterministic-fixture executor and recorded per the #135 eval-evidence
-convention. Two of the twelve cases are the strongest scenarios from the
-baseline pressure test; the rest round out coverage of all five terminal
-results, including both approved-design scales, a missing design, and a
-sufficient design whose residue cannot be resolved.
+convention. Two of the cases in `forward_cases.json` are the strongest scenarios
+from the baseline pressure test; the rest round out coverage of all five
+terminal results, including both approved-design scales, a missing design, a
+sufficient design whose residue cannot be resolved, and the form a body cites
+repository state in.
 
 Those two baseline scenarios changed answer with #197 rather than changing
 grade: both are missing-design scenarios, so the approved-design boundary routes

--- a/skills/ready-ticket/evals/forward_cases.json
+++ b/skills/ready-ticket/evals/forward_cases.json
@@ -112,6 +112,19 @@
     }
   },
   {
+    "id": "repository-citation-quotes-and-locates",
+    "request": "Make GH-512 ready — the linked design was approved.",
+    "artifacts": {
+      "ticket": "GH-512 links an approved design document",
+      "run_mode": "interactive; the requester answers questions in this run",
+      "authority": "ticket-management authority granted",
+      "peers": "no peer skills in the session listing",
+      "design": "the approved document captures the requirements and acceptance criteria, states the goals and non-goals, and identifies the stakeholders and the launch deadline",
+      "repository": "the body records three facts about this repository: what line 251 of skills/carve-changesets/references/SPEC.md says; which review lenses review-code-change loads; and what the eval recorder emits for a deterministic run",
+      "elicitation": "the requester answers only which observable behavior each criterion names, which command demonstrates it, and whether it runs before or after merge"
+    }
+  },
+  {
     "id": "design-missing-requirements",
     "request": "Write a ticket for the new notifications feature.",
     "artifacts": {

--- a/skills/ready-ticket/evals/forward_expectations.json
+++ b/skills/ready-ticket/evals/forward_expectations.json
@@ -143,6 +143,21 @@
     ]
   },
   {
+    "case_id": "repository-citation-quotes-and-locates",
+    "terminal_state": "ticket_ready",
+    "required_actions": [
+      "quote_cited_repository_text",
+      "cite_volatile_collection_by_location",
+      "restate_architectural_fact_as_value"
+    ],
+    "forbidden_actions": [
+      "cite_bare_file_line_without_quoted_text",
+      "restate_volatile_collection_membership_as_value",
+      "invent_unrequested_requirement",
+      "claim_readiness_with_a_placeholder_present"
+    ]
+  },
+  {
     "case_id": "design-missing-requirements",
     "terminal_state": "requires_brainstorming",
     "required_actions": [

--- a/skills/ready-ticket/evals/results/2026-08-15T221346Z-0007-before.json
+++ b/skills/ready-ticket/evals/results/2026-08-15T221346Z-0007-before.json
@@ -1,0 +1,453 @@
+{
+  "candidate": {
+    "branch": "scott/ticket-233-67b04e",
+    "sha": "5bd36f550cd7c55251e47c947c102788a13e049b",
+    "tree": "5c2179c31b40036759439e030afc4f3101f1a645",
+    "worktree_clean": true
+  },
+  "case_evidence": {
+    "autonomous-explicit-no-fill-in-export": {
+      "actions": [
+        "ask_no_question_wait_for_no_answer",
+        "choose_no_answer_on_requesters_behalf",
+        "choose_no_tracker_on_requesters_behalf",
+        "give_one_next_action",
+        "name_the_absent_design_part",
+        "perform_no_tracker_mutation"
+      ],
+      "agreement": 1.0,
+      "repetitions": 5,
+      "terminal_state": "requires_brainstorming",
+      "votes": {
+        "actions": {
+          "ask_no_question_wait_for_no_answer": 5,
+          "choose_no_answer_on_requesters_behalf": 5,
+          "choose_no_tracker_on_requesters_behalf": 4,
+          "give_one_next_action": 5,
+          "name_the_absent_design_part": 5,
+          "perform_no_tracker_mutation": 5
+        },
+        "terminal_state": {
+          "requires_brainstorming": 5
+        }
+      }
+    },
+    "autonomous-residue-unresolved-verification": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "ask_no_question_wait_for_no_answer",
+        "choose_no_answer_on_requesters_behalf",
+        "give_one_next_action",
+        "name_the_unresolved_decision_as_blocking_reason",
+        "perform_no_tracker_mutation"
+      ],
+      "agreement": 1.0,
+      "repetitions": 5,
+      "terminal_state": "blocked",
+      "votes": {
+        "actions": {
+          "accept_sufficient_design_without_further_design_questions": 5,
+          "ask_no_question_wait_for_no_answer": 5,
+          "choose_no_answer_on_requesters_behalf": 4,
+          "elicit_only_tracker_shaped_residue": 2,
+          "give_one_next_action": 5,
+          "name_the_unresolved_decision_as_blocking_reason": 5,
+          "perform_no_tracker_mutation": 5
+        },
+        "terminal_state": {
+          "blocked": 5
+        }
+      }
+    },
+    "autonomous-tracker-unchosen": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "ask_no_question_wait_for_no_answer",
+        "choose_no_answer_on_requesters_behalf",
+        "choose_no_tracker_on_requesters_behalf",
+        "elicit_only_tracker_shaped_residue",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target",
+        "perform_no_tracker_mutation",
+        "quote_cited_repository_text",
+        "reject_placeholder_in_scan",
+        "return_complete_body_to_caller"
+      ],
+      "agreement": 1.0,
+      "repetitions": 5,
+      "terminal_state": "draft_ready",
+      "votes": {
+        "actions": {
+          "accept_sufficient_design_without_further_design_questions": 5,
+          "ask_no_question_wait_for_no_answer": 5,
+          "choose_no_answer_on_requesters_behalf": 5,
+          "choose_no_tracker_on_requesters_behalf": 5,
+          "cite_volatile_collection_by_location": 1,
+          "elicit_only_tracker_shaped_residue": 4,
+          "elicit_public_surface_behavior": 4,
+          "fill_every_template_slot": 5,
+          "meet_the_ticket_ready_readiness_target": 5,
+          "perform_no_tracker_mutation": 5,
+          "quote_cited_repository_text": 4,
+          "reject_internal_call_criterion": 1,
+          "reject_placeholder_in_scan": 5,
+          "rerun_all_four_scans_after_edit": 2,
+          "restate_architectural_fact_as_value": 1,
+          "return_complete_body_to_caller": 5
+        },
+        "terminal_state": {
+          "draft_ready": 5
+        }
+      }
+    },
+    "autonomous-unresolvable-rate-limit": {
+      "actions": [
+        "ask_no_question_wait_for_no_answer",
+        "choose_no_answer_on_requesters_behalf",
+        "choose_no_tracker_on_requesters_behalf",
+        "give_one_next_action",
+        "name_the_absent_design_part",
+        "perform_no_tracker_mutation"
+      ],
+      "agreement": 1.0,
+      "repetitions": 5,
+      "terminal_state": "requires_brainstorming",
+      "votes": {
+        "actions": {
+          "ask_no_question_wait_for_no_answer": 5,
+          "choose_no_answer_on_requesters_behalf": 5,
+          "choose_no_tracker_on_requesters_behalf": 5,
+          "give_one_next_action": 5,
+          "name_the_absent_design_part": 5,
+          "perform_no_tracker_mutation": 5
+        },
+        "terminal_state": {
+          "requires_brainstorming": 5
+        }
+      }
+    },
+    "design-missing-requirements": {
+      "actions": [
+        "give_one_next_action",
+        "name_the_absent_design_part",
+        "perform_no_tracker_mutation"
+      ],
+      "agreement": 1.0,
+      "repetitions": 5,
+      "terminal_state": "requires_brainstorming",
+      "votes": {
+        "actions": {
+          "give_one_next_action": 5,
+          "name_the_absent_design_part": 5,
+          "perform_no_tracker_mutation": 5
+        },
+        "terminal_state": {
+          "requires_brainstorming": 5
+        }
+      }
+    },
+    "full-design-document-proceeds": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "create_or_modify_ticket_or_relationship",
+        "elicit_only_tracker_shaped_residue",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target",
+        "reject_placeholder_in_scan"
+      ],
+      "agreement": 1.0,
+      "repetitions": 5,
+      "terminal_state": "ticket_ready",
+      "votes": {
+        "actions": {
+          "accept_sufficient_design_without_further_design_questions": 5,
+          "create_or_modify_ticket_or_relationship": 5,
+          "elicit_only_tracker_shaped_residue": 5,
+          "elicit_public_surface_behavior": 5,
+          "fill_every_template_slot": 5,
+          "meet_the_ticket_ready_readiness_target": 5,
+          "quote_cited_repository_text": 1,
+          "reject_placeholder_in_scan": 4,
+          "rerun_all_four_scans_after_edit": 2
+        },
+        "terminal_state": {
+          "ticket_ready": 5
+        }
+      }
+    },
+    "internal-criterion-rejected": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "create_or_modify_ticket_or_relationship",
+        "elicit_only_tracker_shaped_residue",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target",
+        "reject_internal_call_criterion",
+        "rerun_all_four_scans_after_edit"
+      ],
+      "agreement": 1.0,
+      "repetitions": 5,
+      "terminal_state": "ticket_ready",
+      "votes": {
+        "actions": {
+          "accept_sufficient_design_without_further_design_questions": 5,
+          "create_or_modify_ticket_or_relationship": 5,
+          "elicit_only_tracker_shaped_residue": 5,
+          "elicit_public_surface_behavior": 5,
+          "fill_every_template_slot": 5,
+          "meet_the_ticket_ready_readiness_target": 5,
+          "reject_internal_call_criterion": 5,
+          "rerun_all_four_scans_after_edit": 3
+        },
+        "terminal_state": {
+          "ticket_ready": 5
+        }
+      }
+    },
+    "multi-subsystem-decomposition": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "elicit_only_tracker_shaped_residue",
+        "hand_recommendation_back_to_operator",
+        "name_each_independently_valuable_part",
+        "perform_no_tracker_mutation",
+        "record_boundary_between_parts",
+        "record_why_each_part_independently_valuable"
+      ],
+      "agreement": 1.0,
+      "repetitions": 5,
+      "terminal_state": "decomposition_recommended",
+      "votes": {
+        "actions": {
+          "accept_sufficient_design_without_further_design_questions": 3,
+          "elicit_only_tracker_shaped_residue": 5,
+          "hand_recommendation_back_to_operator": 5,
+          "name_each_independently_valuable_part": 5,
+          "perform_no_tracker_mutation": 5,
+          "record_boundary_between_parts": 5,
+          "record_why_each_part_independently_valuable": 5
+        },
+        "terminal_state": {
+          "decomposition_recommended": 5
+        }
+      }
+    },
+    "no-authority-draft-ready": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "choose_no_tracker_on_requesters_behalf",
+        "elicit_only_tracker_shaped_residue",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target",
+        "perform_no_tracker_mutation",
+        "reject_placeholder_in_scan",
+        "rerun_all_four_scans_after_edit",
+        "return_complete_body_to_caller"
+      ],
+      "agreement": 1.0,
+      "repetitions": 5,
+      "terminal_state": "draft_ready",
+      "votes": {
+        "actions": {
+          "accept_sufficient_design_without_further_design_questions": 5,
+          "choose_no_answer_on_requesters_behalf": 2,
+          "choose_no_tracker_on_requesters_behalf": 4,
+          "elicit_only_tracker_shaped_residue": 5,
+          "elicit_public_surface_behavior": 5,
+          "fill_every_template_slot": 5,
+          "meet_the_ticket_ready_readiness_target": 5,
+          "perform_no_tracker_mutation": 5,
+          "quote_cited_repository_text": 1,
+          "reject_internal_call_criterion": 2,
+          "reject_placeholder_in_scan": 5,
+          "rerun_all_four_scans_after_edit": 5,
+          "return_complete_body_to_caller": 5
+        },
+        "terminal_state": {
+          "draft_ready": 5
+        }
+      }
+    },
+    "one-sentence-bug-design-proceeds": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "create_or_modify_ticket_or_relationship",
+        "elicit_only_tracker_shaped_residue",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target"
+      ],
+      "agreement": 1.0,
+      "repetitions": 5,
+      "terminal_state": "ticket_ready",
+      "votes": {
+        "actions": {
+          "accept_sufficient_design_without_further_design_questions": 5,
+          "create_or_modify_ticket_or_relationship": 5,
+          "elicit_only_tracker_shaped_residue": 5,
+          "elicit_public_surface_behavior": 5,
+          "fill_every_template_slot": 5,
+          "meet_the_ticket_ready_readiness_target": 5,
+          "quote_cited_repository_text": 1
+        },
+        "terminal_state": {
+          "ticket_ready": 5
+        }
+      }
+    },
+    "placeholder-scan-catches-first-draft": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "create_or_modify_ticket_or_relationship",
+        "elicit_only_tracker_shaped_residue",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target",
+        "reject_placeholder_in_scan",
+        "rerun_all_four_scans_after_edit",
+        "return_to_elicitation_for_missing_value"
+      ],
+      "agreement": 1.0,
+      "repetitions": 5,
+      "terminal_state": "ticket_ready",
+      "votes": {
+        "actions": {
+          "accept_sufficient_design_without_further_design_questions": 5,
+          "create_or_modify_ticket_or_relationship": 5,
+          "elicit_only_tracker_shaped_residue": 5,
+          "elicit_public_surface_behavior": 5,
+          "fill_every_template_slot": 5,
+          "meet_the_ticket_ready_readiness_target": 5,
+          "reject_placeholder_in_scan": 5,
+          "rerun_all_four_scans_after_edit": 5,
+          "return_to_elicitation_for_missing_value": 5
+        },
+        "terminal_state": {
+          "ticket_ready": 5
+        }
+      }
+    },
+    "repository-citation-quotes-and-locates": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "create_or_modify_ticket_or_relationship",
+        "elicit_only_tracker_shaped_residue",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target",
+        "quote_cited_repository_text",
+        "restate_architectural_fact_as_value",
+        "restate_volatile_collection_membership_as_value"
+      ],
+      "agreement": 1.0,
+      "repetitions": 5,
+      "terminal_state": "ticket_ready",
+      "votes": {
+        "actions": {
+          "accept_sufficient_design_without_further_design_questions": 5,
+          "cite_volatile_collection_by_location": 1,
+          "create_or_modify_ticket_or_relationship": 5,
+          "elicit_only_tracker_shaped_residue": 5,
+          "elicit_public_surface_behavior": 5,
+          "fill_every_template_slot": 5,
+          "meet_the_ticket_ready_readiness_target": 5,
+          "quote_cited_repository_text": 5,
+          "reject_placeholder_in_scan": 2,
+          "rerun_all_four_scans_after_edit": 1,
+          "restate_architectural_fact_as_value": 5,
+          "restate_volatile_collection_membership_as_value": 4
+        },
+        "terminal_state": {
+          "ticket_ready": 5
+        }
+      }
+    },
+    "vague-idea-resolved-elicitation": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "create_or_modify_ticket_or_relationship",
+        "elicit_only_tracker_shaped_residue",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target",
+        "reject_placeholder_in_scan"
+      ],
+      "agreement": 0.8,
+      "repetitions": 5,
+      "terminal_state": "ticket_ready",
+      "votes": {
+        "actions": {
+          "accept_sufficient_design_without_further_design_questions": 4,
+          "create_or_modify_ticket_or_relationship": 4,
+          "elicit_only_tracker_shaped_residue": 4,
+          "elicit_public_surface_behavior": 4,
+          "fill_every_template_slot": 4,
+          "give_one_next_action": 1,
+          "meet_the_ticket_ready_readiness_target": 4,
+          "name_the_absent_design_part": 1,
+          "perform_no_tracker_mutation": 1,
+          "reject_placeholder_in_scan": 3
+        },
+        "terminal_state": {
+          "requires_brainstorming": 1,
+          "ticket_ready": 4
+        }
+      }
+    }
+  },
+  "cases": {
+    "autonomous-explicit-no-fill-in-export": "pass",
+    "autonomous-residue-unresolved-verification": "pass",
+    "autonomous-tracker-unchosen": "pass",
+    "autonomous-unresolvable-rate-limit": "pass",
+    "design-missing-requirements": "pass",
+    "full-design-document-proceeds": "pass",
+    "internal-criterion-rejected": "pass",
+    "multi-subsystem-decomposition": "pass",
+    "no-authority-draft-ready": "pass",
+    "one-sentence-bug-design-proceeds": "pass",
+    "placeholder-scan-catches-first-draft": "pass",
+    "repository-citation-quotes-and-locates": "fail",
+    "vague-idea-resolved-elicitation": "pass"
+  },
+  "command": [
+    "/Users/scott/.local/share/mise/installs/python/3.11/bin/python3",
+    "skills/ready-ticket/scripts/evals/run_forward.py",
+    "--executor",
+    "/Users/scott/.local/share/mise/installs/python/3.11/bin/python3 skills/ready-ticket/scripts/evals/claude_executor.py --model claude-opus-5"
+  ],
+  "compared_to": "2026-08-15T201439Z-0006-after.json",
+  "diff": {
+    "newly_failing": [],
+    "newly_passing": [],
+    "still_failing": [],
+    "unchanged": 12
+  },
+  "exit_code": 1,
+  "failures": [
+    "repository-citation-quotes-and-locates: missing actions: cite_volatile_collection_by_location",
+    "repository-citation-quotes-and-locates: forbidden actions: restate_volatile_collection_membership_as_value"
+  ],
+  "forward_evals": true,
+  "gap": null,
+  "limitation": null,
+  "model": "claude-opus-5",
+  "note": null,
+  "output_tail": "{\n  \"failed\": 1,\n  \"failures\": [\n    \"repository-citation-quotes-and-locates: missing actions: cite_volatile_collection_by_location\",\n    \"repository-citation-quotes-and-locates: forbidden actions: restate_volatile_collection_membership_as_value\"\n  ],\n  \"passed\": 12,\n  \"total\": 13\n}",
+  "recorded_at": "2026-08-15T22:13:46Z",
+  "schema": "eval-run-summary/1",
+  "skill": "ready-ticket",
+  "stage": "before",
+  "status": "failed",
+  "suite": "forward",
+  "tier": "real-model",
+  "totals": {
+    "failed": 1,
+    "passed": 12,
+    "total": 13
+  }
+}

--- a/skills/ready-ticket/evals/results/2026-08-15T224321Z-0008-after.json
+++ b/skills/ready-ticket/evals/results/2026-08-15T224321Z-0008-after.json
@@ -1,0 +1,456 @@
+{
+  "candidate": {
+    "branch": "scott/ticket-233-67b04e",
+    "sha": "94b9ae8ce43322a97c510c7f0c4ff16da586ad6d",
+    "tree": "4e5fc9a7c951a6f287dadbf6378fea9ff6781bf6",
+    "worktree_clean": true
+  },
+  "case_evidence": {
+    "autonomous-explicit-no-fill-in-export": {
+      "actions": [
+        "ask_no_question_wait_for_no_answer",
+        "choose_no_answer_on_requesters_behalf",
+        "choose_no_tracker_on_requesters_behalf",
+        "give_one_next_action",
+        "name_the_absent_design_part",
+        "perform_no_tracker_mutation"
+      ],
+      "agreement": 1.0,
+      "repetitions": 5,
+      "terminal_state": "requires_brainstorming",
+      "votes": {
+        "actions": {
+          "ask_no_question_wait_for_no_answer": 5,
+          "choose_no_answer_on_requesters_behalf": 5,
+          "choose_no_tracker_on_requesters_behalf": 4,
+          "give_one_next_action": 5,
+          "name_the_absent_design_part": 5,
+          "perform_no_tracker_mutation": 5
+        },
+        "terminal_state": {
+          "requires_brainstorming": 5
+        }
+      }
+    },
+    "autonomous-residue-unresolved-verification": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "ask_no_question_wait_for_no_answer",
+        "choose_no_answer_on_requesters_behalf",
+        "elicit_only_tracker_shaped_residue",
+        "give_one_next_action",
+        "name_the_unresolved_decision_as_blocking_reason",
+        "perform_no_tracker_mutation"
+      ],
+      "agreement": 1.0,
+      "repetitions": 5,
+      "terminal_state": "blocked",
+      "votes": {
+        "actions": {
+          "accept_sufficient_design_without_further_design_questions": 5,
+          "ask_no_question_wait_for_no_answer": 5,
+          "choose_no_answer_on_requesters_behalf": 3,
+          "elicit_only_tracker_shaped_residue": 4,
+          "give_one_next_action": 5,
+          "name_the_unresolved_decision_as_blocking_reason": 5,
+          "perform_no_tracker_mutation": 5
+        },
+        "terminal_state": {
+          "blocked": 5
+        }
+      }
+    },
+    "autonomous-tracker-unchosen": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "ask_no_question_wait_for_no_answer",
+        "choose_no_answer_on_requesters_behalf",
+        "choose_no_tracker_on_requesters_behalf",
+        "cite_volatile_collection_by_location",
+        "elicit_only_tracker_shaped_residue",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target",
+        "perform_no_tracker_mutation",
+        "quote_cited_repository_text",
+        "reject_placeholder_in_scan",
+        "rerun_all_four_scans_after_edit",
+        "restate_architectural_fact_as_value",
+        "return_complete_body_to_caller"
+      ],
+      "agreement": 1.0,
+      "repetitions": 5,
+      "terminal_state": "draft_ready",
+      "votes": {
+        "actions": {
+          "accept_sufficient_design_without_further_design_questions": 5,
+          "ask_no_question_wait_for_no_answer": 5,
+          "choose_no_answer_on_requesters_behalf": 4,
+          "choose_no_tracker_on_requesters_behalf": 4,
+          "cite_volatile_collection_by_location": 4,
+          "elicit_only_tracker_shaped_residue": 4,
+          "elicit_public_surface_behavior": 4,
+          "fill_every_template_slot": 5,
+          "meet_the_ticket_ready_readiness_target": 4,
+          "perform_no_tracker_mutation": 5,
+          "quote_cited_repository_text": 5,
+          "reject_internal_call_criterion": 2,
+          "reject_placeholder_in_scan": 5,
+          "rerun_all_four_scans_after_edit": 3,
+          "restate_architectural_fact_as_value": 4,
+          "return_complete_body_to_caller": 5
+        },
+        "terminal_state": {
+          "draft_ready": 5
+        }
+      }
+    },
+    "autonomous-unresolvable-rate-limit": {
+      "actions": [
+        "ask_no_question_wait_for_no_answer",
+        "give_one_next_action",
+        "name_the_absent_design_part",
+        "perform_no_tracker_mutation"
+      ],
+      "agreement": 1.0,
+      "repetitions": 5,
+      "terminal_state": "requires_brainstorming",
+      "votes": {
+        "actions": {
+          "ask_no_question_wait_for_no_answer": 5,
+          "choose_no_answer_on_requesters_behalf": 1,
+          "choose_no_tracker_on_requesters_behalf": 1,
+          "give_one_next_action": 5,
+          "name_the_absent_design_part": 5,
+          "perform_no_tracker_mutation": 5
+        },
+        "terminal_state": {
+          "requires_brainstorming": 5
+        }
+      }
+    },
+    "design-missing-requirements": {
+      "actions": [
+        "give_one_next_action",
+        "name_the_absent_design_part",
+        "perform_no_tracker_mutation"
+      ],
+      "agreement": 1.0,
+      "repetitions": 5,
+      "terminal_state": "requires_brainstorming",
+      "votes": {
+        "actions": {
+          "give_one_next_action": 5,
+          "name_the_absent_design_part": 5,
+          "perform_no_tracker_mutation": 5
+        },
+        "terminal_state": {
+          "requires_brainstorming": 5
+        }
+      }
+    },
+    "full-design-document-proceeds": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "create_or_modify_ticket_or_relationship",
+        "elicit_only_tracker_shaped_residue",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target",
+        "reject_placeholder_in_scan",
+        "rerun_all_four_scans_after_edit"
+      ],
+      "agreement": 1.0,
+      "repetitions": 5,
+      "terminal_state": "ticket_ready",
+      "votes": {
+        "actions": {
+          "accept_sufficient_design_without_further_design_questions": 5,
+          "cite_volatile_collection_by_location": 2,
+          "create_or_modify_ticket_or_relationship": 5,
+          "elicit_only_tracker_shaped_residue": 5,
+          "elicit_public_surface_behavior": 5,
+          "fill_every_template_slot": 5,
+          "meet_the_ticket_ready_readiness_target": 5,
+          "quote_cited_repository_text": 2,
+          "reject_placeholder_in_scan": 5,
+          "rerun_all_four_scans_after_edit": 4,
+          "restate_architectural_fact_as_value": 2
+        },
+        "terminal_state": {
+          "ticket_ready": 5
+        }
+      }
+    },
+    "internal-criterion-rejected": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "create_or_modify_ticket_or_relationship",
+        "elicit_only_tracker_shaped_residue",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target",
+        "reject_internal_call_criterion",
+        "rerun_all_four_scans_after_edit"
+      ],
+      "agreement": 1.0,
+      "repetitions": 5,
+      "terminal_state": "ticket_ready",
+      "votes": {
+        "actions": {
+          "accept_sufficient_design_without_further_design_questions": 5,
+          "assert_criterion_on_internals": 1,
+          "create_or_modify_ticket_or_relationship": 5,
+          "elicit_only_tracker_shaped_residue": 5,
+          "elicit_public_surface_behavior": 5,
+          "fill_every_template_slot": 5,
+          "meet_the_ticket_ready_readiness_target": 5,
+          "reject_internal_call_criterion": 5,
+          "rerun_all_four_scans_after_edit": 3
+        },
+        "terminal_state": {
+          "ticket_ready": 5
+        }
+      }
+    },
+    "multi-subsystem-decomposition": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "elicit_only_tracker_shaped_residue",
+        "hand_recommendation_back_to_operator",
+        "name_each_independently_valuable_part",
+        "perform_no_tracker_mutation",
+        "record_boundary_between_parts",
+        "record_why_each_part_independently_valuable"
+      ],
+      "agreement": 1.0,
+      "repetitions": 5,
+      "terminal_state": "decomposition_recommended",
+      "votes": {
+        "actions": {
+          "accept_sufficient_design_without_further_design_questions": 3,
+          "elicit_only_tracker_shaped_residue": 5,
+          "hand_recommendation_back_to_operator": 5,
+          "name_each_independently_valuable_part": 5,
+          "perform_no_tracker_mutation": 5,
+          "record_boundary_between_parts": 5,
+          "record_why_each_part_independently_valuable": 5
+        },
+        "terminal_state": {
+          "decomposition_recommended": 5
+        }
+      }
+    },
+    "no-authority-draft-ready": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "choose_no_tracker_on_requesters_behalf",
+        "elicit_only_tracker_shaped_residue",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target",
+        "perform_no_tracker_mutation",
+        "reject_placeholder_in_scan",
+        "rerun_all_four_scans_after_edit",
+        "return_complete_body_to_caller"
+      ],
+      "agreement": 1.0,
+      "repetitions": 5,
+      "terminal_state": "draft_ready",
+      "votes": {
+        "actions": {
+          "accept_sufficient_design_without_further_design_questions": 5,
+          "choose_no_answer_on_requesters_behalf": 2,
+          "choose_no_tracker_on_requesters_behalf": 4,
+          "elicit_only_tracker_shaped_residue": 5,
+          "elicit_public_surface_behavior": 5,
+          "fill_every_template_slot": 5,
+          "meet_the_ticket_ready_readiness_target": 5,
+          "perform_no_tracker_mutation": 5,
+          "reject_internal_call_criterion": 1,
+          "reject_placeholder_in_scan": 5,
+          "rerun_all_four_scans_after_edit": 4,
+          "return_complete_body_to_caller": 5
+        },
+        "terminal_state": {
+          "draft_ready": 5
+        }
+      }
+    },
+    "one-sentence-bug-design-proceeds": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "create_or_modify_ticket_or_relationship",
+        "elicit_only_tracker_shaped_residue",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target"
+      ],
+      "agreement": 1.0,
+      "repetitions": 5,
+      "terminal_state": "ticket_ready",
+      "votes": {
+        "actions": {
+          "accept_sufficient_design_without_further_design_questions": 5,
+          "create_or_modify_ticket_or_relationship": 5,
+          "elicit_only_tracker_shaped_residue": 5,
+          "elicit_public_surface_behavior": 5,
+          "fill_every_template_slot": 5,
+          "meet_the_ticket_ready_readiness_target": 5,
+          "reject_placeholder_in_scan": 1
+        },
+        "terminal_state": {
+          "ticket_ready": 5
+        }
+      }
+    },
+    "placeholder-scan-catches-first-draft": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "create_or_modify_ticket_or_relationship",
+        "elicit_only_tracker_shaped_residue",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target",
+        "reject_placeholder_in_scan",
+        "rerun_all_four_scans_after_edit",
+        "return_to_elicitation_for_missing_value"
+      ],
+      "agreement": 1.0,
+      "repetitions": 5,
+      "terminal_state": "ticket_ready",
+      "votes": {
+        "actions": {
+          "accept_sufficient_design_without_further_design_questions": 5,
+          "create_or_modify_ticket_or_relationship": 5,
+          "elicit_only_tracker_shaped_residue": 5,
+          "elicit_public_surface_behavior": 5,
+          "fill_every_template_slot": 5,
+          "meet_the_ticket_ready_readiness_target": 5,
+          "reject_placeholder_in_scan": 5,
+          "rerun_all_four_scans_after_edit": 5,
+          "return_to_elicitation_for_missing_value": 5
+        },
+        "terminal_state": {
+          "ticket_ready": 5
+        }
+      }
+    },
+    "repository-citation-quotes-and-locates": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "cite_volatile_collection_by_location",
+        "create_or_modify_ticket_or_relationship",
+        "elicit_only_tracker_shaped_residue",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target",
+        "quote_cited_repository_text",
+        "reject_placeholder_in_scan",
+        "restate_architectural_fact_as_value"
+      ],
+      "agreement": 1.0,
+      "repetitions": 5,
+      "terminal_state": "ticket_ready",
+      "votes": {
+        "actions": {
+          "accept_sufficient_design_without_further_design_questions": 5,
+          "cite_volatile_collection_by_location": 5,
+          "create_or_modify_ticket_or_relationship": 5,
+          "elicit_only_tracker_shaped_residue": 5,
+          "elicit_public_surface_behavior": 5,
+          "fill_every_template_slot": 5,
+          "meet_the_ticket_ready_readiness_target": 5,
+          "quote_cited_repository_text": 5,
+          "reject_placeholder_in_scan": 4,
+          "rerun_all_four_scans_after_edit": 2,
+          "restate_architectural_fact_as_value": 5
+        },
+        "terminal_state": {
+          "ticket_ready": 5
+        }
+      }
+    },
+    "vague-idea-resolved-elicitation": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "create_or_modify_ticket_or_relationship",
+        "elicit_only_tracker_shaped_residue",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target"
+      ],
+      "agreement": 1.0,
+      "repetitions": 5,
+      "terminal_state": "ticket_ready",
+      "votes": {
+        "actions": {
+          "accept_sufficient_design_without_further_design_questions": 5,
+          "create_or_modify_ticket_or_relationship": 5,
+          "elicit_only_tracker_shaped_residue": 5,
+          "elicit_public_surface_behavior": 5,
+          "fill_every_template_slot": 5,
+          "meet_the_ticket_ready_readiness_target": 5,
+          "reject_placeholder_in_scan": 1
+        },
+        "terminal_state": {
+          "ticket_ready": 5
+        }
+      }
+    }
+  },
+  "cases": {
+    "autonomous-explicit-no-fill-in-export": "pass",
+    "autonomous-residue-unresolved-verification": "pass",
+    "autonomous-tracker-unchosen": "pass",
+    "autonomous-unresolvable-rate-limit": "fail",
+    "design-missing-requirements": "pass",
+    "full-design-document-proceeds": "pass",
+    "internal-criterion-rejected": "pass",
+    "multi-subsystem-decomposition": "pass",
+    "no-authority-draft-ready": "pass",
+    "one-sentence-bug-design-proceeds": "pass",
+    "placeholder-scan-catches-first-draft": "pass",
+    "repository-citation-quotes-and-locates": "pass",
+    "vague-idea-resolved-elicitation": "pass"
+  },
+  "command": [
+    "/Users/scott/.local/share/mise/installs/python/3.11/bin/python3",
+    "skills/ready-ticket/scripts/evals/run_forward.py",
+    "--executor",
+    "/Users/scott/.local/share/mise/installs/python/3.11/bin/python3 skills/ready-ticket/scripts/evals/claude_executor.py --model claude-opus-5"
+  ],
+  "compared_to": "2026-08-15T221346Z-0007-before.json",
+  "diff": {
+    "newly_failing": [
+      "autonomous-unresolvable-rate-limit"
+    ],
+    "newly_passing": [
+      "repository-citation-quotes-and-locates"
+    ],
+    "still_failing": [],
+    "unchanged": 11
+  },
+  "exit_code": 1,
+  "failures": [
+    "autonomous-unresolvable-rate-limit: missing actions: choose_no_answer_on_requesters_behalf"
+  ],
+  "forward_evals": true,
+  "gap": null,
+  "limitation": null,
+  "model": "claude-opus-5",
+  "note": null,
+  "output_tail": "{\n  \"failed\": 1,\n  \"failures\": [\n    \"autonomous-unresolvable-rate-limit: missing actions: choose_no_answer_on_requesters_behalf\"\n  ],\n  \"passed\": 12,\n  \"total\": 13\n}",
+  "recorded_at": "2026-08-15T22:43:21Z",
+  "schema": "eval-run-summary/1",
+  "skill": "ready-ticket",
+  "stage": "after",
+  "status": "failed",
+  "suite": "forward",
+  "tier": "real-model",
+  "totals": {
+    "failed": 1,
+    "passed": 12,
+    "total": 13
+  }
+}

--- a/skills/ready-ticket/evals/results/2026-08-15T235404Z-0009-after-at-shipping-head.json
+++ b/skills/ready-ticket/evals/results/2026-08-15T235404Z-0009-after-at-shipping-head.json
@@ -1,0 +1,462 @@
+{
+  "candidate": {
+    "branch": "scott/ticket-233-67b04e",
+    "sha": "75cf01e09e740f7321f3a80f433951a7840b8065",
+    "tree": "5ff3c3f5a347be232ba178e9669cfc1617360925",
+    "worktree_clean": true
+  },
+  "case_evidence": {
+    "autonomous-explicit-no-fill-in-export": {
+      "actions": [
+        "ask_no_question_wait_for_no_answer",
+        "choose_no_answer_on_requesters_behalf",
+        "give_one_next_action",
+        "name_the_absent_design_part",
+        "perform_no_tracker_mutation"
+      ],
+      "agreement": 1.0,
+      "repetitions": 5,
+      "terminal_state": "requires_brainstorming",
+      "votes": {
+        "actions": {
+          "ask_no_question_wait_for_no_answer": 5,
+          "choose_no_answer_on_requesters_behalf": 3,
+          "choose_no_tracker_on_requesters_behalf": 2,
+          "give_one_next_action": 5,
+          "name_the_absent_design_part": 5,
+          "perform_no_tracker_mutation": 5
+        },
+        "terminal_state": {
+          "requires_brainstorming": 5
+        }
+      }
+    },
+    "autonomous-residue-unresolved-verification": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "ask_no_question_wait_for_no_answer",
+        "elicit_only_tracker_shaped_residue",
+        "give_one_next_action",
+        "name_the_unresolved_decision_as_blocking_reason",
+        "perform_no_tracker_mutation"
+      ],
+      "agreement": 1.0,
+      "repetitions": 5,
+      "terminal_state": "blocked",
+      "votes": {
+        "actions": {
+          "accept_sufficient_design_without_further_design_questions": 5,
+          "ask_no_question_wait_for_no_answer": 5,
+          "choose_no_answer_on_requesters_behalf": 1,
+          "elicit_only_tracker_shaped_residue": 3,
+          "elicit_public_surface_behavior": 1,
+          "give_one_next_action": 5,
+          "name_the_unresolved_decision_as_blocking_reason": 5,
+          "perform_no_tracker_mutation": 5
+        },
+        "terminal_state": {
+          "blocked": 5
+        }
+      }
+    },
+    "autonomous-tracker-unchosen": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "ask_no_question_wait_for_no_answer",
+        "choose_no_answer_on_requesters_behalf",
+        "choose_no_tracker_on_requesters_behalf",
+        "cite_volatile_collection_by_location",
+        "elicit_only_tracker_shaped_residue",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target",
+        "perform_no_tracker_mutation",
+        "quote_cited_repository_text",
+        "reject_placeholder_in_scan",
+        "rerun_all_four_scans_after_edit",
+        "return_complete_body_to_caller"
+      ],
+      "agreement": 1.0,
+      "repetitions": 5,
+      "terminal_state": "draft_ready",
+      "votes": {
+        "actions": {
+          "accept_sufficient_design_without_further_design_questions": 5,
+          "ask_no_question_wait_for_no_answer": 5,
+          "choose_no_answer_on_requesters_behalf": 3,
+          "choose_no_tracker_on_requesters_behalf": 3,
+          "cite_volatile_collection_by_location": 3,
+          "elicit_only_tracker_shaped_residue": 5,
+          "elicit_public_surface_behavior": 5,
+          "fill_every_template_slot": 5,
+          "meet_the_ticket_ready_readiness_target": 4,
+          "perform_no_tracker_mutation": 5,
+          "quote_cited_repository_text": 5,
+          "reject_internal_call_criterion": 2,
+          "reject_placeholder_in_scan": 5,
+          "rerun_all_four_scans_after_edit": 3,
+          "restate_architectural_fact_as_value": 2,
+          "return_complete_body_to_caller": 5
+        },
+        "terminal_state": {
+          "draft_ready": 5
+        }
+      }
+    },
+    "autonomous-unresolvable-rate-limit": {
+      "actions": [
+        "ask_no_question_wait_for_no_answer",
+        "choose_no_answer_on_requesters_behalf",
+        "choose_no_tracker_on_requesters_behalf",
+        "give_one_next_action",
+        "name_the_absent_design_part",
+        "perform_no_tracker_mutation"
+      ],
+      "agreement": 1.0,
+      "repetitions": 5,
+      "terminal_state": "requires_brainstorming",
+      "votes": {
+        "actions": {
+          "ask_no_question_wait_for_no_answer": 5,
+          "choose_no_answer_on_requesters_behalf": 4,
+          "choose_no_tracker_on_requesters_behalf": 4,
+          "give_one_next_action": 5,
+          "name_the_absent_design_part": 5,
+          "perform_no_tracker_mutation": 5
+        },
+        "terminal_state": {
+          "requires_brainstorming": 5
+        }
+      }
+    },
+    "design-missing-requirements": {
+      "actions": [
+        "give_one_next_action",
+        "name_the_absent_design_part",
+        "perform_no_tracker_mutation"
+      ],
+      "agreement": 1.0,
+      "repetitions": 5,
+      "terminal_state": "requires_brainstorming",
+      "votes": {
+        "actions": {
+          "ask_no_question_wait_for_no_answer": 1,
+          "give_one_next_action": 5,
+          "name_the_absent_design_part": 5,
+          "perform_no_tracker_mutation": 5
+        },
+        "terminal_state": {
+          "requires_brainstorming": 5
+        }
+      }
+    },
+    "full-design-document-proceeds": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "create_or_modify_ticket_or_relationship",
+        "elicit_only_tracker_shaped_residue",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target",
+        "reject_placeholder_in_scan"
+      ],
+      "agreement": 1.0,
+      "repetitions": 5,
+      "terminal_state": "ticket_ready",
+      "votes": {
+        "actions": {
+          "accept_sufficient_design_without_further_design_questions": 5,
+          "cite_volatile_collection_by_location": 2,
+          "create_or_modify_ticket_or_relationship": 5,
+          "elicit_only_tracker_shaped_residue": 5,
+          "elicit_public_surface_behavior": 5,
+          "fill_every_template_slot": 5,
+          "meet_the_ticket_ready_readiness_target": 5,
+          "quote_cited_repository_text": 2,
+          "reject_placeholder_in_scan": 5,
+          "rerun_all_four_scans_after_edit": 2,
+          "restate_architectural_fact_as_value": 2
+        },
+        "terminal_state": {
+          "ticket_ready": 5
+        }
+      }
+    },
+    "internal-criterion-rejected": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "create_or_modify_ticket_or_relationship",
+        "elicit_only_tracker_shaped_residue",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target",
+        "reject_internal_call_criterion",
+        "rerun_all_four_scans_after_edit"
+      ],
+      "agreement": 1.0,
+      "repetitions": 5,
+      "terminal_state": "ticket_ready",
+      "votes": {
+        "actions": {
+          "accept_sufficient_design_without_further_design_questions": 5,
+          "assert_criterion_on_internals": 2,
+          "create_or_modify_ticket_or_relationship": 5,
+          "elicit_only_tracker_shaped_residue": 5,
+          "elicit_public_surface_behavior": 5,
+          "fill_every_template_slot": 5,
+          "meet_the_ticket_ready_readiness_target": 5,
+          "reject_internal_call_criterion": 5,
+          "reject_placeholder_in_scan": 1,
+          "rerun_all_four_scans_after_edit": 3
+        },
+        "terminal_state": {
+          "ticket_ready": 5
+        }
+      }
+    },
+    "multi-subsystem-decomposition": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "elicit_only_tracker_shaped_residue",
+        "hand_recommendation_back_to_operator",
+        "name_each_independently_valuable_part",
+        "perform_no_tracker_mutation",
+        "record_boundary_between_parts",
+        "record_why_each_part_independently_valuable"
+      ],
+      "agreement": 1.0,
+      "repetitions": 5,
+      "terminal_state": "decomposition_recommended",
+      "votes": {
+        "actions": {
+          "accept_sufficient_design_without_further_design_questions": 4,
+          "elicit_only_tracker_shaped_residue": 5,
+          "hand_recommendation_back_to_operator": 5,
+          "name_each_independently_valuable_part": 5,
+          "perform_no_tracker_mutation": 5,
+          "record_boundary_between_parts": 5,
+          "record_why_each_part_independently_valuable": 5
+        },
+        "terminal_state": {
+          "decomposition_recommended": 5
+        }
+      }
+    },
+    "no-authority-draft-ready": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "cite_volatile_collection_by_location",
+        "elicit_only_tracker_shaped_residue",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target",
+        "perform_no_tracker_mutation",
+        "quote_cited_repository_text",
+        "reject_internal_call_criterion",
+        "reject_placeholder_in_scan",
+        "rerun_all_four_scans_after_edit",
+        "restate_architectural_fact_as_value",
+        "return_complete_body_to_caller"
+      ],
+      "agreement": 1.0,
+      "repetitions": 5,
+      "terminal_state": "draft_ready",
+      "votes": {
+        "actions": {
+          "accept_sufficient_design_without_further_design_questions": 5,
+          "choose_no_tracker_on_requesters_behalf": 1,
+          "cite_volatile_collection_by_location": 3,
+          "elicit_only_tracker_shaped_residue": 5,
+          "elicit_public_surface_behavior": 5,
+          "fill_every_template_slot": 5,
+          "meet_the_ticket_ready_readiness_target": 5,
+          "perform_no_tracker_mutation": 5,
+          "quote_cited_repository_text": 3,
+          "reject_internal_call_criterion": 3,
+          "reject_placeholder_in_scan": 5,
+          "rerun_all_four_scans_after_edit": 4,
+          "restate_architectural_fact_as_value": 3,
+          "return_complete_body_to_caller": 5,
+          "return_to_elicitation_for_missing_value": 2
+        },
+        "terminal_state": {
+          "draft_ready": 5
+        }
+      }
+    },
+    "one-sentence-bug-design-proceeds": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "create_or_modify_ticket_or_relationship",
+        "elicit_only_tracker_shaped_residue",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target",
+        "reject_placeholder_in_scan"
+      ],
+      "agreement": 1.0,
+      "repetitions": 5,
+      "terminal_state": "ticket_ready",
+      "votes": {
+        "actions": {
+          "accept_sufficient_design_without_further_design_questions": 5,
+          "create_or_modify_ticket_or_relationship": 5,
+          "elicit_only_tracker_shaped_residue": 5,
+          "elicit_public_surface_behavior": 5,
+          "fill_every_template_slot": 5,
+          "meet_the_ticket_ready_readiness_target": 5,
+          "reject_placeholder_in_scan": 3,
+          "rerun_all_four_scans_after_edit": 1
+        },
+        "terminal_state": {
+          "ticket_ready": 5
+        }
+      }
+    },
+    "placeholder-scan-catches-first-draft": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "create_or_modify_ticket_or_relationship",
+        "elicit_only_tracker_shaped_residue",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target",
+        "reject_placeholder_in_scan",
+        "rerun_all_four_scans_after_edit",
+        "return_to_elicitation_for_missing_value"
+      ],
+      "agreement": 1.0,
+      "repetitions": 5,
+      "terminal_state": "ticket_ready",
+      "votes": {
+        "actions": {
+          "accept_sufficient_design_without_further_design_questions": 5,
+          "create_or_modify_ticket_or_relationship": 5,
+          "elicit_only_tracker_shaped_residue": 5,
+          "elicit_public_surface_behavior": 5,
+          "fill_every_template_slot": 5,
+          "meet_the_ticket_ready_readiness_target": 5,
+          "reject_placeholder_in_scan": 5,
+          "rerun_all_four_scans_after_edit": 5,
+          "return_to_elicitation_for_missing_value": 5
+        },
+        "terminal_state": {
+          "ticket_ready": 5
+        }
+      }
+    },
+    "repository-citation-quotes-and-locates": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "cite_volatile_collection_by_location",
+        "create_or_modify_ticket_or_relationship",
+        "elicit_only_tracker_shaped_residue",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target",
+        "quote_cited_repository_text",
+        "restate_architectural_fact_as_value"
+      ],
+      "agreement": 1.0,
+      "repetitions": 5,
+      "terminal_state": "ticket_ready",
+      "votes": {
+        "actions": {
+          "accept_sufficient_design_without_further_design_questions": 5,
+          "cite_volatile_collection_by_location": 5,
+          "create_or_modify_ticket_or_relationship": 5,
+          "elicit_only_tracker_shaped_residue": 5,
+          "elicit_public_surface_behavior": 5,
+          "fill_every_template_slot": 5,
+          "meet_the_ticket_ready_readiness_target": 5,
+          "quote_cited_repository_text": 5,
+          "reject_placeholder_in_scan": 1,
+          "rerun_all_four_scans_after_edit": 1,
+          "restate_architectural_fact_as_value": 5
+        },
+        "terminal_state": {
+          "ticket_ready": 5
+        }
+      }
+    },
+    "vague-idea-resolved-elicitation": {
+      "actions": [
+        "accept_sufficient_design_without_further_design_questions",
+        "create_or_modify_ticket_or_relationship",
+        "elicit_only_tracker_shaped_residue",
+        "elicit_public_surface_behavior",
+        "fill_every_template_slot",
+        "meet_the_ticket_ready_readiness_target",
+        "reject_placeholder_in_scan"
+      ],
+      "agreement": 1.0,
+      "repetitions": 5,
+      "terminal_state": "ticket_ready",
+      "votes": {
+        "actions": {
+          "accept_sufficient_design_without_further_design_questions": 5,
+          "create_or_modify_ticket_or_relationship": 5,
+          "elicit_only_tracker_shaped_residue": 5,
+          "elicit_public_surface_behavior": 5,
+          "fill_every_template_slot": 5,
+          "meet_the_ticket_ready_readiness_target": 5,
+          "reject_placeholder_in_scan": 5,
+          "rerun_all_four_scans_after_edit": 1
+        },
+        "terminal_state": {
+          "ticket_ready": 5
+        }
+      }
+    }
+  },
+  "cases": {
+    "autonomous-explicit-no-fill-in-export": "pass",
+    "autonomous-residue-unresolved-verification": "pass",
+    "autonomous-tracker-unchosen": "pass",
+    "autonomous-unresolvable-rate-limit": "pass",
+    "design-missing-requirements": "pass",
+    "full-design-document-proceeds": "pass",
+    "internal-criterion-rejected": "pass",
+    "multi-subsystem-decomposition": "pass",
+    "no-authority-draft-ready": "pass",
+    "one-sentence-bug-design-proceeds": "pass",
+    "placeholder-scan-catches-first-draft": "pass",
+    "repository-citation-quotes-and-locates": "pass",
+    "vague-idea-resolved-elicitation": "pass"
+  },
+  "command": [
+    "/Users/scott/.local/share/mise/installs/python/3.11/bin/python3",
+    "skills/ready-ticket/scripts/evals/run_forward.py",
+    "--executor",
+    "/Users/scott/.local/share/mise/installs/python/3.11/bin/python3 skills/ready-ticket/scripts/evals/claude_executor.py --model claude-opus-5"
+  ],
+  "compared_to": "2026-08-15T224321Z-0008-after.json",
+  "diff": {
+    "newly_failing": [],
+    "newly_passing": [
+      "autonomous-unresolvable-rate-limit"
+    ],
+    "still_failing": [],
+    "unchanged": 12
+  },
+  "exit_code": 0,
+  "failures": [],
+  "forward_evals": true,
+  "gap": null,
+  "limitation": null,
+  "model": "claude-opus-5",
+  "note": null,
+  "output_tail": "{\n  \"failed\": 0,\n  \"failures\": [],\n  \"passed\": 13,\n  \"total\": 13\n}",
+  "recorded_at": "2026-08-15T23:54:04Z",
+  "schema": "eval-run-summary/1",
+  "skill": "ready-ticket",
+  "stage": "after",
+  "status": "completed",
+  "suite": "forward",
+  "tier": "real-model",
+  "totals": {
+    "failed": 0,
+    "passed": 13,
+    "total": 13
+  }
+}

--- a/skills/ready-ticket/scripts/evals/claude_executor.py
+++ b/skills/ready-ticket/scripts/evals/claude_executor.py
@@ -32,6 +32,9 @@ import subprocess
 import sys
 from collections import Counter
 
+# How a sample with no usable terminal state votes. Never a real answer.
+NO_TERMINAL_STATE = "none"
+
 TERMINAL_STATES = (
     "ticket_ready",
     "draft_ready",
@@ -186,14 +189,26 @@ def combine(samples: list[tuple[str | None, frozenset[str]]]) -> dict:
     behavior, and reporting it either way would make a coin flip look
     decided. `votes` keeps every count so the variance stays legible after
     the majority has collapsed it.
+
+    A sample carrying no usable terminal state votes under `NO_TERMINAL_STATE`
+    rather than under `None`, exactly as
+    `triggering/executors/description_executor.py` already votes an absent
+    answer. The counts become dict keys, and `json.dump(..., sort_keys=True)`
+    cannot order `None` against a string: keying it raw turns one unusable
+    sample into a crash that ends the whole corpus run, where the graded
+    `terminal_state` below still reports `None` and grades as the single-case
+    mismatch it is. No real terminal state spells `none`, so the sentinel is
+    unambiguous.
     """
     repetitions = len(samples)
-    state_votes = Counter(state for state, _ in samples)
+    state_votes = Counter(state or NO_TERMINAL_STATE for state, _ in samples)
     winning_state, agreement = state_votes.most_common(1)[0]
     action_votes = Counter(action for _, actions in samples for action in actions)
     majority = repetitions // 2 + 1
     return {
-        "terminal_state": winning_state,
+        "terminal_state": (
+            None if winning_state == NO_TERMINAL_STATE else winning_state
+        ),
         "actions": sorted(
             action for action, count in action_votes.items() if count >= majority
         ),

--- a/skills/ready-ticket/scripts/evals/claude_executor.py
+++ b/skills/ready-ticket/scripts/evals/claude_executor.py
@@ -12,6 +12,13 @@ artifacts, plus the closed action vocabulary below so its choices are gradable
 against `forward_expectations.json`. It never sees fixture identity or any
 expectations. Requires the `claude` CLI on PATH (override with --claude-bin).
 
+Following the micro-test protocol in `docs/skill-authoring.md`, and matching
+`triggering/executors/description_executor.py`, each scenario is asked
+`--repetitions` times (default 5) in independent processes. The majority
+terminal state wins, an action is reported when a majority of samples chose it,
+and the per-sample counts travel with the answer so a 3/5 result is never
+recorded as though it were 5/5.
+
 Usage:
     python3 run_forward.py --executor "python3 claude_executor.py"
 """
@@ -23,6 +30,7 @@ import json
 import re
 import subprocess
 import sys
+from collections import Counter
 
 TERMINAL_STATES = (
     "ticket_ready",
@@ -41,6 +49,8 @@ ACTION_VOCABULARY = (
     "assert_criterion_on_internals",
     "choose_no_answer_on_requesters_behalf",
     "choose_no_tracker_on_requesters_behalf",
+    "cite_bare_file_line_without_quoted_text",
+    "cite_volatile_collection_by_location",
     "claim_readiness_with_a_placeholder_present",
     "close_open_decision_without_requester",
     "create_or_modify_ticket_or_relationship",
@@ -58,11 +68,14 @@ ACTION_VOCABULARY = (
     "name_the_absent_design_part",
     "name_the_unresolved_decision_as_blocking_reason",
     "perform_no_tracker_mutation",
+    "quote_cited_repository_text",
     "reject_internal_call_criterion",
     "reject_placeholder_in_scan",
     "relitigate_settled_design_decision",
     "require_design_ceremony_beyond_the_scale_of_the_work",
     "rerun_all_four_scans_after_edit",
+    "restate_architectural_fact_as_value",
+    "restate_volatile_collection_membership_as_value",
     "return_complete_body_to_caller",
     "return_to_elicitation_for_missing_value",
     "record_boundary_between_parts",
@@ -108,37 +121,88 @@ def extract_json_object(text: str) -> dict:
     return json.loads(candidate[start : end + 1])
 
 
-def run_claude(prompt: str, claude_bin: str, model: str | None) -> dict:
+RESULT_ATTEMPTS = 3
+
+
+def run_claude(
+    prompt: str, claude_bin: str, model: str | None, attempts: int = RESULT_ATTEMPTS
+) -> dict:
     command = [claude_bin, "-p", "--output-format", "json"]
     if model:
         command.extend(["--model", model])
-    completed = subprocess.run(
-        command,
-        input=prompt,
-        text=True,
-        capture_output=True,
-        check=False,
-    )
-    if completed.returncode:
-        raise RuntimeError(
-            f"claude exited {completed.returncode}: {completed.stderr.strip()}"
+
+    # The model occasionally ends its turn with the JSON object incomplete --
+    # a missing closing brace, or an unescaped quote inside a string value.
+    # That is a malformed *response*, not a boundary-detection bug in
+    # extract_json_object, and a fresh independent sample clears it almost
+    # every time. Without this loop one flaky sample sinks a whole recorded
+    # run, which is now `--repetitions` times as many samples as it was.
+    last_error: ValueError | None = None
+    for _ in range(attempts):
+        completed = subprocess.run(
+            command,
+            input=prompt,
+            text=True,
+            capture_output=True,
+            check=False,
         )
-    envelope = json.loads(completed.stdout)
-    result_text = envelope.get("result")
-    if not isinstance(result_text, str):
-        raise RuntimeError("claude --output-format json returned no result text")
-    return extract_json_object(result_text)
+        if completed.returncode:
+            raise RuntimeError(
+                f"claude exited {completed.returncode}: {completed.stderr.strip()}"
+            )
+        envelope = json.loads(completed.stdout)
+        result_text = envelope.get("result")
+        if not isinstance(result_text, str):
+            raise RuntimeError("claude --output-format json returned no result text")
+        try:
+            return extract_json_object(result_text)
+        except ValueError as error:
+            last_error = error
+    raise RuntimeError(
+        f"executor model returned malformed JSON after {attempts} attempts: {last_error}"
+    )
 
 
-def normalize(observed: dict) -> dict:
+def sample(observed: dict) -> tuple[str | None, frozenset[str]]:
+    """One sample reduced to the two things the grader is defined on."""
     actions = observed.get("actions")
     if not isinstance(actions, list):
         actions = []
-    return {
-        "terminal_state": observed.get("terminal_state"),
-        "actions": sorted(
-            {str(action) for action in actions if str(action) in ACTION_VOCABULARY}
+    state = observed.get("terminal_state")
+    return (
+        str(state) if isinstance(state, str) else None,
+        frozenset(
+            str(action) for action in actions if str(action) in ACTION_VOCABULARY
         ),
+    )
+
+
+def combine(samples: list[tuple[str | None, frozenset[str]]]) -> dict:
+    """Majority-vote independent samples into one gradable answer.
+
+    The terminal state is the modal answer. An action is reported when a
+    strict majority of samples chose it, which is the same rule applied
+    per-element: a term half the samples reached for is not this run's
+    behavior, and reporting it either way would make a coin flip look
+    decided. `votes` keeps every count so the variance stays legible after
+    the majority has collapsed it.
+    """
+    repetitions = len(samples)
+    state_votes = Counter(state for state, _ in samples)
+    winning_state, agreement = state_votes.most_common(1)[0]
+    action_votes = Counter(action for _, actions in samples for action in actions)
+    majority = repetitions // 2 + 1
+    return {
+        "terminal_state": winning_state,
+        "actions": sorted(
+            action for action, count in action_votes.items() if count >= majority
+        ),
+        "repetitions": repetitions,
+        "agreement": agreement / repetitions,
+        "votes": {
+            "terminal_state": dict(state_votes),
+            "actions": dict(action_votes),
+        },
     }
 
 
@@ -150,14 +214,26 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="Optional model override passed to `claude --model`",
     )
+    parser.add_argument(
+        "--repetitions",
+        type=int,
+        default=5,
+        help="Independent samples per scenario; the majority answer is graded",
+    )
     return parser.parse_args()
 
 
 def main() -> int:
     args = parse_args()
+    if args.repetitions < 1:
+        raise SystemExit("--repetitions must be at least 1")
     payload = json.load(sys.stdin)
-    observed = run_claude(build_prompt(payload), args.claude_bin, args.model)
-    json.dump(normalize(observed), sys.stdout, sort_keys=True)
+    prompt = build_prompt(payload)
+    samples = [
+        sample(run_claude(prompt, args.claude_bin, args.model))
+        for _ in range(args.repetitions)
+    ]
+    json.dump(combine(samples), sys.stdout, sort_keys=True)
     sys.stdout.write("\n")
     return 0
 

--- a/skills/ready-ticket/scripts/evals/fixture_executor.py
+++ b/skills/ready-ticket/scripts/evals/fixture_executor.py
@@ -104,6 +104,14 @@ ANSWERS: dict[str, dict] = {
             "elicit_public_surface_behavior",
         ],
     },
+    "Make GH-512 ready — the linked design was approved.": {
+        "terminal_state": "ticket_ready",
+        "actions": [
+            "quote_cited_repository_text",
+            "cite_volatile_collection_by_location",
+            "restate_architectural_fact_as_value",
+        ],
+    },
     "Write a ticket for the new notifications feature.": {
         "terminal_state": "requires_brainstorming",
         "actions": [

--- a/skills/ready-ticket/scripts/tests/test_authoring_contract.py
+++ b/skills/ready-ticket/scripts/tests/test_authoring_contract.py
@@ -386,6 +386,39 @@ class ReadyTicketContractTests(unittest.TestCase):
             self.contract,
         )
 
+    # --- Repository citations ---------------------------------------------
+
+    def test_a_cited_repository_line_carries_its_quoted_text(self):
+        for clause in (
+            "A citation of repository text carries the text, not only the address",
+            "never the bare `SPEC.md:251`",
+            "it fails silently, because it still resolves, to something else",
+        ):
+            self.assertIn(clause, self.contract)
+
+    def test_a_volatile_fact_is_located_and_an_architectural_one_is_restated(self):
+        for clause in (
+            "A fact that changes whenever a consumer is added — a collection's "
+            "members, a count, a registry's contents — goes false the next time "
+            "anyone adds one",
+            "let the reader read today's members: \"the lenses `review-code-change` "
+            'loads", not "the three lenses"',
+            "An architectural fact is one whose change is itself something a reader "
+            "has to notice",
+            "what a script writes, what an executor refuses to emit, what a runner "
+            "ships to a model",
+        ):
+            self.assertIn(clause, self.contract)
+
+    def test_the_two_forms_are_separated_by_a_stated_discriminator(self):
+        """Without the question, the pair is two examples and no way to apply it."""
+        for clause in (
+            "what would make this statement false?",
+            "If adding one more consumer would, cite the location",
+            "If only a deliberate decision would, state the value",
+        ):
+            self.assertIn(clause, self.contract)
+
     # --- Criteria quality and the self-review pass ------------------------
 
     def test_criteria_are_surface_observable_and_test_encodable(self):

--- a/skills/ready-ticket/scripts/tests/test_forward_evals.py
+++ b/skills/ready-ticket/scripts/tests/test_forward_evals.py
@@ -14,6 +14,7 @@ import subprocess
 import sys
 import unittest
 from pathlib import Path
+from unittest import mock
 
 SKILL_ROOT = Path(__file__).resolve().parents[2]
 EVALS = SKILL_ROOT / "evals"
@@ -337,35 +338,43 @@ class RepetitionTests(unittest.TestCase):
         self.assertEqual([], combined["actions"])
         self.assertEqual({}, combined["votes"]["actions"])
 
+    @staticmethod
+    def completed(result_text: str) -> subprocess.CompletedProcess:
+        return subprocess.CompletedProcess(
+            args=["claude"],
+            returncode=0,
+            stdout=json.dumps({"result": result_text}),
+            stderr="",
+        )
+
     def test_a_malformed_sample_is_retried_rather_than_sinking_the_run(self) -> None:
         """One flaky response must not end a run of many sequential samples."""
-        attempts: list[str] = []
+        malformed = '{"terminal_state": "ticket_ready"'
+        valid = '{"terminal_state": "ticket_ready", "actions": []}'
 
-        def flaky(**_kwargs):
-            attempts.append("call")
-            if len(attempts) < 3:
-                return SimpleCompleted('{"terminal_state": "ticket_ready"')
-            return SimpleCompleted('{"terminal_state": "ticket_ready", "actions": []}')
-
-        original = claude_executor.subprocess.run
-        claude_executor.subprocess.run = lambda *args, **kwargs: flaky(**kwargs)
-        try:
+        with mock.patch.object(
+            claude_executor.subprocess,
+            "run",
+            side_effect=[self.completed(malformed), self.completed(valid)],
+        ) as run_mock:
             observed = claude_executor.run_claude("prompt", "claude", None)
-        finally:
-            claude_executor.subprocess.run = original
 
         self.assertEqual("ticket_ready", observed["terminal_state"])
-        self.assertEqual(3, len(attempts))
+        self.assertEqual(2, run_mock.call_count)
 
+    def test_a_run_of_malformed_samples_raises_once_attempts_are_spent(self) -> None:
+        malformed = '{"terminal_state": "ticket_ready"'
+        attempts = claude_executor.RESULT_ATTEMPTS
 
-class SimpleCompleted:
-    """The two fields `run_claude` reads off a completed `claude -p` process."""
+        with mock.patch.object(
+            claude_executor.subprocess,
+            "run",
+            side_effect=[self.completed(malformed)] * attempts,
+        ) as run_mock:
+            with self.assertRaises(RuntimeError):
+                claude_executor.run_claude("prompt", "claude", None)
 
-    returncode = 0
-    stderr = ""
-
-    def __init__(self, result_text: str) -> None:
-        self.stdout = json.dumps({"result": result_text})
+        self.assertEqual(attempts, run_mock.call_count)
 
 
 if __name__ == "__main__":

--- a/skills/ready-ticket/scripts/tests/test_forward_evals.py
+++ b/skills/ready-ticket/scripts/tests/test_forward_evals.py
@@ -297,6 +297,40 @@ class RepetitionTests(unittest.TestCase):
             combined["votes"]["actions"],
         )
 
+    def test_a_sample_without_a_terminal_state_still_serializes(self) -> None:
+        """One unusable sample grades as a mismatch; it does not end the run.
+
+        The vote counts become JSON object keys, and
+        `json.dump(..., sort_keys=True)` cannot order `None` against a string.
+        Keying an absent state raw raised `TypeError` at output time, which
+        `run_forward.py` surfaces as a non-zero executor exit — ending the
+        whole corpus mid-run, discarding every case already sampled, and
+        leaving `record_eval_run.py` to file the loss as `attempted`, the
+        status reserved for an environment without model access.
+        """
+        combined = claude_executor.combine(
+            [
+                claude_executor.sample({"terminal_state": "ticket_ready"}),
+                claude_executor.sample({"actions": []}),
+            ]
+        )
+
+        json.dumps(combined, sort_keys=True)
+        self.assertEqual(
+            {"ticket_ready": 1, "none": 1}, combined["votes"]["terminal_state"]
+        )
+
+    def test_an_all_unusable_run_reports_no_terminal_state_rather_than_the_sentinel(
+        self,
+    ) -> None:
+        """The sentinel is a vote key, never a graded answer."""
+        combined = claude_executor.combine(
+            [claude_executor.sample({"actions": []}) for _ in range(3)]
+        )
+
+        self.assertIsNone(combined["terminal_state"])
+        self.assertEqual({"none": 3}, combined["votes"]["terminal_state"])
+
     def test_a_term_outside_the_vocabulary_is_discarded(self) -> None:
         combined = self.combine(("ticket_ready", ["not_a_real_action"]))
 

--- a/skills/ready-ticket/scripts/tests/test_forward_evals.py
+++ b/skills/ready-ticket/scripts/tests/test_forward_evals.py
@@ -8,6 +8,7 @@ the suite is free to run in CI.
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import subprocess
 import sys
@@ -17,6 +18,23 @@ from pathlib import Path
 SKILL_ROOT = Path(__file__).resolve().parents[2]
 EVALS = SKILL_ROOT / "evals"
 RUN_FORWARD = SKILL_ROOT / "scripts" / "evals" / "run_forward.py"
+CLAUDE_EXECUTOR = SKILL_ROOT / "scripts" / "evals" / "claude_executor.py"
+
+
+def load_module(path: Path, name: str):
+    """Import an eval script by file path.
+
+    `scripts/evals/` is not a package, and both this skill and
+    implement-ticket ship a `claude_executor.py`; importing by path keeps the
+    two from colliding on a shared `sys.path` entry.
+    """
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+claude_executor = load_module(CLAUDE_EXECUTOR, "ready_ticket_claude_executor")
 
 CASES = json.loads((EVALS / "forward_cases.json").read_text())
 EXPECTATIONS = {
@@ -106,6 +124,46 @@ class CorpusShapeTests(unittest.TestCase):
             self.assertNotIn("required_actions", case)
             self.assertNotIn("workflow_state", case)
 
+    def test_a_case_grades_how_repository_state_is_cited(self) -> None:
+        """AC: a case grades quoting, location-citing, and value-restating."""
+        expectation = EXPECTATIONS["repository-citation-quotes-and-locates"]
+
+        self.assertEqual("ticket_ready", expectation["terminal_state"])
+        required = set(expectation["required_actions"])
+        forbidden = set(expectation["forbidden_actions"])
+        self.assertIn("quote_cited_repository_text", required)
+        self.assertIn("cite_volatile_collection_by_location", required)
+        self.assertIn("restate_architectural_fact_as_value", required)
+        self.assertIn("cite_bare_file_line_without_quoted_text", forbidden)
+        self.assertIn("restate_volatile_collection_membership_as_value", forbidden)
+        self.assertFalse(required & forbidden)
+
+    def test_the_citation_case_names_its_facts_without_classifying_them(self) -> None:
+        """The scenario must state the facts and leave the rule to the prose.
+
+        An earlier draft described the lens set as one that "gains a member
+        whenever a lens is added" and the recorder's output as changing "only
+        when someone decides to change it". Both phrasings are the answer
+        rather than the scenario: a fresh model given them chose correctly at
+        the pre-change tree, so the case graded the hint instead of the prose.
+        """
+        case = next(
+            item
+            for item in CASES
+            if item["id"] == "repository-citation-quotes-and-locates"
+        )
+        repository = case["artifacts"]["repository"]
+
+        self.assertIn("line 251 of", repository)
+        self.assertIn("which review lenses", repository)
+        self.assertIn("what the eval recorder emits", repository)
+        for classification in (
+            "gains a member",
+            "only when someone decides",
+            "volatile",
+        ):
+            self.assertNotIn(classification, repository)
+
     def test_two_cases_are_the_strongest_baseline_scenarios(self) -> None:
         """AC: the strongest scenarios from the baseline pressure test are here."""
         requests = {case["request"] for case in CASES}
@@ -178,6 +236,102 @@ class RunnerTests(unittest.TestCase):
         self.assertTrue(
             any("forbidden actions" in failure for failure in summary["failures"])
         )
+
+    def test_every_fixture_answer_uses_the_closed_vocabulary(self) -> None:
+        """A corpus term absent from the executor's list is ungradable."""
+        fixture = load_module(
+            SKILL_ROOT / "scripts" / "evals" / "fixture_executor.py",
+            "ready_ticket_fixture_executor",
+        )
+        vocabulary = set(claude_executor.ACTION_VOCABULARY)
+
+        self.assertEqual(set(fixture.ANSWERS), {case["request"] for case in CASES})
+        for request, answer in fixture.ANSWERS.items():
+            self.assertLessEqual(set(answer["actions"]), vocabulary, request)
+        for case_id, expectation in EXPECTATIONS.items():
+            self.assertLessEqual(
+                set(expectation["required_actions"])
+                | set(expectation["forbidden_actions"]),
+                vocabulary,
+                case_id,
+            )
+
+
+class RepetitionTests(unittest.TestCase):
+    """AC: the real-model tier records how many repetitions agreed."""
+
+    def combine(self, *samples: tuple[str, list[str]]) -> dict:
+        return claude_executor.combine(
+            [
+                claude_executor.sample({"terminal_state": state, "actions": actions})
+                for state, actions in samples
+            ]
+        )
+
+    def test_the_majority_terminal_state_wins_and_its_agreement_is_recorded(
+        self,
+    ) -> None:
+        combined = self.combine(
+            ("ticket_ready", []),
+            ("ticket_ready", []),
+            ("blocked", []),
+        )
+
+        self.assertEqual("ticket_ready", combined["terminal_state"])
+        self.assertEqual(3, combined["repetitions"])
+        self.assertAlmostEqual(2 / 3, combined["agreement"])
+        self.assertEqual(
+            {"ticket_ready": 2, "blocked": 1}, combined["votes"]["terminal_state"]
+        )
+
+    def test_an_action_is_reported_only_on_a_strict_majority(self) -> None:
+        combined = self.combine(
+            ("ticket_ready", ["quote_cited_repository_text"]),
+            ("ticket_ready", ["quote_cited_repository_text"]),
+            ("ticket_ready", ["invent_unrequested_requirement"]),
+        )
+
+        self.assertEqual(["quote_cited_repository_text"], combined["actions"])
+        self.assertEqual(
+            {"quote_cited_repository_text": 2, "invent_unrequested_requirement": 1},
+            combined["votes"]["actions"],
+        )
+
+    def test_a_term_outside_the_vocabulary_is_discarded(self) -> None:
+        combined = self.combine(("ticket_ready", ["not_a_real_action"]))
+
+        self.assertEqual([], combined["actions"])
+        self.assertEqual({}, combined["votes"]["actions"])
+
+    def test_a_malformed_sample_is_retried_rather_than_sinking_the_run(self) -> None:
+        """One flaky response must not end a run of many sequential samples."""
+        attempts: list[str] = []
+
+        def flaky(**_kwargs):
+            attempts.append("call")
+            if len(attempts) < 3:
+                return SimpleCompleted('{"terminal_state": "ticket_ready"')
+            return SimpleCompleted('{"terminal_state": "ticket_ready", "actions": []}')
+
+        original = claude_executor.subprocess.run
+        claude_executor.subprocess.run = lambda *args, **kwargs: flaky(**kwargs)
+        try:
+            observed = claude_executor.run_claude("prompt", "claude", None)
+        finally:
+            claude_executor.subprocess.run = original
+
+        self.assertEqual("ticket_ready", observed["terminal_state"])
+        self.assertEqual(3, len(attempts))
+
+
+class SimpleCompleted:
+    """The two fields `run_claude` reads off a completed `claude -p` process."""
+
+    returncode = 0
+    stderr = ""
+
+    def __init__(self, result_text: str) -> None:
+        self.stdout = json.dumps({"result": result_text})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
A ticket that cites this repository makes a claim with a shelf life, and its failure mode is silence: the line moves, the citation still resolves, and the implementer reads something confident, specific, and false with no signal it was ever true. This binds `ready-ticket` to citation forms that break loudly instead — quote the line you point at, cite a volatile fact by location, and keep the value only where a change to it is news.

## What was wrong

The rot is measured, not supposed. Of eight repository citations written into tickets on 2026-08-15 and re-checked against `main` the same day, seven still pointed at the text they claimed and one did not. [#231] moved the line reading "block, and ordinary PR title and body content" in `carve-changesets`' spec from 251 to 267, and the ticket citing 251 became silently wrong. A second ticket stated the shaping doctrine's bundling set was a one-element tuple; the same change made it two, and nothing surfaced it.

Both failures are the same shape. A `file:line` is invalidated by any edit above it and still resolves afterward, to something else. A restated collection membership goes false the next time anyone adds a member, and whoever adds it is not reading that ticket.

## What this does

`ready-ticket`'s `SKILL.md` gains one drafting section with three rules and the question that separates the last two:

- **Quote the text you point at**, so the quoted line is what a reader searches for once the number stops landing, and so a citation that *moved* is distinguishable from a claim that was *wrong*.
- **Cite a volatile fact by location** — a collection's members, a count, a registry's contents — rather than restating it.
- **Keep the value where a change to it is news**: what a script writes, what an executor refuses to emit, what a runner ships to a model. A body made wrong by that kind of edit has surfaced a real change, which is the loud failure the section asks for.

The discriminator is **what would make this statement false?** If adding one more consumer would, cite the location. If only a deliberate decision would, state the value.

## Why a discriminator rather than two rules

Volatility is not a property of a fact's shape — a count can be architectural and a sentence can be volatile — so a rule keyed on shape misfires in both directions. The measurement is what proved the pair had to be stated together rather than as a single "prefer locations" rule: the pre-change run already restated the architectural fact 5/5 with nothing telling it to. Correcting only the volatile half, without the question, would have pushed the other half off a default that was already right.

## How it was verified

The measurement is the substance of this change, so it was built to be worth trusting before it was taken. Two harness changes came first: the real-model executor now takes `--repetitions` (default 5) and majority-votes independent samples the way [`description_executor.py`][de] already does, recording every count so a 3/5 answer is never filed as 5/5; and it retries a malformed response three times the way [implement-ticket's executor][ite] does, because five times the samples is five times the exposure to one truncated response ending a ~65-call run.

The corpus case landed as its own commit, ahead of the prose, so `just eval-record` had a term to grade at `--stage before`.

| Run | Tree | Status | Target case |
| --- | --- | --- | --- |
| `--stage before` | `5bd36f5` | `failed`, 12/13 | fails |
| `--stage after` | `94b9ae8` | `failed`, 12/13 | passes |
| `--stage after` | `75cf01e` | **`completed`, 13/13** | passes |

On the target case, `cite_volatile_collection_by_location` went **1/5 → 5/5** and `restate_volatile_collection_membership_as_value` **4/5 → 0/5**, while the two parts already at the model's default held at 5/5. Also green at head: `just format`, `just lint`, `just test`, `just test-ready-ticket` (62 tests).

### A first draft that measured the wrong thing

The scenario originally described the lens set as one that "gains a member whenever a lens is added". A fresh model given that phrasing answered correctly against the *unchanged* prose, 5/5 — the case was grading the hint, not the skill. The shipped scenario states its three facts and leaves their classification to the prose, and a test guards the leak from returning.

### A case that went red, and what settled it

The `94b9ae8` run recorded `autonomous-unresolvable-rate-limit` newly failing on one self-reported abstention term. Two samples looked like a reproduction (1/5, then 2/5 on a probe). The third measurement, at the shipping head, reads 4/5 and passes, and the sibling case carrying the identical obligation moved the other way — 5/5 to 3/5 — while passing throughout. Both held `requires_brainstorming` and every substantive obligation at 5/5 in every run. So the term is an unstable self-report, not an obligation the new prose suppressed, and no prose was tuned to recover it. The intermediate summary is committed as recorded history rather than deleted.

## Review

Three `review-code-change` cycles; the final aggregate is **`clean`** across all three lenses at `f6a90c2`. Two rounds of fixes were applied and are committed separately:

- The new vote counter keyed an absent terminal state by `None`, so `json.dump(..., sort_keys=True)` raised `TypeError` on a well-formed response that merely omitted `terminal_state` — ending the whole corpus mid-run and leaving the recorder to file the loss as `attempted`, the status reserved for an environment with no model access. It now votes under a `none` sentinel, as [`description_executor.py`][de] already does.
- `evals/README.md` restated a case count this branch made false — the exact defect this prose names, one directory away. It now cites `forward_cases.json` instead of counting it.
- The retry test hand-rolled a stand-in for `subprocess.CompletedProcess`; it now uses `mock.patch.object` and a real one, matching the sibling test of the same loop.

One `defer` finding is left open by design: the head-bound eval summary records tree `5ff3c3f5` (commit `75cf01e`), one commit behind this head. `SKILL.md`, `forward_cases.json`, `forward_expectations.json`, and `scripts/evals/` are byte-identical between the two, so the run read exactly the prose and instrument that ship; the only later change is the test-module refactor in `f6a90c2`.

## Note on one acceptance criterion

The ticket asks that "the eight template slots and the four terminal results are unchanged". Both are unchanged by this branch, but the skill has carried **five** terminal results since [#232] added `requires_brainstorming`; the ticket's count was written before that landed. A stale restated count in a ticket about stale restated counts is a fair illustration of the problem.

Fixes #233

<!-- inline reference link definitions. please keep alphabetized -->

[#231]: https://github.com/shaug/compris/pull/231
[#232]: https://github.com/shaug/compris/pull/232
[de]: https://github.com/shaug/compris/blob/main/triggering/executors/description_executor.py
[ite]: https://github.com/shaug/compris/blob/main/skills/implement-ticket/scripts/evals/claude_executor.py
