### PR TITLE
fix: make the eval candidate's recorded identity resolvable, and keep it that way

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,16 +78,24 @@ tier may report more than an outcome — the triggering corpus's description tie
 reports how many of its repetitions agreed. Variance is the metric there, and a
 case degrading from unanimous to a bare majority still records `pass`.
 
-Record from a committed, clean tree, so the summary's `candidate.sha` names a
-commit a later reader can resolve, and commit the summaries on top. A run
-recorded from a dirty tree — or from a commit later amended away — names a tree
-nobody else can retrieve, which is the one thing the record exists to supply.
+Record from a committed, clean tree, so the summary's `candidate.trees` can be
+derived from `HEAD` at all and names content a later reader can retrieve, and
+commit the summaries on top. A run recorded from a dirty tree read files no
+commit holds, so the subtrees it records name something other than what the eval
+actually saw — and naming that content is the one thing the record exists to do.
 
 Each summary also carries `candidate.trees` — a map from repository path to that
-path's subtree hash, holding `skills/<skill>` for every run and `triggering` as
-well for a triggering-suite run, whose executors live outside every skill —
-`candidate.tree`, the whole repository's `git rev-parse HEAD^{tree}`, and, for a
-real-model run, `model`, the exact `--model` the recorded command passed.
+path's subtree hash. It names `skills/<skill>` for every run, the prose under
+measurement, plus every repository unit the run's own resolved command names, so
+a run whose instrument lives elsewhere says so: a triggering run picks up
+`triggering/`, where its executors live outside every skill, and an
+`implement-epic` run picks up `skills/implement-ticket`, whose runner, executor,
+and corpus it is measured through. A path whose subtree could not be read is
+listed under `candidate.trees_unresolved` rather than dropped, because a run
+that derived nothing would otherwise be indistinguishable from a summary
+predating the field. Alongside them a summary carries `candidate.tree`, the
+whole repository's `git rev-parse HEAD^{tree}`, and, for a real-model run,
+`model`, the exact `--model` the recorded command passed.
 
 `sha` and `tree` are both branch-local. A rebase onto a moved `main` rewrites
 the commit and changes the repository tree through files outside the skill
@@ -124,16 +132,24 @@ commit rather than collapsing them, so each intermediate subtree still lands on
 `main` and stays reachable — a rebase moves a commit without disturbing a
 subtree the commit never touched, which is the same property `candidate.trees`
 rests on in the first place. It rewrites `sha`, but `sha` is already recorded as
-branch-local. Rebase merging is therefore left available; only a squash
-collapses the measured states away.
+branch-local. The exception is a rebase that resolves conflicts inside a skill
+directory: there the replayed commit carries content the recorded run never
+read, so the recorded subtree lands nowhere and
+`scripts/tests/test_eval_candidate_citations.py` turning red is correct rather
+than a false alarm — that guard names this case alongside the squash, and the
+answer to it is to re-record. Rebase merging is therefore left available; only a
+squash collapses the measured states away with nothing to re-record against.
 
 `model` exists because a before/after pair taken across a model update compares
 two different subjects wearing the same tier name; a diff is drawn only when the
 compared runs' tier, suite, and model all match. A deterministic run records no
 model — there is none to name. Summaries recorded before these fields existed
-carry `trees` only where it could be derived from a commit they still name, and
-carry no `model` at all: no model can be recovered for them after the fact, and
-they are not backfilled. The derivation that is backfilled,
+carry `trees` only where it could be derived from a commit still reachable from
+`HEAD`, and carry no `model` at all: no model can be recovered for them after
+the fact, and they are not backfilled. Reachability rather than resolvability is
+the criterion, because a commit surviving in one clone as a dangling object
+resolves there and nowhere else — deriving from those would write citations the
+guard reports as rot, which is what they are. The derivation that is backfilled,
 `git rev-parse <recorded sha>:<path>`, is a computation over what the file
 already carries and could not have come out differently had the field existed
 when it was written. A landing commit is not backfilled for the opposite reason:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,17 +95,37 @@ entirely, so neither survives one, and a squash-merge then discards both
 outright. It is `trees` a reader should expect to still resolve, because
 unrelated files moving cannot disturb a subtree the change never touched.
 
-A subtree resolves only while a commit carrying it stays reachable, so a pull
-request that adds or changes any file under `skills/*/evals/results/` merges as
-a merge commit rather than a squash. A squash keeps one tree per pull request,
-and the states eval evidence measures are intermediate by construction: a
-before-stage run measures a new corpus against the old prose, and a superseded
-after-stage run measures prose a later commit changed. Squashing such a pull
-request destroys the measured content in every clone but the author's, and no
-later repair recovers it — the only remedy is to re-record against a state that
-still exists and to say in the summary that the original is unrecoverable.
-`scripts/tests/test_eval_candidate_citations.py` is what turns red when this
-goes wrong, and `carve-changesets` already defaults its merge method to `merge`.
+A subtree resolves only while a commit carrying it stays reachable, which is why
+this repository merges as a merge commit rather than a squash. A squash keeps
+one tree per pull request, and the states eval evidence measures are
+intermediate by construction: a before-stage run measures a new corpus against
+the old prose, and a superseded after-stage run measures prose a later commit
+changed. Squashing such a pull request destroys the measured content in every
+clone but the author's, and no later repair recovers it — the only remedy is to
+re-record against a state that still exists and to say in the summary that the
+original is unrecoverable. `scripts/tests/test_eval_candidate_citations.py` is
+what turns red when this goes wrong, and `carve-changesets` already defaults its
+merge method to `merge`.
+
+The rule is unconditional rather than scoped to the pull requests that carry
+eval evidence, because a conditional one cannot be enforced. GitHub's merge
+method is a repository setting, not a per-pull-request one, so "squash normally,
+merge-commit when the diff touches `skills/*/evals/results/`" is not a
+configuration anyone can express — it would rest entirely on whoever clicks
+merge classifying the pull request correctly, every time, with no mechanism
+catching a mistake. The two failures are not comparable: squashing an
+eval-carrying pull request loses content permanently, while merge-committing one
+that carries none costs a non-linear history that `git log --first-parent` reads
+straight through. Disabling squash merging on the repository is what makes the
+rule hold; the prose only records why.
+
+Squash is the only method that has to be off. Rebase merging replays every
+commit rather than collapsing them, so each intermediate subtree still lands on
+`main` and stays reachable — a rebase moves a commit without disturbing a
+subtree the commit never touched, which is the same property `candidate.trees`
+rests on in the first place. It rewrites `sha`, but `sha` is already recorded as
+branch-local. Rebase merging is therefore left available; only a squash
+collapses the measured states away.
 
 `model` exists because a before/after pair taken across a model update compares
 two different subjects wearing the same tier name; a diff is drawn only when the
@@ -205,12 +225,14 @@ said. Neither satisfies the other.
   within a day.
 
 - Changelog: a backfilled SHA names the commit that carried the entry onto
-  `main` — the squash-merge commit for a squash-merged pull request, and the
-  authoring commit only where it survives, as under a merge-commit pull request
-  or a direct push to `main`. `main` is almost entirely squash-merged, and a
-  squash discards every authoring commit the pull request held, so backfilling
-  an authoring SHA leaves a citation that resolves to nothing while still
-  reading like one that resolves.
+  `main` — the authoring commit where it survives, as under a merge-commit pull
+  request or a direct push to `main`, and the squash-merge commit for a
+  squash-merged one. Merge-commit is now this repository's method, so the
+  authoring commit normally is the landing commit. The distinction still matters
+  for the squash-merged history behind that change: a squash discards every
+  authoring commit its pull request held, so backfilling an authoring SHA there
+  leaves a citation that resolves to nothing while still reading like one that
+  resolves.
 
 - Changelog: backfill an entry only once it has landed on `main`. An entry added
   on the current branch cannot know which commit will carry it there, so it
@@ -218,9 +240,11 @@ said. Neither satisfies the other.
   below it that has landed and still lacks a SHA — which is more than one
   whenever the previous pull request contributed several.
 
-- Changelog: several entries citing one SHA is expected, not a mistake. A
-  squash-merge commit carries every entry its pull request contributed, so each
-  of those entries names it.
+- Changelog: several entries citing one SHA is expected, not a mistake, in the
+  squash-merged history behind the merge-commit change — a squash-merge commit
+  carries every entry its pull request contributed, so each of those entries
+  names it. Under a merge commit each entry has its own authoring commit, so new
+  entries normally cite distinct SHAs.
 
 - Changelog: recover an entry's landing commit with
   `git log main --format='%H %s' -S'<the entry's first line>' -- CHANGELOG.md`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,18 +83,43 @@ commit a later reader can resolve, and commit the summaries on top. A run
 recorded from a dirty tree — or from a commit later amended away — names a tree
 nobody else can retrieve, which is the one thing the record exists to supply.
 
-Each summary also carries `candidate.tree`, the committed content's
-`git rev-parse HEAD^{tree}`, and — for a real-model run — `model`, the exact
-`--model` the recorded command passed. `sha` names the commit, which rebase
-rewrites and squash-merge discards outright; `tree` names the content, which is
-identical under both, so it is `tree`, not `sha`, that a reader should expect to
-still resolve once a change has landed on `main`. `model` exists because a
-before/after pair taken across a model update compares two different subjects
-wearing the same tier name; a diff is drawn only when the compared runs' tier,
-suite, and model all match. A deterministic run records no model — there is none
-to name. Summaries recorded before this field existed carry no `model` at all
-and are branch-local and unattributed: no model can be recovered for them after
-the fact, and they are not backfilled.
+Each summary also carries `candidate.trees` — a map from repository path to that
+path's subtree hash, holding `skills/<skill>` for every run and `triggering` as
+well for a triggering-suite run, whose executors live outside every skill —
+`candidate.tree`, the whole repository's `git rev-parse HEAD^{tree}`, and, for a
+real-model run, `model`, the exact `--model` the recorded command passed.
+
+`sha` and `tree` are both branch-local. A rebase onto a moved `main` rewrites
+the commit and changes the repository tree through files outside the skill
+entirely, so neither survives one, and a squash-merge then discards both
+outright. It is `trees` a reader should expect to still resolve, because
+unrelated files moving cannot disturb a subtree the change never touched.
+
+A subtree resolves only while a commit carrying it stays reachable, so a pull
+request that adds or changes any file under `skills/*/evals/results/` merges as
+a merge commit rather than a squash. A squash keeps one tree per pull request,
+and the states eval evidence measures are intermediate by construction: a
+before-stage run measures a new corpus against the old prose, and a superseded
+after-stage run measures prose a later commit changed. Squashing such a pull
+request destroys the measured content in every clone but the author's, and no
+later repair recovers it — the only remedy is to re-record against a state that
+still exists and to say in the summary that the original is unrecoverable.
+`scripts/tests/test_eval_candidate_citations.py` is what turns red when this
+goes wrong, and `carve-changesets` already defaults its merge method to `merge`.
+
+`model` exists because a before/after pair taken across a model update compares
+two different subjects wearing the same tier name; a diff is drawn only when the
+compared runs' tier, suite, and model all match. A deterministic run records no
+model — there is none to name. Summaries recorded before these fields existed
+carry `trees` only where it could be derived from a commit they still name, and
+carry no `model` at all: no model can be recovered for them after the fact, and
+they are not backfilled. The derivation that is backfilled,
+`git rev-parse <recorded sha>:<path>`, is a computation over what the file
+already carries and could not have come out differently had the field existed
+when it was written. A landing commit is not backfilled for the opposite reason:
+which commit carries a summary onto `main` is decided after the run by a merge
+that has not happened yet, so writing it in would add a claim nothing in the
+file supports.
 
 Summaries already written under `evals/results/` are the one exemption, and it
 is narrow by construction. Recording several skills in sequence writes a summary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ summary: Chronological history of repository and skill changes.
 
 ## 2026-08-16 — Diagnosed the same citation rot in the eval summaries and designed the identity that survives it
 
+- fix(evals): derive the durable identity of every summary that still names a
+  reachable commit — 23 of the 82 summaries gain `candidate.trees` computed
+  from the commit each already carries, and the other 59 keep none. The
+  derivation asserts nothing the recorder did not hold:
+  `git rev-parse <recorded sha>:<path>` could not have come out differently had
+  the field existed when the summary was written, which is what separates it
+  from backfilling a landing commit — a fact decided after the run by a merge
+  that had not happened yet. One of the 23 is a triggering-suite run and needs
+  both its skill path and `triggering`. The 59 measured content that no longer
+  exists in any clone but its author's; unlike the changelog's citations, there
+  is nothing left to recover.
 - feat(evals): record the subtree identity that survives a rebase —
   `candidate.tree` was `git rev-parse HEAD^{tree}`, the whole repository's, so a
   rebase onto a moved `main` changed it through files outside the skill and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ summary: Chronological history of repository and skill changes.
 
 ## 2026-08-16 — Diagnosed the same citation rot in the eval summaries and designed the identity that survives it
 
+- docs: state the merge method the eval evidence depends on, and correct what
+  `AGENTS.md` claims survives — the file told a reader to trust `candidate.tree`
+  over `candidate.sha` on the grounds that content is identical under rebase and
+  squash where a commit is not. It is not: `tree` is the whole repository's, so
+  a rebase onto a moved `main` changes it through files outside the skill. Both
+  are now stated as branch-local, `candidate.trees` is named as the durable
+  half, and the rule that makes it durable is written down — a pull request
+  touching `skills/*/evals/results/` merges as a merge commit, because a squash
+  keeps one tree per pull request while the states eval evidence measures are
+  intermediate by construction. `babysit-pr`'s example output block is brought
+  into line with the obligation its own prose already carried.
 - test(evals): hold every recorded subtree to reachability from `HEAD` —
   `scripts/tests/test_eval_candidate_citations.py` fails when a summary's
   `candidate.trees` names content no commit reachable from `HEAD` carries, which

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ summary: Chronological history of repository and skill changes.
 
 ## 2026-08-16 — Diagnosed the same citation rot in the eval summaries and designed the identity that survives it
 
+- fix(evals): name every path a run was measured through, and stop claiming
+  `sha` resolves — `subtree_paths` named `skills/<skill>` and, for a triggering
+  run, `triggering`, which under-describes any skill whose eval instrument lives
+  elsewhere. `implement-epic` is measured entirely through
+  `skills/implement-ticket`'s runner, executor, and corpus, so its corpus could
+  change, an `implement-epic` run be re-recorded, and the new summary's
+  `candidate.trees` come out byte-identical to the old — two runs on different
+  instruments with one recorded identity, which two committed summaries taken on
+  different dates already share. The paths are now derived from the run's own
+  resolved command, so a target self-describes and no hand-maintained mapping
+  can drift; the three affected backfilled summaries gain
+  `skills/implement-ticket`, derived from the commit each already names. A path
+  whose subtree cannot be read is recorded under `candidate.trees_unresolved`
+  rather than dropped, since a run that derived nothing otherwise reads exactly
+  like a summary predating the field and the reachability guard passes both. The
+  prose is corrected where it still asserted what this branch had just
+  disproved: the clean-tree rule kept its requirement but was resting on
+  `candidate.sha` resolving, the grandfathered 59 were said to name commits that
+  no longer resolve when the criterion applied was reachability from `HEAD`, and
+  the rebase-safety claim omitted the exception its own guard names — a rebase
+  resolving conflicts inside the skill directory. The rebase test now performs a
+  real rebase rather than committing an unrelated change on top, which proved
+  only that an untouched subtree survives an unrelated commit.
+
 - docs: make merge-commit the repository's merge method, not a rule about one
   directory — the eval-evidence rule this replaces was conditional, applying to
   pull requests that touch `skills/*/evals/results/`, and a conditional merge

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ summary: Chronological history of repository and skill changes.
 
 ## 2026-08-16 — Diagnosed the same citation rot in the eval summaries and designed the identity that survives it
 
+- docs: make merge-commit the repository's merge method, not a rule about one
+  directory — the eval-evidence rule this replaces was conditional, applying to
+  pull requests that touch `skills/*/evals/results/`, and a conditional merge
+  method is one nothing can enforce. GitHub's merge method is a repository
+  setting rather than a per-pull-request one, so the conditional form rested
+  entirely on whoever clicked merge classifying the pull request correctly every
+  time, with no mechanism to catch a miss and no repair once missed. Since evals
+  first landed, 20 of 46 commits on `main` touched `evals/results/`, so the
+  classification would have been live on nearly half of them. The two failures
+  are not comparable either: squashing an eval-carrying pull request loses the
+  measured content permanently, while merge-committing one that carries none
+  costs a non-linear history `git log --first-parent` reads straight through.
+  The changelog's own backfill convention is updated to match — under a merge
+  commit the authoring commit is the landing commit, so new entries normally
+  cite distinct SHAs rather than sharing one, though the squash-merged history
+  behind this change still behaves the old way.
+
 - docs: state the merge method the eval evidence depends on, and correct what
   `AGENTS.md` claims survives — the file told a reader to trust `candidate.tree`
   over `candidate.sha` on the grounds that content is identical under rebase and
@@ -17,6 +34,7 @@ summary: Chronological history of repository and skill changes.
   keeps one tree per pull request while the states eval evidence measures are
   intermediate by construction. `babysit-pr`'s example output block is brought
   into line with the obligation its own prose already carried.
+
 - test(evals): hold every recorded subtree to reachability from `HEAD` —
   `scripts/tests/test_eval_candidate_citations.py` fails when a summary's
   `candidate.trees` names content no commit reachable from `HEAD` carries, which
@@ -27,6 +45,7 @@ summary: Chronological history of repository and skill changes.
   history across a rebase. A summary carrying no `trees` passes — those predate
   the field and are recorded as unresolvable rather than pretended into
   evidence.
+
 - fix(evals): derive the durable identity of every summary that still names a
   reachable commit — 23 of the 82 summaries gain `candidate.trees` computed from
   the commit each already carries, and the other 59 keep none. The derivation
@@ -38,6 +57,7 @@ summary: Chronological history of repository and skill changes.
   both its skill path and `triggering`. The 59 measured content that no longer
   exists in any clone but its author's; unlike the changelog's citations, there
   is nothing left to recover.
+
 - feat(evals): record the subtree identity that survives a rebase —
   `candidate.tree` was `git rev-parse HEAD^{tree}`, the whole repository's, so a
   rebase onto a moved `main` changed it through files outside the skill and the
@@ -48,6 +68,7 @@ summary: Chronological history of repository and skill changes.
   claim passed only by simulating a rebase as a new parent over an identical
   tree, which is the one thing a real rebase never is; it now models a base that
   moved, and fails against the old behavior.
+
 - docs: design the eval candidate's durable identity — `AGENTS.md` tells a
   reader to trust `candidate.tree` over `candidate.sha`, on the grounds that
   content is identical under rebase and squash where a commit is not. It is not:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,20 @@ summary: Chronological history of repository and skill changes.
 
 ## 2026-08-16 — Diagnosed the same citation rot in the eval summaries and designed the identity that survives it
 
+- test(evals): hold every recorded subtree to reachability from `HEAD` —
+  `scripts/tests/test_eval_candidate_citations.py` fails when a summary's
+  `candidate.trees` names content no commit reachable from `HEAD` carries, which
+  is the same silent rot `scripts/tests/test_changelog_citations.py` catches for
+  the changelog: a hash resolving to nothing reads exactly like one that
+  resolves. Unlike its sibling it needs no unlanded-branch exemption, because a
+  subtree recorded on an open branch stays reachable from that branch's own
+  history across a rebase. A summary carrying no `trees` passes — those predate
+  the field and are recorded as unresolvable rather than pretended into
+  evidence.
 - fix(evals): derive the durable identity of every summary that still names a
-  reachable commit — 23 of the 82 summaries gain `candidate.trees` computed
-  from the commit each already carries, and the other 59 keep none. The
-  derivation asserts nothing the recorder did not hold:
+  reachable commit — 23 of the 82 summaries gain `candidate.trees` computed from
+  the commit each already carries, and the other 59 keep none. The derivation
+  asserts nothing the recorder did not hold:
   `git rev-parse <recorded sha>:<path>` could not have come out differently had
   the field existed when the summary was written, which is what separates it
   from backfilling a landing commit — a fact decided after the run by a merge

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ summary: Chronological history of repository and skill changes.
 
 ## 2026-08-16 — Diagnosed the same citation rot in the eval summaries and designed the identity that survives it
 
+- feat(evals): record the subtree identity that survives a rebase —
+  `candidate.tree` was `git rev-parse HEAD^{tree}`, the whole repository's, so a
+  rebase onto a moved `main` changed it through files outside the skill and the
+  recorded identity resolved to nothing. `candidate.trees` now maps each path
+  whose content decided what the run read — `skills/<skill>` always, and
+  `triggering` as well for a triggering-suite run, whose executors live outside
+  every skill — to that path's subtree hash. The test that had asserted the old
+  claim passed only by simulating a rebase as a new parent over an identical
+  tree, which is the one thing a real rebase never is; it now models a base that
+  moved, and fails against the old behavior.
 - docs: design the eval candidate's durable identity — `AGENTS.md` tells a
   reader to trust `candidate.tree` over `candidate.sha`, on the grounds that
   content is identical under rebase and squash where a commit is not. It is not:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,37 +4,65 @@ summary: Chronological history of repository and skill changes.
 
 # Changelog
 
+## 2026-08-16 — Diagnosed the same citation rot in the eval summaries and designed the identity that survives it
+
+- docs: design the eval candidate's durable identity — `AGENTS.md` tells a
+  reader to trust `candidate.tree` over `candidate.sha`, on the grounds that
+  content is identical under rebase and squash where a commit is not. It is not:
+  `candidate.tree` is `git rev-parse HEAD^{tree}`, the whole-repository tree, so
+  a rebase onto a moved `main` changes it through files outside the skill
+  entirely. 59 of the repository's 82 summaries already name an unreachable
+  `sha`, proportionally worse than the 68 of 248 changelog citations
+  (77011ed74d28ec522ea7c05d4e310ed53b1dd0d6) repaired, and the loss falls where
+  the evidence matters most — 45 of 47 `after`-stage runs are gone, against 20
+  of 21 `before`-stage runs surviving only because they name an untouched branch
+  point already on `main`. Recording the skill's subtree fixes the rebase case,
+  verified against `scott/ticket-234-09af55` where five of five subtrees survive
+  a rebase that took all five commits, but fixes nothing under squash: a
+  `before` run measures new corpus against old prose, a superseded `after` run
+  measures prose a later commit changed, and neither state is on any commit a
+  squash keeps. The design therefore merge-commits pull requests carrying eval
+  evidence, records `candidate.trees` per path so a triggering-suite run also
+  names `triggering/`, and adds a reachability guard modeled on
+  `scripts/tests/test_changelog_citations.py`. The 23 summaries still naming a
+  reachable commit gain `candidate.trees` derived from it — a lossless
+  computation over what each file already carries, unlike a backfilled landing
+  commit, which would assert a fact the recorder never held. The other 59 are
+  grandfathered: unlike the changelog's citations, the content they measured no
+  longer exists to be recovered.
+
 ## 2026-08-15 — Moved the design boundary to a checkable place, retired carve-changesets' duplicate shaping rules, set up the citation-rot measurement, and repaired the changelog's own rotted citations under a convention that survives squash-merge
 
-- fix: cite the commit that reached `main`, and hold the changelog to it — 68 of
-  this file's 248 commit citations resolved to nothing. The changelog convention
-  told an author to backfill the SHA of the commit that wrote the entry, but
-  `main` is almost entirely squash-merged, and a squash discards every authoring
-  commit its pull request held. A pull request contributing several entries
-  therefore rotted all of them at once, which is how #147, #176, #185, and #222
-  account for 24 of the 26 dangling citations in the newer `(<sha>)` form. The
-  older `` (`<sha>`) `` form — 169 citations the bare-parenthesis search does
-  not see at all — carried 42 more. Two were not squash rot but fabrication: a
-  7-character prefix expanded to a plausible 40-character string that had never
-  named anything, sharing its prefix with the real commit it was meant to cite.
-  Every one is repointed at the commit that carried its entry onto `main`,
-  recovered by asking which commit introduced that entry's own line, and
-  cross-checked wherever a second source existed: GitHub's merge commit for the
-  cited SHA covers 52, and a real commit sharing the cited prefix covers the 2
-  fabricated ones. Neither source can speak for the remaining 14, whose
-  authoring commits GitHub never saw. No cross-check contradicted the recovered
-  commit. `AGENTS.md` now states the rule the repair follows — cite the landing
-  commit, backfill only once an entry has landed, and expect one SHA across
-  every entry its pull request contributed — and the seven entries that had
-  landed with no SHA at all gain one.
-  `scripts/tests/test_changelog_citations.py` keeps it true, and CI checks out
-  full history because a depth-1 clone cannot answer the question. The guard was
-  verified capable of failing: it named all 68 before the repair, and mutating
-  one character of a single surviving citation turns it red naming that line.
-  One SHA is deliberately left unchecked — the writing-plans experiment's `pin`
-  names a commit in the `superpowers` peer repository, which cannot resolve
-  here, and is written backticked outside parentheses rather than as a citation,
-  which is the distinction the check is scoped to.
+- fix: cite the commit that reached `main`, and hold the changelog to it
+  (77011ed74d28ec522ea7c05d4e310ed53b1dd0d6) — 68 of this file's 248 commit
+  citations resolved to nothing. The changelog convention told an author to
+  backfill the SHA of the commit that wrote the entry, but `main` is almost
+  entirely squash-merged, and a squash discards every authoring commit its pull
+  request held. A pull request contributing several entries therefore rotted all
+  of them at once, which is how #147, #176, #185, and #222 account for 24 of the
+  26 dangling citations in the newer `(<sha>)` form. The older `` (`<sha>`) ``
+  form — 169 citations the bare-parenthesis search does not see at all — carried
+  42 more. Two were not squash rot but fabrication: a 7-character prefix
+  expanded to a plausible 40-character string that had never named anything,
+  sharing its prefix with the real commit it was meant to cite. Every one is
+  repointed at the commit that carried its entry onto `main`, recovered by
+  asking which commit introduced that entry's own line, and cross-checked
+  wherever a second source existed: GitHub's merge commit for the cited SHA
+  covers 52, and a real commit sharing the cited prefix covers the 2 fabricated
+  ones. Neither source can speak for the remaining 14, whose authoring commits
+  GitHub never saw. No cross-check contradicted the recovered commit.
+  `AGENTS.md` now states the rule the repair follows — cite the landing commit,
+  backfill only once an entry has landed, and expect one SHA across every entry
+  its pull request contributed — and the seven entries that had landed with no
+  SHA at all gain one. `scripts/tests/test_changelog_citations.py` keeps it
+  true, and CI checks out full history because a depth-1 clone cannot answer the
+  question. The guard was verified capable of failing: it named all 68 before
+  the repair, and mutating one character of a single surviving citation turns it
+  red naming that line. One SHA is deliberately left unchecked — the
+  writing-plans experiment's `pin` names a commit in the `superpowers` peer
+  repository, which cannot resolve here, and is written backticked outside
+  parentheses rather than as a citation, which is the distinction the check is
+  scoped to.
 
 - test(ready-ticket): test the retry loop the way its sibling already does —
   review found the new retry test hand-rolling a partial stand-in for

--- a/docs/superpowers/plans/2026-08-16-eval-candidate-identity.md
+++ b/docs/superpowers/plans/2026-08-16-eval-candidate-identity.md
@@ -1,0 +1,1109 @@
+# Eval Candidate Identity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make an eval summary's `candidate` block name repository state a later
+reader can still retrieve, by recording per-path subtree hashes, guarding their
+reachability, backfilling the summaries that can still be derived, and merging
+eval-carrying pull requests in a way that keeps the measured content on `main`.
+
+**Architecture:** `candidate_identity()` gains `trees`, a map from repository
+path to that path's subtree hash — `skills/<skill>` always, plus `triggering`
+for a triggering-suite run. A new guard under `scripts/tests/` holds every
+recorded entry to reachability from `HEAD`, modeled on the changelog citation
+guard #236 added. A one-shot derivation backfills the 23 summaries still naming
+a reachable commit. `AGENTS.md` states the corrected durability claim and the
+merge-method rule that makes it true.
+
+**Tech Stack:** Python 3 standard library only (`json`, `subprocess`,
+`unittest`, `pathlib`). No new dependencies. `just format`, `just lint`,
+`just test` are the gates.
+
+## Global Constraints
+
+- Required before every commit: `just format`, `just lint`, `just test`.
+- Commit messages use Conventional Commits, written to a temp file and passed
+  with `git commit -F`, never inline `-m`. Bodies are Markdown with `## Summary`
+  and `## Why`.
+- Markdown links are inline reference links with definitions collected at the
+  end of the file under
+  `<!-- inline reference link definitions. please keep alphabetized -->`.
+- Test modules under `scripts/tests/` that import a sibling helper establish
+  their own `sys.path` entry from `__file__`. The new guard imports no sibling,
+  so it needs no shim.
+- Summaries are written with
+  `json.dumps(summary, indent=2, sort_keys=True) + "\n"`. All 82 existing files
+  round-trip byte-identically under that call; the backfill must preserve this
+  so its diff is pure addition.
+- Do not use destructive git commands. Do not rewrite reference branches.
+- The design this implements is
+  [`docs/superpowers/specs/2026-08-16-eval-candidate-identity-design.md`][spec].
+
+______________________________________________________________________
+
+## File Structure
+
+| File                                             | Responsibility                                                                                                    |
+| ------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------- |
+| `scripts/record_eval_run.py`                     | Add `subtree_paths()`; extend `candidate_identity()` to take `skill`/`suite` and record `trees`                   |
+| `scripts/tests/test_record_eval_run.py`          | Replace the test asserting the disproved claim; add `trees` coverage; assert `AGENTS.md` states the merge policy  |
+| `scripts/tests/test_eval_candidate_citations.py` | New. Hold every recorded subtree to reachability from `HEAD`                                                      |
+| `skills/*/evals/results/*.json`                  | Data. 23 files gain `candidate.trees`                                                                             |
+| `AGENTS.md`                                      | Correct the durability claim; state the merge policy, the backfill, and the grandfathering                        |
+| `skills/babysit-pr/SKILL.md`                     | Editorial: line 398's example says "squash method" where line 357 already says "repository-approved merge method" |
+| `CHANGELOG.md`                                   | One entry per commit, newest first, under today's heading                                                         |
+
+______________________________________________________________________
+
+### Task 1: Record the subtree identity that survives a rebase
+
+**Files:**
+
+- Modify: `scripts/record_eval_run.py:389-425` (after `RESULTS_PATH_MARKER`,
+  through `candidate_identity`)
+- Modify: `scripts/record_eval_run.py:513` (the `build_summary` call site)
+- Test: `scripts/tests/test_record_eval_run.py:459-511` (replace
+  `test_candidate_tree_survives_rebase_and_squash`)
+- Test: `scripts/tests/test_record_eval_run.py:597-620` (two call sites that
+  pass no arguments)
+
+**Interfaces:**
+
+- Consumes: `record_eval_run.FORWARD_SUITE` (`"forward"`),
+  `record_eval_run.TRIGGERING_SUITE` (`"triggering"`),
+  `record_eval_run.REPOSITORY_ROOT`, both already defined.
+
+- Produces:
+
+  - `subtree_paths(skill: str, suite: str) -> list[str]` — the repository paths
+    whose content decides what a run of that suite read.
+  - `candidate_identity(skill: str, suite: str) -> dict` — signature change,
+    from no arguments. Returns the existing keys plus `trees: dict[str, str]`,
+    mapping each path from `subtree_paths` to its subtree hash.
+  - Task 2's backfill reproduces `subtree_paths`' path selection against
+    recorded summaries. Task 3's guard reads `candidate["trees"]`.
+
+- [ ] **Step 1: Replace the test that encodes the disproved claim**
+
+The existing `test_candidate_tree_survives_rebase_and_squash` passes only
+because it simulates a rebase as "same tree, new parent", which is the one thing
+a real rebase never is. Delete it — the whole method and its four-line `# AC:`
+comment above it — and put this in its place, keeping the surrounding class:
+
+```python
+    # AC: the recorded identity still resolves to the evaluated content after
+    # a real rebase onto a moved `main` — one that changes files outside the
+    # skill, as every rebase in this repository does. `sha` cannot survive
+    # that, and neither can the whole-repository `tree`; the skill's subtree
+    # must, because unrelated files moving cannot disturb it.
+    def test_candidate_identity_survives_a_rebase_onto_a_moved_base(self) -> None:
+        repo = self.root / "git-repo"
+        skill = repo / "skills" / "demo"
+        skill.mkdir(parents=True)
+
+        def git(*args: str) -> str:
+            completed = subprocess.run(
+                ["git", *args],
+                cwd=repo,
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+            return completed.stdout.strip()
+
+        git("init", "-q")
+        git("config", "user.email", "a@example.com")
+        git("config", "user.name", "a")
+        (repo / "AGENTS.md").write_text("base\n", encoding="utf-8")
+        (skill / "SKILL.md").write_text("prose v1\n", encoding="utf-8")
+        git("add", "-A")
+        git("commit", "-q", "-m", "first")
+
+        with mock.patch.object(record_eval_run, "REPOSITORY_ROOT", repo):
+            before = record_eval_run.candidate_identity(
+                "demo", record_eval_run.FORWARD_SUITE
+            )
+
+        # The rebase: `main` moved by changing a file outside the skill, and
+        # the branch's work is replayed on top. The skill's content is
+        # untouched; the repository's tree is not.
+        (repo / "AGENTS.md").write_text("moved\n", encoding="utf-8")
+        git("add", "-A")
+        git("commit", "-q", "-m", "unrelated change on main")
+
+        with mock.patch.object(record_eval_run, "REPOSITORY_ROOT", repo):
+            after = record_eval_run.candidate_identity(
+                "demo", record_eval_run.FORWARD_SUITE
+            )
+
+        self.assertNotEqual(after["sha"], before["sha"])
+        self.assertNotEqual(after["tree"], before["tree"])
+        self.assertEqual(after["trees"], before["trees"])
+        self.assertEqual(sorted(before["trees"]), ["skills/demo"])
+
+    # AC: a squash-merge that keeps the measured content keeps the recorded
+    # identity with it. This is the half of the deleted test that was worth
+    # keeping — it is what makes a run recorded at the shipping head
+    # resolvable on `main` afterward, and it is the only durability the
+    # merge-method rule in `AGENTS.md` cannot supply on its own.
+    def test_candidate_identity_survives_a_squash_that_keeps_the_content(
+        self,
+    ) -> None:
+        repo = self.root / "squash-repo"
+        skill = repo / "skills" / "demo"
+        skill.mkdir(parents=True)
+
+        def git(*args: str) -> str:
+            completed = subprocess.run(
+                ["git", *args],
+                cwd=repo,
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+            return completed.stdout.strip()
+
+        git("init", "-q")
+        git("config", "user.email", "a@example.com")
+        git("config", "user.name", "a")
+        (repo / "AGENTS.md").write_text("base\n", encoding="utf-8")
+        (skill / "SKILL.md").write_text("prose v1\n", encoding="utf-8")
+        git("add", "-A")
+        git("commit", "-q", "-m", "first")
+
+        with mock.patch.object(record_eval_run, "REPOSITORY_ROOT", repo):
+            before = record_eval_run.candidate_identity(
+                "demo", record_eval_run.FORWARD_SUITE
+            )
+
+        # The squash: one brand new commit carrying the other files the pull
+        # request touched, with no ancestry to the recorded commit at all.
+        (repo / "AGENTS.md").write_text("squashed\n", encoding="utf-8")
+        git("add", "-A")
+        git("commit", "-q", "-m", "other files in the same pull request")
+        squashed = git("commit-tree", git("rev-parse", "HEAD^{tree}"), "-m", "squash")
+        git("reset", "--hard", squashed)
+
+        with mock.patch.object(record_eval_run, "REPOSITORY_ROOT", repo):
+            after = record_eval_run.candidate_identity(
+                "demo", record_eval_run.FORWARD_SUITE
+            )
+
+        self.assertNotEqual(after["sha"], before["sha"])
+        self.assertNotEqual(after["tree"], before["tree"])
+        self.assertEqual(after["trees"], before["trees"])
+
+    # AC: a triggering run's executors live in `triggering/`, outside every
+    # skill, so a summary naming only the skill would under-describe the
+    # instrument that produced it.
+    def test_triggering_run_also_names_the_triggering_executors(self) -> None:
+        repo = self.root / "triggering-repo"
+        (repo / "skills" / "demo").mkdir(parents=True)
+        (repo / "triggering").mkdir(parents=True)
+
+        def git(*args: str) -> str:
+            completed = subprocess.run(
+                ["git", *args],
+                cwd=repo,
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+            return completed.stdout.strip()
+
+        git("init", "-q")
+        git("config", "user.email", "a@example.com")
+        git("config", "user.name", "a")
+        (repo / "skills" / "demo" / "SKILL.md").write_text("p\n", encoding="utf-8")
+        (repo / "triggering" / "runner.py").write_text("r\n", encoding="utf-8")
+        git("add", "-A")
+        git("commit", "-q", "-m", "first")
+
+        with mock.patch.object(record_eval_run, "REPOSITORY_ROOT", repo):
+            identity = record_eval_run.candidate_identity(
+                "demo", record_eval_run.TRIGGERING_SUITE
+            )
+
+        self.assertEqual(
+            sorted(identity["trees"]), ["skills/demo", "triggering"]
+        )
+```
+
+- [ ] **Step 2: Update the two call sites that pass no arguments**
+
+`candidate_identity` is called with no arguments in two other tests. Both are
+about worktree cleanliness and do not care which skill ran, so pass the same
+values the new tests use. In
+`test_a_previous_summary_does_not_make_the_next_run_look_dirty` and
+`test_real_dirt_still_makes_a_run_unclean`, change each
+
+```python
+            identity = record_eval_run.candidate_identity()
+```
+
+to
+
+```python
+            identity = record_eval_run.candidate_identity(
+                "demo", record_eval_run.FORWARD_SUITE
+            )
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `python3 -m unittest scripts.tests.test_record_eval_run -v`
+
+Expected: FAIL. All three new tests —
+`test_candidate_identity_survives_a_rebase_onto_a_moved_base`,
+`test_candidate_identity_survives_a_squash_that_keeps_the_content`, and
+`test_triggering_run_also_names_the_triggering_executors` — raise
+`TypeError: candidate_identity() takes 0 positional arguments but 2 were given`.
+
+This failure is the point of the task: the rebase it models is the one the old
+test avoided, and the old test's passing is what let the false claim into
+`AGENTS.md`.
+
+- [ ] **Step 4: Add `subtree_paths` and extend `candidate_identity`**
+
+In `scripts/record_eval_run.py`, insert `subtree_paths` immediately after the
+`RESULTS_PATH_MARKER` assignment and before `candidate_identity`:
+
+```python
+def subtree_paths(skill: str, suite: str) -> list[str]:
+    """Name the paths whose content decides what a run of this suite read.
+
+    The skill directory holds both the prose under measurement and, at
+    `scripts/evals/`, the executor that produced the evidence — which is the
+    pair a re-record at the shipping head exists to keep together. A
+    triggering run's executors live in `triggering/` instead, outside every
+    skill, so naming only the skill would under-describe the instrument.
+    """
+
+    paths = [f"skills/{skill}"]
+    if suite == TRIGGERING_SUITE:
+        paths.append("triggering")
+    return paths
+```
+
+Then replace `candidate_identity`'s signature, docstring, and return statement.
+The `git` helper and the `status` block above it are unchanged:
+
+```python
+def candidate_identity(skill: str, suite: str) -> dict:
+    """Bind the run to the content that produced it.
+
+    `trees` is the durable half. `sha` and `tree` are both branch-local: a
+    rebase onto a moved `main` rewrites the commit and changes the
+    whole-repository tree through files outside the skill entirely, so neither
+    survives one. A subtree the change never touched is undisturbed by
+    unrelated files moving, which is why it is `trees` a later reader should
+    expect to resolve.
+
+    `worktree_clean` is left unknown rather than asserted when git cannot be
+    read: an empty `git status` and a failed `git status` are the same string,
+    and defaulting to `True` would let a summary claim the strongest available
+    provenance on the strength of a command that never ran.
+    """
+```
+
+and the return:
+
+```python
+    trees = {}
+    for path in subtree_paths(skill, suite):
+        resolved = git("rev-parse", f"HEAD:{path}")
+        if resolved is not None:
+            trees[path] = resolved
+    return {
+        "sha": git("rev-parse", "HEAD"),
+        "tree": git("rev-parse", "HEAD^{tree}"),
+        "trees": trees,
+        "branch": git("rev-parse", "--abbrev-ref", "HEAD"),
+        "worktree_clean": None if relevant is None else not relevant,
+    }
+```
+
+A path that does not resolve is omitted rather than recorded as `None`, for the
+same reason `worktree_clean` is left unknown: a key whose value is `null` reads
+in the guard like a citation to check, and there is nothing there to check.
+
+- [ ] **Step 5: Pass `skill` and `suite` at the call site**
+
+In `build_summary`, at `scripts/record_eval_run.py:513`, change
+
+```python
+        "candidate": candidate_identity(),
+```
+
+to
+
+```python
+        "candidate": candidate_identity(skill, suite),
+```
+
+Both names are already parameters of `build_summary`.
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `python3 -m unittest scripts.tests.test_record_eval_run -v` Expected: PASS,
+all tests.
+
+- [ ] **Step 7: Run the full gate**
+
+```bash
+just format && just lint && just test
+```
+
+Expected: all pass.
+
+- [ ] **Step 8: Add the changelog entry**
+
+Under a `## 2026-08-16 — ...` heading at the top of `CHANGELOG.md` (the heading
+already exists from the design commit; add this entry above the existing one,
+newest first), with no SHA — it has not landed:
+
+```markdown
+- feat(evals): record the subtree identity that survives a rebase —
+  `candidate.tree` was `git rev-parse HEAD^{tree}`, the whole repository's, so
+  a rebase onto a moved `main` changed it through files outside the skill and
+  the recorded identity resolved to nothing. `candidate.trees` now maps each
+  path whose content decided what the run read — `skills/<skill>` always, and
+  `triggering` as well for a triggering-suite run, whose executors live outside
+  every skill — to that path's subtree hash. The test that had asserted the old
+  claim passed only by simulating a rebase as a new parent over an identical
+  tree, which is the one thing a real rebase never is; it now models a base
+  that moved, and fails against the old behavior.
+```
+
+- [ ] **Step 9: Commit**
+
+```bash
+cat >/tmp/commit-msg.md <<'EOF'
+feat(evals): record the subtree identity that survives a rebase
+
+## Summary
+
+- Add `subtree_paths()` and record `candidate.trees`, a map from repository
+  path to that path's subtree hash
+- Take `skill` and `suite` in `candidate_identity()`, so a triggering run also
+  names `triggering/`
+- Replace the test that asserted the disproved durability claim with one that
+  models a real rebase onto a moved base
+
+## Why
+
+`candidate.tree` names the whole repository, so a rebase onto a moved `main`
+changes it through files outside the skill entirely. The test that was supposed
+to hold the claim honest simulated a rebase as a new parent over an identical
+tree — the one shape a real rebase never has — so it passed while the claim it
+guarded was false. The replacement moves a file outside the skill, and fails
+against the old behavior.
+EOF
+git add scripts/record_eval_run.py scripts/tests/test_record_eval_run.py CHANGELOG.md
+git commit -F /tmp/commit-msg.md
+```
+
+______________________________________________________________________
+
+### Task 2: Backfill the 23 summaries that can still be derived
+
+**Files:**
+
+- Modify (data): 23 files under `skills/*/evals/results/*.json`
+- No script is added to the repository. The derivation is a one-shot migration
+  with nothing left to run afterward; its exact text lives in this plan so a
+  reviewer can reproduce it.
+
+**Interfaces:**
+
+- Consumes: `candidate.sha` from each summary; the path selection Task 1 encoded
+  in `subtree_paths`.
+
+- Produces: `candidate.trees` in 23 files. Task 3's guard checks them, and its
+  vacuity test depends on this task having run — which is why the backfill comes
+  first: the guard would otherwise have to be committed red.
+
+- [ ] **Step 1: Run the derivation**
+
+Save this as `/tmp/backfill_eval_trees.py` and run it from the repository root
+with `python3 /tmp/backfill_eval_trees.py`:
+
+```python
+"""Derive `candidate.trees` for every summary still naming a reachable commit.
+
+This is a computation over what each file already carries, not an addition to
+it: `git rev-parse <recorded sha>:<path>` could not have come out differently
+had the field existed when the summary was written. That is what separates it
+from backfilling a landing commit, which would assert something decided after
+the run by a merge that had not happened yet.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+if not (ROOT / "AGENTS.md").is_file():
+    ROOT = Path.cwd()
+
+FORWARD_SUITE = "forward"
+TRIGGERING_SUITE = "triggering"
+
+
+def git(*arguments: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ("git", "-C", str(ROOT), *arguments), capture_output=True, text=True
+    )
+
+
+reachable = set(git("rev-list", "HEAD").stdout.split())
+written = 0
+
+for summary in sorted(ROOT.glob("skills/*/evals/results/*.json")):
+    recorded = json.loads(summary.read_text(encoding="utf-8"))
+    candidate = recorded.get("candidate") or {}
+    sha = candidate.get("sha")
+    if candidate.get("trees") or sha not in reachable:
+        continue
+
+    suite = recorded.get("suite")
+    if suite is None:
+        # A summary predating the `suite` field is a forward run — unless its
+        # name says otherwise, in which case guessing would silently record
+        # the wrong path set, so stop instead.
+        named = [s for s in (TRIGGERING_SUITE,) if s in summary.name]
+        if named:
+            sys.exit(f"{summary}: no recorded suite, but its name says {named}")
+        suite = FORWARD_SUITE
+
+    skill = summary.parents[2].name
+    paths = [f"skills/{skill}"]
+    if suite == TRIGGERING_SUITE:
+        paths.append(TRIGGERING_SUITE)
+
+    trees = {}
+    for path in paths:
+        resolved = git("rev-parse", f"{sha}:{path}")
+        if resolved.returncode:
+            sys.exit(f"{summary}: {path} does not exist at {sha}")
+        trees[path] = resolved.stdout.strip()
+
+    candidate["trees"] = trees
+    summary.write_text(
+        json.dumps(recorded, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    written += 1
+
+print(f"backfilled {written} summaries")
+```
+
+Expected output: `backfilled 23 summaries`.
+
+If it prints any other count, stop and report it rather than continuing — the
+set was verified at 23 against this tree, and a different number means the tree
+moved or the selection logic diverged from the design.
+
+- [ ] **Step 2: Verify the diff is pure addition**
+
+```bash
+git diff --stat -- 'skills/*/evals/results/*.json'
+git diff -- 'skills/*/evals/results/*.json' | grep -c '^-[^-]'
+```
+
+Expected: 23 files changed, and the second command prints `0` — every existing
+line is untouched, because all 82 summaries already round-trip byte-identically
+under `json.dumps(..., indent=2, sort_keys=True)`.
+
+- [ ] **Step 3: Verify one derivation by hand**
+
+Pick any changed file and confirm the recorded hash is what its own `sha`
+yields, so the reviewer is not taking the script's word for it:
+
+```bash
+python3 - <<'EOF'
+import glob, json, subprocess
+for path in sorted(glob.glob("skills/*/evals/results/*.json"))[:200]:
+    candidate = (json.loads(open(path).read()).get("candidate") or {})
+    for repo_path, digest in (candidate.get("trees") or {}).items():
+        expected = subprocess.run(
+            ["git", "rev-parse", f"{candidate['sha']}:{repo_path}"],
+            capture_output=True, text=True,
+        ).stdout.strip()
+        assert expected == digest, (path, repo_path, expected, digest)
+print("every recorded subtree matches its own recorded sha")
+EOF
+```
+
+Expected: `every recorded subtree matches its own recorded sha`.
+
+- [ ] **Step 4: Confirm every derived entry is reachable**
+
+Task 3's guard does not exist yet, so check the property it will enforce
+directly. This is what makes the guard land green rather than red:
+
+```bash
+python3 - <<'EOF'
+import glob, json, subprocess
+def subtrees(path):
+    commits = subprocess.run(["git", "rev-list", "HEAD"], capture_output=True, text=True).stdout.split()
+    listed = subprocess.run(
+        ["git", "cat-file", "--batch-check=%(objectname) %(objecttype)"],
+        input="".join(f"{c}:{path}\n" for c in commits), capture_output=True, text=True,
+    ).stdout
+    return {line.split()[0] for line in listed.splitlines() if line.endswith("tree")}
+cache, cited, dangling = {}, 0, []
+for summary in sorted(glob.glob("skills/*/evals/results/*.json")):
+    trees = (json.loads(open(summary).read()).get("candidate") or {}).get("trees") or {}
+    for path, digest in trees.items():
+        cited += 1
+        if digest not in cache.setdefault(path, subtrees(path)):
+            dangling.append((summary, path, digest))
+print(f"{cited} entries cited, {len(dangling)} unreachable")
+assert not dangling, dangling
+EOF
+```
+
+Expected: `24 entries cited, 0 unreachable` — 23 summaries, one of which is a
+triggering run carrying two paths.
+
+- [ ] **Step 5: Run the full gate**
+
+```bash
+just format && just lint && just test
+```
+
+Expected: all pass, with `just test` now fully green.
+
+- [ ] **Step 6: Add the changelog entry**
+
+```markdown
+- fix(evals): derive the durable identity of every summary that still names a
+  reachable commit — 23 of the 82 summaries gain `candidate.trees` computed
+  from the commit each already carries, and the other 59 keep none. The
+  derivation asserts nothing the recorder did not hold:
+  `git rev-parse <recorded sha>:<path>` could not have come out differently had
+  the field existed when the summary was written, which is what separates it
+  from backfilling a landing commit — a fact decided after the run by a merge
+  that had not happened yet. One of the 23 is a triggering-suite run and needs
+  both its skill path and `triggering`. The 59 measured content that no longer
+  exists in any clone but its author's; unlike the changelog's citations, there
+  is nothing left to recover.
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+cat >/tmp/commit-msg.md <<'EOF'
+fix(evals): derive the durable identity of every recoverable summary
+
+## Summary
+
+- Backfill `candidate.trees` into the 23 summaries whose recorded `sha` is
+  still reachable from `HEAD`
+- Leave the other 59 without the field, recorded as unresolvable rather than
+  pretended into evidence
+
+## Why
+
+The derivation is a computation over what each file already carries, not an
+addition to it. `git rev-parse <recorded sha>:<path>` is reproducible by any
+reader from the file alone and could not have come out differently had the
+field existed when the summary was written — which is what separates it from a
+backfilled landing commit, decided after the run by a merge that had not
+happened yet.
+
+All 23 derive and every derived entry is reachable, so the new guard goes green
+on real evidence rather than on an empty set. The remaining 59 measured content
+that exists in no clone but their author's.
+EOF
+git add 'skills/*/evals/results/*.json' CHANGELOG.md
+git commit -F /tmp/commit-msg.md
+```
+
+______________________________________________________________________
+
+### Task 3: Guard every recorded subtree against reachability
+
+**Files:**
+
+- Create: `scripts/tests/test_eval_candidate_citations.py`
+- Reference (do not modify): `scripts/tests/test_changelog_citations.py`, the
+  sibling this is modeled on
+
+**Interfaces:**
+
+- Consumes: `candidate["trees"]`, as newly written by Task 1 and backfilled into
+  the 23 recoverable summaries by Task 2.
+
+- Produces: a test module `just test` picks up through
+  `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` (the
+  `test-plugins` recipe). Nothing imports it.
+
+- [ ] **Step 1: Write the guard**
+
+Create `scripts/tests/test_eval_candidate_citations.py`:
+
+```python
+"""Every subtree an eval summary cites has to still name reachable content.
+
+A summary's `candidate.trees` is the only machine-checkable link from a
+recorded measurement to the content it measured, and its failure mode is
+silent: a subtree hash that resolves to nothing reads exactly like one that
+resolves, so nobody discovers the rot until they try to follow it.
+
+The check is reachability from `HEAD`, and under subtree identity it is
+well-defined at every point in a change's life. A summary recorded on an open
+branch names a subtree of that branch's own history, rebase included, because
+a rebase that leaves the skill alone leaves its subtree alone. So this module
+needs no unlanded-branch exemption, unlike its changelog sibling.
+
+It turns red in two cases, and both are real. A pull request carrying eval
+evidence was squash-merged, which keeps one tree per pull request and discards
+the intermediate states eval evidence measures by construction — `AGENTS.md`
+requires such a pull request to merge as a merge commit for exactly this
+reason. Or a rebase resolved conflicts inside the skill directory, in which
+case the recorded run measured content that never shipped and the answer is to
+re-record.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import unittest
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+SUMMARIES = sorted(REPOSITORY_ROOT.glob("skills/*/evals/results/*.json"))
+
+
+def _git(*arguments: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ("git", "-C", str(REPOSITORY_ROOT), *arguments),
+        capture_output=True,
+        text=True,
+    )
+
+
+def _citations() -> list[tuple[str, str, str]]:
+    """Return (summary path, repository path, subtree hash) for every citation.
+
+    A summary carrying no `trees` is not a failure. Those predate the field
+    and could not have their identity derived from a commit that still
+    resolves; `AGENTS.md` records them as branch-local and unresolvable.
+    """
+
+    found = []
+    for summary in SUMMARIES:
+        recorded = json.loads(summary.read_text(encoding="utf-8"))
+        trees = (recorded.get("candidate") or {}).get("trees") or {}
+        for path, digest in sorted(trees.items()):
+            found.append(
+                (str(summary.relative_to(REPOSITORY_ROOT)), path, digest)
+            )
+    return found
+
+
+def _reachable_subtrees(path: str) -> set[str]:
+    """Every hash `path` has had across the commits reachable from `HEAD`."""
+
+    commits = _git("rev-list", "HEAD").stdout.split()
+    request = "".join(f"{commit}:{path}\n" for commit in commits)
+    listed = subprocess.run(
+        (
+            "git",
+            "-C",
+            str(REPOSITORY_ROOT),
+            "cat-file",
+            "--batch-check=%(objectname) %(objecttype)",
+        ),
+        input=request,
+        capture_output=True,
+        text=True,
+    ).stdout
+    return {
+        line.split()[0] for line in listed.splitlines() if line.endswith("tree")
+    }
+
+
+class EvalCandidateCitationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.citations = _citations()
+
+    def test_some_summary_cites_a_subtree(self) -> None:
+        # Without this, deleting the field from every summary — or writing it
+        # under a key this module does not read — would turn the reachability
+        # check green by emptying it, which is the failure this module exists
+        # to prevent rather than reproduce.
+        self.assertTrue(
+            self.citations,
+            "no summary under skills/*/evals/results/ carries "
+            "candidate.trees, so the reachability check below is vacuous",
+        )
+
+    def test_every_cited_subtree_is_reachable_from_head(self) -> None:
+        if _git("rev-parse", "--git-dir").returncode != 0:
+            self.skipTest("not a git repository, so no history to check against")
+        if _git("rev-parse", "--is-shallow-repository").stdout.strip() == "true":
+            self.fail(
+                "history is shallow, so an unreachable subtree cannot be told "
+                "apart from an unfetched one; run `git fetch --unshallow`"
+            )
+
+        reachable: dict[str, set[str]] = {}
+        dangling = []
+        for summary, path, digest in self.citations:
+            if path not in reachable:
+                reachable[path] = _reachable_subtrees(path)
+            if digest not in reachable[path]:
+                dangling.append((summary, path, digest))
+
+        self.assertEqual(
+            dangling,
+            [],
+            "eval summaries cite subtrees that are not reachable from HEAD:\n"
+            + "\n".join(
+                f"  {summary}\n    {path} @ {digest}"
+                for summary, path, digest in dangling
+            )
+            + "\n\nA recorded subtree stays resolvable only while the commit "
+            "carrying it does\n(see AGENTS.md). A pull request touching "
+            "skills/*/evals/results/ merges as a\nmerge commit rather than a "
+            "squash for this reason. If one was squashed, the\nmeasured "
+            "content is gone and the remedy is to re-record against a state "
+            "that\nstill exists, saying in the summary that the original is "
+            "unrecoverable.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run it and verify it passes on real evidence**
+
+Run: `python3 -m unittest scripts.tests.test_eval_candidate_citations -v`
+
+Expected: PASS, both tests. `test_some_summary_cites_a_subtree` is satisfied by
+the 23 summaries Task 2 backfilled, and every one of their 24 entries is
+reachable.
+
+A pass here proves nothing on its own — a check that cannot fail passes too.
+Step 3 is what earns it.
+
+- [ ] **Step 3: Verify the reachability check is capable of failing**
+
+Prove the guard can go red before trusting it, and prove both of its tests can.
+First, mutate one backfilled summary to carry a subtree that names nothing:
+
+```bash
+python3 - <<'EOF'
+import json
+from pathlib import Path
+p = Path("skills/ready-ticket/evals/results/2026-08-15T173118Z-0003-before.json")
+d = json.loads(p.read_text())
+d["candidate"]["trees"] = {"skills/ready-ticket": "0" * 40}
+p.write_text(json.dumps(d, indent=2, sort_keys=True) + "\n")
+EOF
+python3 -m unittest scripts.tests.test_eval_candidate_citations -v
+```
+
+Expected: `test_every_cited_subtree_is_reachable_from_head` FAILS, naming that
+file, that path, and `0000...`.
+
+Restore it:
+
+```bash
+git checkout -- skills/ready-ticket/evals/results/2026-08-15T173118Z-0003-before.json
+```
+
+Then prove the vacuity test can fail too, by stripping every `trees` entry into
+a scratch copy of the tree rather than the real one:
+
+```bash
+python3 - <<'EOF'
+import importlib.util, unittest
+from pathlib import Path
+spec = importlib.util.spec_from_file_location(
+    "guard", "scripts/tests/test_eval_candidate_citations.py"
+)
+guard = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(guard)
+guard.SUMMARIES = []          # the state before Task 2 backfilled anything
+case = guard.EvalCandidateCitationTests("test_some_summary_cites_a_subtree")
+guard.EvalCandidateCitationTests.setUpClass()
+print(unittest.TextTestRunner(verbosity=2).run(unittest.TestSuite([case])))
+EOF
+```
+
+Expected: FAIL with "no summary under skills/\*/evals/results/ carries
+candidate.trees". That is the state the repository was in before Task 2, and it
+is what the test exists to catch if the field is ever removed or renamed.
+
+- [ ] **Step 4: Run the full gate**
+
+```bash
+just format && just lint && just test
+```
+
+Expected: all pass. Confirm the working tree is clean before committing — Step 3
+mutated a summary and restored it:
+
+```bash
+git status --porcelain
+```
+
+Expected: only `scripts/tests/test_eval_candidate_citations.py` and
+`CHANGELOG.md` appear.
+
+- [ ] **Step 5: Add the changelog entry**
+
+```markdown
+- test(evals): hold every recorded subtree to reachability from `HEAD` —
+  `scripts/tests/test_eval_candidate_citations.py` fails when a summary's
+  `candidate.trees` names content no commit reachable from `HEAD` carries,
+  which is the same silent rot `scripts/tests/test_changelog_citations.py`
+  catches for the changelog: a hash resolving to nothing reads exactly like one
+  that resolves. Unlike its sibling it needs no unlanded-branch exemption,
+  because a subtree recorded on an open branch stays reachable from that
+  branch's own history across a rebase. A summary carrying no `trees` passes —
+  those predate the field and are recorded as unresolvable rather than
+  pretended into evidence.
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+cat >/tmp/commit-msg.md <<'EOF'
+test(evals): hold every recorded subtree to reachability from HEAD
+
+## Summary
+
+- Add `scripts/tests/test_eval_candidate_citations.py`, failing when a
+  summary's `candidate.trees` names content unreachable from `HEAD`
+- Guard against vacuity: the module fails if no summary cites a subtree at all
+
+## Why
+
+A subtree hash that resolves to nothing reads exactly like one that resolves,
+which is how 59 of this repository's 82 summaries came to name commits nobody
+can retrieve without anyone noticing. The check needs no unlanded-branch
+exemption, unlike the changelog's: a subtree recorded on an open branch is
+reachable from that branch's own history across a rebase, so it is well-defined
+at every point in a change's life.
+EOF
+git add scripts/tests/test_eval_candidate_citations.py CHANGELOG.md
+git commit -F /tmp/commit-msg.md
+```
+
+______________________________________________________________________
+
+### Task 4: State the merge policy and correct the durability claim
+
+**Files:**
+
+- Modify: `AGENTS.md:86-97` (the `candidate.tree` paragraph)
+- Modify: `AGENTS.md:95-97` (the grandfathering sentence about `model`)
+- Modify: `skills/babysit-pr/SKILL.md:398`
+- Test: `scripts/tests/test_record_eval_run.py`, class `NormIsStatedTests`
+
+**Interfaces:**
+
+- Consumes: nothing from earlier tasks at runtime. The prose describes the
+  behavior Tasks 1–3 built.
+
+- Produces: no callable surface.
+
+- [ ] **Step 1: Write the failing test**
+
+In `scripts/tests/test_record_eval_run.py`, add to `NormIsStatedTests`, after
+`test_agents_md_states_the_norm_and_the_results_convention`:
+
+```python
+    def test_agents_md_states_the_merge_method_the_evidence_depends_on(
+        self,
+    ) -> None:
+        """AC: the rule that keeps a recorded subtree resolvable is written
+        where a contributor and a merging agent both read it.
+
+        A recorded subtree resolves only while a commit carrying it stays
+        reachable, so the merge method is load-bearing rather than stylistic
+        and its failure is unrepairable. Prose that omits it leaves the guard
+        firing on `main` with nothing to point the citation at.
+        """
+
+        agents = (REPOSITORY_ROOT / "AGENTS.md").read_text(encoding="utf-8")
+
+        self.assertIn("candidate.trees", agents)
+        self.assertIn("merge commit", agents)
+        self.assertIn("skills/*/evals/results/", agents)
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run:
+`python3 -m unittest scripts.tests.test_record_eval_run.NormIsStatedTests -v`
+
+Expected: FAIL on `assertIn("candidate.trees", agents)` — `AGENTS.md` still
+describes only `candidate.tree`.
+
+- [ ] **Step 3: Replace the durability paragraph in `AGENTS.md`**
+
+Replace the paragraph beginning "Each summary also carries `candidate.tree`" and
+ending "...they are not backfilled." with:
+
+```markdown
+Each summary also carries `candidate.trees` — a map from repository path to
+that path's subtree hash, holding `skills/<skill>` for every run and
+`triggering` as well for a triggering-suite run, whose executors live outside
+every skill — `candidate.tree`, the whole repository's
+`git rev-parse HEAD^{tree}`, and, for a real-model run, `model`, the exact
+`--model` the recorded command passed.
+
+`sha` and `tree` are both branch-local. A rebase onto a moved `main` rewrites
+the commit and changes the repository tree through files outside the skill
+entirely, so neither survives one, and a squash-merge then discards both
+outright. It is `trees` a reader should expect to still resolve, because
+unrelated files moving cannot disturb a subtree the change never touched.
+
+A subtree resolves only while a commit carrying it stays reachable, so a pull
+request that adds or changes any file under `skills/*/evals/results/` merges as
+a merge commit rather than a squash. A squash keeps one tree per pull request,
+and the states eval evidence measures are intermediate by construction: a
+before-stage run measures a new corpus against the old prose, and a superseded
+after-stage run measures prose a later commit changed. Squashing such a pull
+request destroys the measured content in every clone but the author's, and no
+later repair recovers it — the only remedy is to re-record against a state that
+still exists and to say in the summary that the original is unrecoverable.
+`scripts/tests/test_eval_candidate_citations.py` is what turns red when this
+goes wrong, and `carve-changesets` already defaults its merge method to `merge`.
+
+`model` exists because a before/after pair taken across a model update compares
+two different subjects wearing the same tier name; a diff is drawn only when the
+compared runs' tier, suite, and model all match. A deterministic run records no
+model — there is none to name. Summaries recorded before these fields existed
+carry `trees` only where it could be derived from a commit they still name, and
+carry no `model` at all: no model can be recovered for them after the fact, and
+they are not backfilled. The derivation that is backfilled,
+`git rev-parse <recorded sha>:<path>`, is a computation over what the file
+already carries and could not have come out differently had the field existed
+when it was written. A landing commit is not backfilled for the opposite
+reason: which commit carries a summary onto `main` is decided after the run by a
+merge that has not happened yet, so writing it in would add a claim nothing in
+the file supports.
+```
+
+- [ ] **Step 4: Correct the `babysit-pr` example**
+
+At `skills/babysit-pr/SKILL.md:398`, change
+
+```text
+next_action: caller may merge via repository-approved squash method
+```
+
+to
+
+```text
+next_action: caller may merge via the repository-approved merge method
+```
+
+This is editorial and carries no eval-evidence obligation: line 357 already
+obliges the caller to use "the repository-approved merge method", so the example
+is being brought into line with the rule rather than changing one.
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run:
+`python3 -m unittest scripts.tests.test_record_eval_run.NormIsStatedTests -v`
+Expected: PASS.
+
+- [ ] **Step 6: Run the full gate**
+
+```bash
+just format && just lint && just test
+```
+
+Expected: all pass. `just lint` runs `skills-ref validate`, which must stay
+green across the `babysit-pr` edit.
+
+- [ ] **Step 7: Add the changelog entry**
+
+```markdown
+- docs: state the merge method the eval evidence depends on, and correct what
+  `AGENTS.md` claims survives — the file told a reader to trust `candidate.tree`
+  over `candidate.sha` on the grounds that content is identical under rebase and
+  squash where a commit is not. It is not: `tree` is the whole repository's, so
+  a rebase onto a moved `main` changes it through files outside the skill. Both
+  are now stated as branch-local, `candidate.trees` is named as the durable
+  half, and the rule that makes it durable is written down — a pull request
+  touching `skills/*/evals/results/` merges as a merge commit, because a squash
+  keeps one tree per pull request while the states eval evidence measures are
+  intermediate by construction. `babysit-pr`'s example output block is brought
+  into line with the obligation its own prose already carried.
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+cat >/tmp/commit-msg.md <<'EOF'
+docs: state the merge method the eval evidence depends on
+
+## Summary
+
+- Correct `AGENTS.md`: `sha` and `tree` are both branch-local, and
+  `candidate.trees` is the half a reader should expect to resolve
+- State the merge-commit rule for pull requests touching
+  `skills/*/evals/results/`, and why its failure is unrepairable
+- Record why the subtree derivation is backfilled where a landing commit is not
+- Bring `babysit-pr`'s example output into line with the obligation at
+  `SKILL.md:357`
+
+## Why
+
+The claim that `tree` outlives `sha` was false in the rebase case, and it was
+the claim a contributor was told to rely on. Correcting it without stating the
+merge method would leave the corrected claim just as false, because a subtree
+resolves only while a commit carrying it stays reachable — and a squash-merge
+of a pull request carrying eval evidence destroys the measured content in every
+clone but the author's.
+
+The `babysit-pr` edit is editorial: line 357 already obliges the caller to use
+the repository-approved merge method, so the example at line 398 is being
+brought into line with a rule rather than given a new one. No obligation
+changes, so the eval-backed change norm does not apply.
+EOF
+git add AGENTS.md skills/babysit-pr/SKILL.md scripts/tests/test_record_eval_run.py CHANGELOG.md
+git commit -F /tmp/commit-msg.md
+```
+
+______________________________________________________________________
+
+## Merging this work
+
+This pull request adds files under `skills/*/evals/results/` — Task 2 modifies
+23 of them — so by the rule it installs, **it merges as a merge commit, not a
+squash**. Merging it with a squash would be the first violation of its own
+policy, and would discard the intermediate states its commits carry.
+
+The eval-backed change norm does not apply to this work: `AGENTS.md` is
+repository prose rather than a skill's, and the one skill edit is editorial. Say
+so in the pull request body rather than leaving a reviewer to derive it.
+
+Two things to state plainly in the pull request body:
+
+- 59 summaries remain unresolvable and cannot be repaired. Unlike #236's
+  citations, the history they should have named is on no branch — the pull
+  request repairs what is derivable and says the rest is gone.
+- Both of the guard's tests were verified capable of failing, per Task 3 Step 3,
+  rather than assumed to work because they are green.
+
+<!-- inline reference link definitions. please keep alphabetized -->
+
+[spec]: ../specs/2026-08-16-eval-candidate-identity-design.md

--- a/docs/superpowers/specs/2026-08-16-eval-candidate-identity-design.md
+++ b/docs/superpowers/specs/2026-08-16-eval-candidate-identity-design.md
@@ -1,0 +1,224 @@
+# The eval candidate's durable identity
+
+This is the design for making an eval summary's `candidate` block name
+repository state a later reader can still retrieve. It changes how a pull
+request carrying eval evidence is merged, what `candidate_identity()` records,
+and adds a guard holding the recorded identity to reachability. It does not
+change what the evals measure or how they run.
+
+## The problem
+
+[`scripts/record_eval_run.py`][recorder] writes `candidate.sha` and
+`candidate.tree` into every summary under `skills/<skill>/evals/results/`.
+[`AGENTS.md`][agents] tells the reader which of the two to trust:
+
+> `sha` names the commit, which rebase rewrites and squash-merge discards
+> outright; `tree` names the content, which is identical under both, so it is
+> `tree`, not `sha`, that a reader should expect to still resolve once a change
+> has landed on `main`.
+
+That is wrong, and it fails the same way [#236][pr236] found `CHANGELOG.md`
+citations failing. `candidate.tree` is `git rev-parse HEAD^{tree}` — the
+whole-repository tree. A rebase onto a moved `main` changes files outside the
+skill, so the rebased commit carries a different top-level tree. Neither half of
+the pair survives, and after a squash-merge both are unreachable from `main` for
+anyone without the pre-rebase clone.
+
+The rot is already at scale. Of the 82 summaries in the repository, 59 name a
+`sha` unreachable from `HEAD` — proportionally worse than the 68 of 248 dangling
+changelog citations #236 repaired. Only 16 carry a `tree` at all, the field
+being recent, and 8 of those 16 resolve.
+
+It is concentrated where the evidence matters most:
+
+| stage      | resolves | dangles |
+| ---------- | -------- | ------- |
+| `after`    | 2        | 45      |
+| `baseline` | 1        | 13      |
+| `before`   | 20       | 1       |
+
+A `before` run mostly survives by accident. Recorded at an untouched branch
+point, it names the merge-base — a commit already on `main` — so nothing about
+the branch's fate can take it away. The single exception proves the accident is
+fragile: [#234][issue234]'s before-run was recorded after its new eval cases
+were already committed, so it names a mid-branch state and dangles like the
+rest.
+
+The `after` run has no such luck. It names a branch-local commit by
+construction, and 45 of 47 are gone. The two survivors came onto `main` through
+[#235][pr235], the one recent pull request merged as a merge commit rather than
+a squash. The run that says how the shipped prose actually behaves is the run
+this repository has already lost, every time, since squash-merge became its
+habit.
+
+## Why recording the skill's subtree is necessary but not sufficient
+
+The obvious repair is to record `git rev-parse HEAD:skills/<skill>` instead of
+the whole-repository tree: unrelated files moving under a rebase cannot disturb
+it, and it is what actually determines what the eval read. Running the
+counterfactual against `scott/ticket-234-09af55`, whose five summaries name
+pre-rebase commits that survive in that clone only as dangling objects, all five
+subtrees are reachable from the rebased branch where none of the five commits
+is.
+
+Simulating that branch's squash-merge, none of the five survives — not as
+subtrees, and not with `evals/results/` excluded from the hash either. The
+reason is structural rather than a matter of hashing granularity:
+
+- The `before` run measures the new eval corpus against the *old* prose. That
+  combination exists only mid-branch, on no commit that ever lands.
+- Every superseded `after` run measures prose a later commit on the same branch
+  changed, which is why `a397c63` and `10a7b54` on that branch both re-record at
+  the shipping head.
+
+A squash-merge keeps one tree per pull request. Eval evidence is the one
+artifact class in this repository whose value depends on *intermediate* branch
+states remaining resolvable. No identity scheme can make reachable what git was
+instructed to discard.
+
+## The design
+
+### Merge policy
+
+A pull request that adds or changes any file under `skills/*/evals/results/`
+merges as a merge commit, never a squash. Every authoring commit lands, so every
+state a summary measured stays reachable from `main` permanently.
+
+This is the part that makes retrieval possible; everything below only keeps the
+recorded identity intact until the merge. It has ample precedent in this
+repository: 37 pull requests through [#107][pr107] landed as merge commits, and
+#235 is why the only two surviving `after` runs survive.
+
+[`skills/babysit-pr/SKILL.md:357`][babysit] already obliges the caller to use
+"the repository-approved merge method", so the policy belongs in `AGENTS.md` and
+the skill needs no normative change. The example output block at line 398 says
+"repository-approved squash method"; correcting it to match line 357 alters no
+obligation and is editorial under the eval-backed change norm. A carved chain
+needs no change either: `carve-changesets` already defaults its merge method to
+`merge`.
+
+The failure this policy prevents is unrepairable once it happens, which is worth
+stating where the policy is written. A squash-merged pull request carrying eval
+evidence turns the guard red on `main` with no way to repoint the citation — the
+measured content is gone from every clone but the author's. The only remedy is
+to re-record against a state that still exists and to say in the summary that
+the original is unrecoverable.
+
+### What `candidate_identity()` records
+
+`candidate.trees`, a map from repository path to that path's subtree hash:
+
+- `skills/<skill>` for every run. The skill directory holds both the prose under
+  measurement and, at `skills/<skill>/scripts/evals/claude_executor.py`, the
+  executor that produced the evidence — which is exactly the pair
+  [`2dc1e4e` re-recorded to keep together][reroll].
+- `triggering` additionally for a triggering-suite run, whose executors live in
+  `triggering/executors/`, outside any skill.
+
+The subtree is needed even under the merge policy above, because `AGENTS.md`
+requires rebasing onto `main` before submitting a pull request and a rebase
+rewrites the commits summaries name. On `scott/ticket-234-09af55` that is not
+hypothetical: five of five `sha`s dangle after the rebase and five of five
+subtrees survive it.
+
+A map rather than a scalar because a scalar silently under-describes a
+triggering-suite run, and because it extends to `review-suite/` for free if
+`just eval-record` ever learns to drive those corpora.
+
+No `evals/results/` exclusion is needed, which is worth stating because it is
+not obvious: the subtree is captured before the summary is written, and under
+the merge policy that parent commit lands, so the recorded hash stays resolvable
+even though committing the summary changes the skill's subtree afterward.
+
+`sha` and the whole-repository `tree` continue to be recorded as best-effort
+context and are documented as branch-local. Summaries already written keep
+`tree` meaning the whole-repository tree; recorded evidence does not get its
+fields redefined underneath it.
+
+### The guard
+
+`scripts/tests/test_eval_candidate_citations.py`, a sibling of
+[`test_changelog_citations.py`][changelog-guard]: every `candidate.trees` entry
+in every summary must name a subtree reachable from `HEAD`, failing with the
+same distinct message on a shallow clone rather than passing vacuously. CI
+already checks out with `fetch-depth: 0`, added by #236 for the changelog guard,
+so no workflow change is needed.
+
+Reachability for a subtree means the hash appears as `<commit>:<path>` for some
+commit reachable from `HEAD`, resolved with one `git rev-list` and one
+`git cat-file --batch-check` per distinct path.
+
+### What the guard does about an unlanded branch
+
+Nothing, and it needs no exemption. Under subtree identity a summary recorded on
+an open branch is reachable from that branch's own `HEAD` at every point in its
+lifecycle, rebase included. The guard turns red only when a skill's content
+changed after recording *and* history was squashed — the case the merge policy
+prevents — or when a rebase resolved conflicts inside the skill directory, where
+re-recording is the correct response rather than a false alarm.
+
+This is a real difference from the changelog guard, which needs `AGENTS.md` to
+close the window from the other side by deferring backfill until an entry lands.
+
+### No backfilled landing commit
+
+Under the merge policy the recorded `sha` already resolves on `main`, so there
+is nothing to repair. The deeper reason not to adopt the changelog's backfill: a
+changelog entry's fact of interest genuinely is which commit carried it onto
+`main`, whereas a summary's fact of interest is what the eval read, which the
+subtree names directly and immutably.
+
+A landing commit would also be a fact the recorder never held. Which commit
+carries a summary onto `main` is decided after the run, by a merge that has not
+happened yet, so writing it in adds a claim nothing in the file can support.
+That is the line this design draws around editing recorded evidence, and it is
+narrower than "never touch these files" — see the backfill below, which stays on
+the other side of it.
+
+### Existing summaries
+
+The 23 summaries whose `sha` is still reachable from `HEAD` gain
+`candidate.trees`, derived from the commit each already names. The remaining 59
+are grandfathered untouched: the guard checks only `candidate.trees`, so a
+summary without it passes, and `AGENTS.md` states that such summaries are
+branch-local and unresolvable — the treatment it already gives summaries
+predating the `model` field.
+
+This is a derivation, not an addition. `git rev-parse <recorded sha>:<path>` is
+a lossless computation over data the summary already carries, reproducible by
+anyone from the file itself, and it cannot say anything the recorder would not
+have said had the field existed. That is what separates it from a backfilled
+landing commit, which asserts something no recorded field implies.
+
+Verified against the current tree: all 23 derive, and every derived entry is
+reachable, so the backfill leaves the guard green rather than importing 23
+failures. One of the 23 is a triggering-suite run and needs both
+`skills/review-solution-simplicity` and `triggering`, which is the map shape
+paying for itself on real data rather than on a hypothetical. Seven predate the
+`suite` field and are treated as forward runs; all seven are confirmed
+non-triggering by name, and the implementation fails loudly on a summary whose
+suite it cannot determine rather than guessing.
+
+The 59 measured content that no longer exists in any clone but their author's,
+unlike #236's citations, which were recoverable because the history they should
+have named was still on `main`. The pull request says so plainly rather than
+implying a repair it did not make.
+
+## Scope
+
+Out of scope: what the evals measure, how they run, the tier and suite model,
+and whether `just eval-record` can drive the review-suite corpora. The merge
+policy applies to pull requests carrying eval evidence and leaves every other
+pull request squash-merged.
+
+<!-- inline reference link definitions. please keep alphabetized -->
+
+[agents]: ../../../AGENTS.md
+[babysit]: ../../../skills/babysit-pr/SKILL.md
+[changelog-guard]: ../../../scripts/tests/test_changelog_citations.py
+[issue234]: https://github.com/shaug/compris/issues/234
+[pr107]: https://github.com/shaug/compris/pull/107
+[pr235]: https://github.com/shaug/compris/pull/235
+[pr236]: https://github.com/shaug/compris/pull/236
+[recorder]: ../../../scripts/record_eval_run.py
+[reroll]: https://github.com/shaug/compris/commit/2dc1e4e3339a1fb5be52208d657663b6518fd7ec

--- a/scripts/record_eval_run.py
+++ b/scripts/record_eval_run.py
@@ -389,8 +389,31 @@ def diff_against(
 RESULTS_PATH_MARKER = "/evals/results/"
 
 
-def candidate_identity() -> dict:
-    """Bind the run to the tree that produced it.
+def subtree_paths(skill: str, suite: str) -> list[str]:
+    """Name the paths whose content decides what a run of this suite read.
+
+    The skill directory holds both the prose under measurement and, at
+    `scripts/evals/`, the executor that produced the evidence — which is the
+    pair a re-record at the shipping head exists to keep together. A
+    triggering run's executors live in `triggering/` instead, outside every
+    skill, so naming only the skill would under-describe the instrument.
+    """
+
+    paths = [f"skills/{skill}"]
+    if suite == TRIGGERING_SUITE:
+        paths.append("triggering")
+    return paths
+
+
+def candidate_identity(skill: str, suite: str) -> dict:
+    """Bind the run to the content that produced it.
+
+    `trees` is the durable half. `sha` and `tree` are both branch-local: a
+    rebase onto a moved `main` rewrites the commit and changes the
+    whole-repository tree through files outside the skill entirely, so neither
+    survives one. A subtree the change never touched is undisturbed by
+    unrelated files moving, which is why it is `trees` a later reader should
+    expect to resolve.
 
     `worktree_clean` is left unknown rather than asserted when git cannot be
     read: an empty `git status` and a failed `git status` are the same string,
@@ -417,9 +440,15 @@ def candidate_identity() -> dict:
             for line in status.splitlines()
             if RESULTS_PATH_MARKER not in line.replace("\\", "/")
         ]
+    trees = {}
+    for path in subtree_paths(skill, suite):
+        resolved = git("rev-parse", f"HEAD:{path}")
+        if resolved is not None:
+            trees[path] = resolved
     return {
         "sha": git("rev-parse", "HEAD"),
         "tree": git("rev-parse", "HEAD^{tree}"),
+        "trees": trees,
         "branch": git("rev-parse", "--abbrev-ref", "HEAD"),
         "worktree_clean": None if relevant is None else not relevant,
     }
@@ -510,7 +539,7 @@ def build_summary(
         "gap": gap,
         "note": note,
         "command": command,
-        "candidate": candidate_identity(),
+        "candidate": candidate_identity(skill, suite),
         "status": status,
         "exit_code": completed.returncode,
         "limitation": limitation,

--- a/scripts/record_eval_run.py
+++ b/scripts/record_eval_run.py
@@ -10,8 +10,8 @@ Each run writes one JSON summary to `skills/<skill>/evals/results/`, carrying
 the recorded date, the tier and exact executor command, the candidate the run
 evaluated, per-case pass/fail, and the diff against that skill's previous
 recorded run of the same tier. Summaries are evidence, not a CI gate. Record
-from a committed, clean tree so `candidate.sha` names a commit a later reader
-can actually resolve.
+from a committed, clean tree so `candidate.trees` can be derived from `HEAD`
+at all, and so what it names is content a later reader can actually resolve.
 
 Usage:
     python3 scripts/record_eval_run.py implement-ticket --stage baseline
@@ -389,23 +389,56 @@ def diff_against(
 RESULTS_PATH_MARKER = "/evals/results/"
 
 
-def subtree_paths(skill: str, suite: str) -> list[str]:
-    """Name the paths whose content decides what a run of this suite read.
+def owning_unit(token: str) -> str | None:
+    """The top-level repository unit a command-line token names, if it names one.
 
-    The skill directory holds both the prose under measurement and, at
-    `scripts/evals/`, the executor that produced the evidence — which is the
-    pair a re-record at the shipping head exists to keep together. A
-    triggering run's executors live in `triggering/` instead, outside every
-    skill, so naming only the skill would under-describe the instrument.
+    A unit is `skills/<name>` for anything under `skills/` and the top-level
+    directory otherwise, because that is the granularity at which content in
+    this repository moves together. A token that is a flag, an absolute path,
+    a bare word, or a path no directory backs is not a repository path and
+    yields nothing.
     """
 
-    paths = [f"skills/{skill}"]
-    if suite == TRIGGERING_SUITE:
-        paths.append("triggering")
-    return paths
+    if token.startswith("-") or "/" not in token or token.startswith("/"):
+        return None
+    parts = [part for part in token.split("/") if part]
+    if not parts or parts[0] in {".", ".."} or ".." in parts:
+        return None
+    if parts[0] == "skills" and len(parts) > 1:
+        unit = f"skills/{parts[1]}"
+    else:
+        unit = parts[0]
+    return unit if (REPOSITORY_ROOT / unit).is_dir() else None
 
 
-def candidate_identity(skill: str, suite: str) -> dict:
+def subtree_paths(skill: str, command: list[str]) -> list[str]:
+    """Name the paths whose content decides what a run read.
+
+    `skills/<skill>` is always named: it holds the prose under measurement,
+    whether or not the command happens to mention it. Everything else is
+    derived from the run's own resolved command, so a target self-describes
+    and no hand-maintained mapping can drift away from the registry. Two
+    cases this repository already has depend on it — a triggering run's
+    executors live in `triggering/`, outside every skill, and
+    `implement-epic`'s runner, executor, and corpus all live under
+    `skills/implement-ticket/`, so naming only the skill would leave two runs
+    on different instruments carrying the same recorded identity.
+
+    A registered target's `--model` and script path normally live inside one
+    compound `--executor` string rather than as separate tokens, so each token
+    is re-split before its paths are read, the same way `model_for` does it.
+    """
+
+    paths = {f"skills/{skill}"}
+    for token in command:
+        for word in shlex.split(token) if " " in token else [token]:
+            unit = owning_unit(word)
+            if unit is not None:
+                paths.add(unit)
+    return sorted(paths)
+
+
+def candidate_identity(skill: str, command: list[str]) -> dict:
     """Bind the run to the content that produced it.
 
     `trees` is the durable half. `sha` and `tree` are both branch-local: a
@@ -419,6 +452,12 @@ def candidate_identity(skill: str, suite: str) -> dict:
     read: an empty `git status` and a failed `git status` are the same string,
     and defaulting to `True` would let a summary claim the strongest available
     provenance on the strength of a command that never ran.
+
+    `trees_unresolved` names any path whose subtree could not be read, for the
+    same reason. Dropping it silently would leave a run that derived nothing
+    indistinguishable from a summary predating the field — both carry no
+    citation, and the reachability guard reads the absence as legacy and stays
+    green either way.
     """
 
     def git(*args: str) -> str | None:
@@ -441,14 +480,18 @@ def candidate_identity(skill: str, suite: str) -> dict:
             if RESULTS_PATH_MARKER not in line.replace("\\", "/")
         ]
     trees = {}
-    for path in subtree_paths(skill, suite):
+    unresolved = []
+    for path in subtree_paths(skill, command):
         resolved = git("rev-parse", f"HEAD:{path}")
-        if resolved is not None:
+        if resolved is None:
+            unresolved.append(path)
+        else:
             trees[path] = resolved
     return {
         "sha": git("rev-parse", "HEAD"),
         "tree": git("rev-parse", "HEAD^{tree}"),
         "trees": trees,
+        "trees_unresolved": unresolved,
         "branch": git("rev-parse", "--abbrev-ref", "HEAD"),
         "worktree_clean": None if relevant is None else not relevant,
     }
@@ -539,7 +582,7 @@ def build_summary(
         "gap": gap,
         "note": note,
         "command": command,
-        "candidate": candidate_identity(skill, suite),
+        "candidate": candidate_identity(skill, command),
         "status": status,
         "exit_code": completed.returncode,
         "limitation": limitation,

--- a/scripts/tests/test_eval_candidate_citations.py
+++ b/scripts/tests/test_eval_candidate_citations.py
@@ -1,0 +1,131 @@
+"""Every subtree an eval summary cites has to still name reachable content.
+
+A summary's `candidate.trees` is the only machine-checkable link from a
+recorded measurement to the content it measured, and its failure mode is
+silent: a subtree hash that resolves to nothing reads exactly like one that
+resolves, so nobody discovers the rot until they try to follow it.
+
+The check is reachability from `HEAD`, and under subtree identity it is
+well-defined at every point in a change's life. A summary recorded on an open
+branch names a subtree of that branch's own history, rebase included, because
+a rebase that leaves the skill alone leaves its subtree alone. So this module
+needs no unlanded-branch exemption, unlike its changelog sibling.
+
+It turns red in two cases, and both are real. A pull request carrying eval
+evidence was squash-merged, which keeps one tree per pull request and discards
+the intermediate states eval evidence measures by construction — `AGENTS.md`
+requires such a pull request to merge as a merge commit for exactly this
+reason. Or a rebase resolved conflicts inside the skill directory, in which
+case the recorded run measured content that never shipped and the answer is to
+re-record.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import unittest
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+SUMMARIES = sorted(REPOSITORY_ROOT.glob("skills/*/evals/results/*.json"))
+
+
+def _git(*arguments: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ("git", "-C", str(REPOSITORY_ROOT), *arguments),
+        capture_output=True,
+        text=True,
+    )
+
+
+def _citations() -> list[tuple[str, str, str]]:
+    """Return (summary path, repository path, subtree hash) for every citation.
+
+    A summary carrying no `trees` is not a failure. Those predate the field
+    and could not have their identity derived from a commit that still
+    resolves; `AGENTS.md` records them as branch-local and unresolvable.
+    """
+
+    found = []
+    for summary in SUMMARIES:
+        recorded = json.loads(summary.read_text(encoding="utf-8"))
+        trees = (recorded.get("candidate") or {}).get("trees") or {}
+        for path, digest in sorted(trees.items()):
+            found.append((str(summary.relative_to(REPOSITORY_ROOT)), path, digest))
+    return found
+
+
+def _reachable_subtrees(path: str) -> set[str]:
+    """Every hash `path` has had across the commits reachable from `HEAD`."""
+
+    commits = _git("rev-list", "HEAD").stdout.split()
+    request = "".join(f"{commit}:{path}\n" for commit in commits)
+    listed = subprocess.run(
+        (
+            "git",
+            "-C",
+            str(REPOSITORY_ROOT),
+            "cat-file",
+            "--batch-check=%(objectname) %(objecttype)",
+        ),
+        input=request,
+        capture_output=True,
+        text=True,
+    ).stdout
+    return {line.split()[0] for line in listed.splitlines() if line.endswith("tree")}
+
+
+class EvalCandidateCitationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.citations = _citations()
+
+    def test_some_summary_cites_a_subtree(self) -> None:
+        # Without this, deleting the field from every summary — or writing it
+        # under a key this module does not read — would turn the reachability
+        # check green by emptying it, which is the failure this module exists
+        # to prevent rather than reproduce.
+        self.assertTrue(
+            self.citations,
+            "no summary under skills/*/evals/results/ carries "
+            "candidate.trees, so the reachability check below is vacuous",
+        )
+
+    def test_every_cited_subtree_is_reachable_from_head(self) -> None:
+        if _git("rev-parse", "--git-dir").returncode != 0:
+            self.skipTest("not a git repository, so no history to check against")
+        if _git("rev-parse", "--is-shallow-repository").stdout.strip() == "true":
+            self.fail(
+                "history is shallow, so an unreachable subtree cannot be told "
+                "apart from an unfetched one; run `git fetch --unshallow`"
+            )
+
+        reachable: dict[str, set[str]] = {}
+        dangling = []
+        for summary, path, digest in self.citations:
+            if path not in reachable:
+                reachable[path] = _reachable_subtrees(path)
+            if digest not in reachable[path]:
+                dangling.append((summary, path, digest))
+
+        self.assertEqual(
+            dangling,
+            [],
+            "eval summaries cite subtrees that are not reachable from HEAD:\n"
+            + "\n".join(
+                f"  {summary}\n    {path} @ {digest}"
+                for summary, path, digest in dangling
+            )
+            + "\n\nA recorded subtree stays resolvable only while the commit "
+            "carrying it does\n(see AGENTS.md). A pull request touching "
+            "skills/*/evals/results/ merges as a\nmerge commit rather than a "
+            "squash for this reason. If one was squashed, the\nmeasured "
+            "content is gone and the remedy is to re-record against a state "
+            "that\nstill exists, saying in the summary that the original is "
+            "unrecoverable.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_eval_candidate_citations.py
+++ b/scripts/tests/test_eval_candidate_citations.py
@@ -43,8 +43,8 @@ def _citations() -> list[tuple[str, str, str]]:
     """Return (summary path, repository path, subtree hash) for every citation.
 
     A summary carrying no `trees` is not a failure. Those predate the field
-    and could not have their identity derived from a commit that still
-    resolves; `AGENTS.md` records them as branch-local and unresolvable.
+    and name no commit reachable from `HEAD`, so nothing could be derived for
+    them; `AGENTS.md` records them as branch-local and unresolvable.
     """
 
     found = []
@@ -90,6 +90,27 @@ class EvalCandidateCitationTests(unittest.TestCase):
             self.citations,
             "no summary under skills/*/evals/results/ carries "
             "candidate.trees, so the reachability check below is vacuous",
+        )
+
+    def test_no_summary_records_a_path_it_could_not_derive(self) -> None:
+        # A run that derived nothing writes no `trees` at all, which reads
+        # here exactly like a summary predating the field — so the check
+        # above would stay green over a summary carrying no citation because
+        # its derivation failed. `candidate.trees_unresolved` is what tells
+        # the two apart, and a non-empty one is a recording fault.
+        unresolved = []
+        for summary in SUMMARIES:
+            recorded = json.loads(summary.read_text(encoding="utf-8"))
+            paths = (recorded.get("candidate") or {}).get("trees_unresolved") or []
+            for path in sorted(paths):
+                unresolved.append((str(summary.relative_to(REPOSITORY_ROOT)), path))
+
+        self.assertEqual(
+            unresolved,
+            [],
+            "eval summaries name paths whose subtree could not be read at "
+            "record time, so they carry no citation for them:\n"
+            + "\n".join(f"  {summary}\n    {path}" for summary, path in unresolved),
         )
 
     def test_every_cited_subtree_is_reachable_from_head(self) -> None:

--- a/scripts/tests/test_record_eval_run.py
+++ b/scripts/tests/test_record_eval_run.py
@@ -616,7 +616,16 @@ class NormIsStatedTests(unittest.TestCase):
         agents = (REPOSITORY_ROOT / "AGENTS.md").read_text(encoding="utf-8")
 
         self.assertIn("candidate.trees", agents)
-        self.assertIn("merge commit", agents)
+        # "merge commit" alone is not enough: the changelog-backfill section
+        # already says "squash-merge commit" twice, which contains "merge
+        # commit" as a substring and would pass unconditionally. Assert the
+        # full rule instead, against whitespace-normalized text — mdformat
+        # wraps prose at 80 columns, and the phrase spans that wrapped line
+        # boundary in the committed file.
+        normalized_agents = " ".join(agents.split())
+        self.assertIn(
+            "merges as a merge commit rather than a squash", normalized_agents
+        )
         self.assertIn("skills/*/evals/results/", agents)
 
     def test_pull_request_template_points_at_the_norm(self) -> None:

--- a/scripts/tests/test_record_eval_run.py
+++ b/scripts/tests/test_record_eval_run.py
@@ -483,23 +483,32 @@ class RecorderTests(unittest.TestCase):
         (skill / "SKILL.md").write_text("prose v1\n", encoding="utf-8")
         git("add", "-A")
         git("commit", "-q", "-m", "first")
+        trunk = git("rev-parse", "--abbrev-ref", "HEAD")
+
+        # The branch under measurement changes the skill, so its recorded
+        # subtree is one only this branch carries — not the base's, which
+        # would survive anything.
+        git("checkout", "-q", "-b", "work")
+        (skill / "SKILL.md").write_text("prose v2\n", encoding="utf-8")
+        git("add", "-A")
+        git("commit", "-q", "-m", "change the skill under measurement")
 
         with mock.patch.object(record_eval_run, "REPOSITORY_ROOT", repo):
-            before = record_eval_run.candidate_identity(
-                "demo", record_eval_run.FORWARD_SUITE
-            )
+            before = record_eval_run.candidate_identity("demo", [])
 
-        # The rebase: `main` moved by changing a file outside the skill, and
-        # the branch's work is replayed on top. The skill's content is
-        # untouched; the repository's tree is not.
+        # `main` moves by changing a file outside the skill, as every rebase
+        # in this repository does, and the branch is really rebased onto it.
+        # The rebase rewrites the commit that touched the skill; the content
+        # it touched is unchanged.
+        git("checkout", "-q", trunk)
         (repo / "AGENTS.md").write_text("moved\n", encoding="utf-8")
         git("add", "-A")
         git("commit", "-q", "-m", "unrelated change on main")
+        git("checkout", "-q", "work")
+        git("rebase", trunk)
 
         with mock.patch.object(record_eval_run, "REPOSITORY_ROOT", repo):
-            after = record_eval_run.candidate_identity(
-                "demo", record_eval_run.FORWARD_SUITE
-            )
+            after = record_eval_run.candidate_identity("demo", [])
 
         self.assertNotEqual(after["sha"], before["sha"])
         self.assertNotEqual(after["tree"], before["tree"])
@@ -537,9 +546,7 @@ class RecorderTests(unittest.TestCase):
         git("commit", "-q", "-m", "first")
 
         with mock.patch.object(record_eval_run, "REPOSITORY_ROOT", repo):
-            before = record_eval_run.candidate_identity(
-                "demo", record_eval_run.FORWARD_SUITE
-            )
+            before = record_eval_run.candidate_identity("demo", [])
 
         # The squash: one brand new commit carrying the other files the pull
         # request touched, with no ancestry to the recorded commit at all.
@@ -550,9 +557,7 @@ class RecorderTests(unittest.TestCase):
         git("reset", "--hard", squashed)
 
         with mock.patch.object(record_eval_run, "REPOSITORY_ROOT", repo):
-            after = record_eval_run.candidate_identity(
-                "demo", record_eval_run.FORWARD_SUITE
-            )
+            after = record_eval_run.candidate_identity("demo", [])
 
         self.assertNotEqual(after["sha"], before["sha"])
         self.assertNotEqual(after["tree"], before["tree"])
@@ -586,10 +591,43 @@ class RecorderTests(unittest.TestCase):
 
         with mock.patch.object(record_eval_run, "REPOSITORY_ROOT", repo):
             identity = record_eval_run.candidate_identity(
-                "demo", record_eval_run.TRIGGERING_SUITE
+                "demo", [sys.executable, "triggering/runner.py", "--skill", "demo"]
             )
 
         self.assertEqual(sorted(identity["trees"]), ["skills/demo", "triggering"])
+        self.assertEqual(identity["trees_unresolved"], [])
+
+    # AC: a path whose subtree cannot be read is recorded rather than dropped.
+    # A summary that derived nothing otherwise reads exactly like one written
+    # before the field existed, and the reachability guard passes both.
+    def test_an_underivable_path_is_named_rather_than_dropped(self) -> None:
+        repo = self.root / "no-such-path-repo"
+        (repo / "skills" / "demo").mkdir(parents=True)
+
+        def git(*args: str) -> str:
+            completed = subprocess.run(
+                ["git", *args],
+                cwd=repo,
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+            return completed.stdout.strip()
+
+        git("init", "-q")
+        git("config", "user.email", "a@example.com")
+        git("config", "user.name", "a")
+        (repo / "AGENTS.md").write_text("base\n", encoding="utf-8")
+        git("add", "-A")
+        git("commit", "-q", "-m", "first")
+
+        # `skills/demo` exists in the worktree but was never committed, so
+        # `git rev-parse HEAD:skills/demo` has nothing to resolve.
+        with mock.patch.object(record_eval_run, "REPOSITORY_ROOT", repo):
+            identity = record_eval_run.candidate_identity("demo", [])
+
+        self.assertEqual(identity["trees"], {})
+        self.assertEqual(identity["trees_unresolved"], ["skills/demo"])
 
 
 class NormIsStatedTests(unittest.TestCase):
@@ -714,9 +752,7 @@ class NormIsStatedTests(unittest.TestCase):
             "run",
             return_value=subprocess.CompletedProcess([], 0, status, ""),
         ):
-            identity = record_eval_run.candidate_identity(
-                "demo", record_eval_run.FORWARD_SUITE
-            )
+            identity = record_eval_run.candidate_identity("demo", [])
 
         self.assertTrue(identity["worktree_clean"])
 
@@ -727,9 +763,7 @@ class NormIsStatedTests(unittest.TestCase):
             "run",
             return_value=subprocess.CompletedProcess([], 0, status, ""),
         ):
-            identity = record_eval_run.candidate_identity(
-                "demo", record_eval_run.FORWARD_SUITE
-            )
+            identity = record_eval_run.candidate_identity("demo", [])
 
         self.assertFalse(identity["worktree_clean"])
 
@@ -743,6 +777,21 @@ class NormIsStatedTests(unittest.TestCase):
 
         self.assertEqual(resolved["suite"], "triggering")
         self.assertIn("triggering/runner.py", " ".join(resolved["command"]))
+
+    # AC: a skill whose eval instrument lives under another skill names that
+    # skill too. `implement-epic`'s runner, executor, and corpus are all
+    # `implement-ticket`'s, so naming only `skills/implement-epic` lets two
+    # runs on different instruments carry byte-identical identity — which two
+    # committed summaries recorded on different dates already do.
+    def test_a_run_names_the_skill_whose_corpus_and_executor_it_uses(self) -> None:
+        resolved = record_eval_run.plan(
+            skill="implement-epic", tier=None, override=None, per_case=True
+        )
+
+        self.assertEqual(
+            record_eval_run.subtree_paths("implement-epic", resolved["command"]),
+            ["skills/implement-epic", "skills/implement-ticket"],
+        )
 
     def test_just_exposes_the_recorder_as_eval_record(self) -> None:
         justfile = (REPOSITORY_ROOT / "justfile").read_text(encoding="utf-8")

--- a/scripts/tests/test_record_eval_run.py
+++ b/scripts/tests/test_record_eval_run.py
@@ -456,22 +456,22 @@ class RecorderTests(unittest.TestCase):
         summary = json.loads(files[-1].read_text(encoding="utf-8"))
         self.assertIsNone(summary["compared_to"])
 
-    # AC: the recorded tree identifier still resolves to the evaluated content
-    # after the branch history that produced it is rewritten — first as a
-    # rebase would (a new parent), then as a squash-merge would (a brand new
-    # commit reusing the identical tree). `sha` cannot survive either; `tree`
-    # must survive both.
-    def test_candidate_tree_survives_rebase_and_squash(self) -> None:
+    # AC: the recorded identity still resolves to the evaluated content after
+    # a real rebase onto a moved `main` — one that changes files outside the
+    # skill, as every rebase in this repository does. `sha` cannot survive
+    # that, and neither can the whole-repository `tree`; the skill's subtree
+    # must, because unrelated files moving cannot disturb it.
+    def test_candidate_identity_survives_a_rebase_onto_a_moved_base(self) -> None:
         repo = self.root / "git-repo"
-        repo.mkdir()
+        skill = repo / "skills" / "demo"
+        skill.mkdir(parents=True)
 
-        def git(*args: str, input: str | None = None) -> str:
+        def git(*args: str) -> str:
             completed = subprocess.run(
                 ["git", *args],
                 cwd=repo,
                 text=True,
                 capture_output=True,
-                input=input,
                 check=True,
             )
             return completed.stdout.strip()
@@ -479,36 +479,117 @@ class RecorderTests(unittest.TestCase):
         git("init", "-q")
         git("config", "user.email", "a@example.com")
         git("config", "user.name", "a")
-        (repo / "file.txt").write_text("v1", encoding="utf-8")
-        git("add", "file.txt")
+        (repo / "AGENTS.md").write_text("base\n", encoding="utf-8")
+        (skill / "SKILL.md").write_text("prose v1\n", encoding="utf-8")
+        git("add", "-A")
         git("commit", "-q", "-m", "first")
 
         with mock.patch.object(record_eval_run, "REPOSITORY_ROOT", repo):
-            before_rewrite = record_eval_run.candidate_identity()
+            before = record_eval_run.candidate_identity(
+                "demo", record_eval_run.FORWARD_SUITE
+            )
 
-        original_tree = before_rewrite["tree"]
-        self.assertTrue(original_tree)
-
-        # A rebase: the same tree, a new synthetic parent.
-        empty_tree = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
-        rebase_parent = git("commit-tree", empty_tree, "-m", "rebased-onto")
-        rebased = git(
-            "commit-tree", original_tree, "-p", rebase_parent, "-m", "rebased"
-        )
-        git("reset", "--hard", rebased)
-
-        # A squash-merge on top: yet another brand new commit, still the same
-        # tree, with no ancestry relationship to the original commit at all.
-        squashed = git("commit-tree", original_tree, "-m", "squashed")
-        git("reset", "--hard", squashed)
-
-        self.assertEqual((repo / "file.txt").read_text(encoding="utf-8"), "v1")
+        # The rebase: `main` moved by changing a file outside the skill, and
+        # the branch's work is replayed on top. The skill's content is
+        # untouched; the repository's tree is not.
+        (repo / "AGENTS.md").write_text("moved\n", encoding="utf-8")
+        git("add", "-A")
+        git("commit", "-q", "-m", "unrelated change on main")
 
         with mock.patch.object(record_eval_run, "REPOSITORY_ROOT", repo):
-            after_rewrite = record_eval_run.candidate_identity()
+            after = record_eval_run.candidate_identity(
+                "demo", record_eval_run.FORWARD_SUITE
+            )
 
-        self.assertEqual(after_rewrite["tree"], original_tree)
-        self.assertNotEqual(after_rewrite["sha"], before_rewrite["sha"])
+        self.assertNotEqual(after["sha"], before["sha"])
+        self.assertNotEqual(after["tree"], before["tree"])
+        self.assertEqual(after["trees"], before["trees"])
+        self.assertEqual(sorted(before["trees"]), ["skills/demo"])
+
+    # AC: a squash-merge that keeps the measured content keeps the recorded
+    # identity with it. This is the half of the deleted test that was worth
+    # keeping — it is what makes a run recorded at the shipping head
+    # resolvable on `main` afterward, and it is the only durability the
+    # merge-method rule in `AGENTS.md` cannot supply on its own.
+    def test_candidate_identity_survives_a_squash_that_keeps_the_content(
+        self,
+    ) -> None:
+        repo = self.root / "squash-repo"
+        skill = repo / "skills" / "demo"
+        skill.mkdir(parents=True)
+
+        def git(*args: str) -> str:
+            completed = subprocess.run(
+                ["git", *args],
+                cwd=repo,
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+            return completed.stdout.strip()
+
+        git("init", "-q")
+        git("config", "user.email", "a@example.com")
+        git("config", "user.name", "a")
+        (repo / "AGENTS.md").write_text("base\n", encoding="utf-8")
+        (skill / "SKILL.md").write_text("prose v1\n", encoding="utf-8")
+        git("add", "-A")
+        git("commit", "-q", "-m", "first")
+
+        with mock.patch.object(record_eval_run, "REPOSITORY_ROOT", repo):
+            before = record_eval_run.candidate_identity(
+                "demo", record_eval_run.FORWARD_SUITE
+            )
+
+        # The squash: one brand new commit carrying the other files the pull
+        # request touched, with no ancestry to the recorded commit at all.
+        (repo / "AGENTS.md").write_text("squashed\n", encoding="utf-8")
+        git("add", "-A")
+        git("commit", "-q", "-m", "other files in the same pull request")
+        squashed = git("commit-tree", git("rev-parse", "HEAD^{tree}"), "-m", "squash")
+        git("reset", "--hard", squashed)
+
+        with mock.patch.object(record_eval_run, "REPOSITORY_ROOT", repo):
+            after = record_eval_run.candidate_identity(
+                "demo", record_eval_run.FORWARD_SUITE
+            )
+
+        self.assertNotEqual(after["sha"], before["sha"])
+        self.assertNotEqual(after["tree"], before["tree"])
+        self.assertEqual(after["trees"], before["trees"])
+
+    # AC: a triggering run's executors live in `triggering/`, outside every
+    # skill, so a summary naming only the skill would under-describe the
+    # instrument that produced it.
+    def test_triggering_run_also_names_the_triggering_executors(self) -> None:
+        repo = self.root / "triggering-repo"
+        (repo / "skills" / "demo").mkdir(parents=True)
+        (repo / "triggering").mkdir(parents=True)
+
+        def git(*args: str) -> str:
+            completed = subprocess.run(
+                ["git", *args],
+                cwd=repo,
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+            return completed.stdout.strip()
+
+        git("init", "-q")
+        git("config", "user.email", "a@example.com")
+        git("config", "user.name", "a")
+        (repo / "skills" / "demo" / "SKILL.md").write_text("p\n", encoding="utf-8")
+        (repo / "triggering" / "runner.py").write_text("r\n", encoding="utf-8")
+        git("add", "-A")
+        git("commit", "-q", "-m", "first")
+
+        with mock.patch.object(record_eval_run, "REPOSITORY_ROOT", repo):
+            identity = record_eval_run.candidate_identity(
+                "demo", record_eval_run.TRIGGERING_SUITE
+            )
+
+        self.assertEqual(sorted(identity["trees"]), ["skills/demo", "triggering"])
 
 
 class NormIsStatedTests(unittest.TestCase):
@@ -606,7 +687,9 @@ class NormIsStatedTests(unittest.TestCase):
             "run",
             return_value=subprocess.CompletedProcess([], 0, status, ""),
         ):
-            identity = record_eval_run.candidate_identity()
+            identity = record_eval_run.candidate_identity(
+                "demo", record_eval_run.FORWARD_SUITE
+            )
 
         self.assertTrue(identity["worktree_clean"])
 
@@ -617,7 +700,9 @@ class NormIsStatedTests(unittest.TestCase):
             "run",
             return_value=subprocess.CompletedProcess([], 0, status, ""),
         ):
-            identity = record_eval_run.candidate_identity()
+            identity = record_eval_run.candidate_identity(
+                "demo", record_eval_run.FORWARD_SUITE
+            )
 
         self.assertFalse(identity["worktree_clean"])
 

--- a/scripts/tests/test_record_eval_run.py
+++ b/scripts/tests/test_record_eval_run.py
@@ -601,6 +601,24 @@ class NormIsStatedTests(unittest.TestCase):
         self.assertIn("skills/<skill>/evals/results/", agents)
         self.assertIn("just eval-record", agents)
 
+    def test_agents_md_states_the_merge_method_the_evidence_depends_on(
+        self,
+    ) -> None:
+        """AC: the rule that keeps a recorded subtree resolvable is written
+        where a contributor and a merging agent both read it.
+
+        A recorded subtree resolves only while a commit carrying it stays
+        reachable, so the merge method is load-bearing rather than stylistic
+        and its failure is unrepairable. Prose that omits it leaves the guard
+        firing on `main` with nothing to point the citation at.
+        """
+
+        agents = (REPOSITORY_ROOT / "AGENTS.md").read_text(encoding="utf-8")
+
+        self.assertIn("candidate.trees", agents)
+        self.assertIn("merge commit", agents)
+        self.assertIn("skills/*/evals/results/", agents)
+
     def test_pull_request_template_points_at_the_norm(self) -> None:
         template = REPOSITORY_ROOT / ".github" / "PULL_REQUEST_TEMPLATE.md"
 

--- a/skills/babysit-pr/SKILL.md
+++ b/skills/babysit-pr/SKILL.md
@@ -395,7 +395,7 @@ feedback: 3 comments dispositioned (2 fixed, 1 rejected with evidence);
 fixes_pushed: 1 (commit 4f2c…9a1d, review-requested null check)
 mergeability: MERGEABLE / CLEAN    mutation_ownership: this task, released
 caller_owned_follow_up: merge, tracker transition, branch/worktree cleanup
-next_action: caller may merge via repository-approved squash method
+next_action: caller may merge via the repository-approved merge method
 ```
 
 A non-converged example instead reports the retained candidate:

--- a/skills/carve-changesets/evals/results/2026-08-04T224247Z-0003-before.json
+++ b/skills/carve-changesets/evals/results/2026-08-04T224247Z-0003-before.json
@@ -2,6 +2,9 @@
   "candidate": {
     "branch": "scott/131-dispatch-guidance",
     "sha": "a1ee71cc43ab04af221667a184f7dbf3edac77f1",
+    "trees": {
+      "skills/carve-changesets": "a226d3f0c6ed439b0539dfa024b4ed6f068b3f58"
+    },
     "worktree_clean": false
   },
   "cases": {

--- a/skills/carve-changesets/evals/results/2026-08-07T195757Z-0007-before.json
+++ b/skills/carve-changesets/evals/results/2026-08-07T195757Z-0007-before.json
@@ -2,6 +2,9 @@
   "candidate": {
     "branch": "scott/implement-ticket-105-4098f0",
     "sha": "da26dc3d9d90274890f86019dadff1010dfefe61",
+    "trees": {
+      "skills/carve-changesets": "f48502538338070a16171a90355cf8f16443aaa5"
+    },
     "worktree_clean": true
   },
   "case_evidence": {

--- a/skills/carve-changesets/evals/results/2026-08-07T225836Z-0009-before.json
+++ b/skills/carve-changesets/evals/results/2026-08-07T225836Z-0009-before.json
@@ -2,6 +2,9 @@
   "candidate": {
     "branch": "HEAD",
     "sha": "20d05b0d49bb1e7930024ccc720c52ed4e320111",
+    "trees": {
+      "skills/carve-changesets": "be3ab221aa185927a78a5e2816bfffa09bfe1e9f"
+    },
     "worktree_clean": true
   },
   "case_evidence": {

--- a/skills/carve-changesets/evals/results/2026-08-08T003538Z-0011-before.json
+++ b/skills/carve-changesets/evals/results/2026-08-08T003538Z-0011-before.json
@@ -2,6 +2,9 @@
   "candidate": {
     "branch": "scott/133-compaction-ledger",
     "sha": "2d5fa6041825cc5161d4300f9b3056b948bd8029",
+    "trees": {
+      "skills/carve-changesets": "111245e8780ab501e5d4af37de112da772e1a034"
+    },
     "worktree_clean": true
   },
   "case_evidence": {

--- a/skills/carve-changesets/evals/results/2026-08-15T154025Z-0014-before.json
+++ b/skills/carve-changesets/evals/results/2026-08-15T154025Z-0014-before.json
@@ -3,6 +3,9 @@
     "branch": "scott/ticket-187-shaping-doctrine",
     "sha": "cb712926c7090d12e18d180c81d219c1c03db600",
     "tree": "4595192a3d818b38e1d36f1c561223220cd2bd70",
+    "trees": {
+      "skills/carve-changesets": "56c91ccbbe65e3b677929fed5728510184225939"
+    },
     "worktree_clean": true
   },
   "case_evidence": {

--- a/skills/implement-epic/evals/results/2026-08-04T224247Z-0001-before.json
+++ b/skills/implement-epic/evals/results/2026-08-04T224247Z-0001-before.json
@@ -2,6 +2,9 @@
   "candidate": {
     "branch": "scott/131-dispatch-guidance",
     "sha": "a1ee71cc43ab04af221667a184f7dbf3edac77f1",
+    "trees": {
+      "skills/implement-epic": "561fb17539ed510947ffd199e00e08a3f597a2c2"
+    },
     "worktree_clean": false
   },
   "cases": {

--- a/skills/implement-epic/evals/results/2026-08-04T224247Z-0001-before.json
+++ b/skills/implement-epic/evals/results/2026-08-04T224247Z-0001-before.json
@@ -3,7 +3,8 @@
     "branch": "scott/131-dispatch-guidance",
     "sha": "a1ee71cc43ab04af221667a184f7dbf3edac77f1",
     "trees": {
-      "skills/implement-epic": "561fb17539ed510947ffd199e00e08a3f597a2c2"
+      "skills/implement-epic": "561fb17539ed510947ffd199e00e08a3f597a2c2",
+      "skills/implement-ticket": "0969370f3280dc3726a41805433d63331e066bbf"
     },
     "worktree_clean": false
   },

--- a/skills/implement-epic/evals/results/2026-08-04T225809Z-0003-before.json
+++ b/skills/implement-epic/evals/results/2026-08-04T225809Z-0003-before.json
@@ -3,7 +3,8 @@
     "branch": "HEAD",
     "sha": "a1ee71cc43ab04af221667a184f7dbf3edac77f1",
     "trees": {
-      "skills/implement-epic": "561fb17539ed510947ffd199e00e08a3f597a2c2"
+      "skills/implement-epic": "561fb17539ed510947ffd199e00e08a3f597a2c2",
+      "skills/implement-ticket": "0969370f3280dc3726a41805433d63331e066bbf"
     },
     "worktree_clean": true
   },

--- a/skills/implement-epic/evals/results/2026-08-04T225809Z-0003-before.json
+++ b/skills/implement-epic/evals/results/2026-08-04T225809Z-0003-before.json
@@ -2,6 +2,9 @@
   "candidate": {
     "branch": "HEAD",
     "sha": "a1ee71cc43ab04af221667a184f7dbf3edac77f1",
+    "trees": {
+      "skills/implement-epic": "561fb17539ed510947ffd199e00e08a3f597a2c2"
+    },
     "worktree_clean": true
   },
   "cases": {

--- a/skills/implement-epic/evals/results/2026-08-08T004209Z-0012-before.json
+++ b/skills/implement-epic/evals/results/2026-08-08T004209Z-0012-before.json
@@ -3,7 +3,8 @@
     "branch": "scott/133-compaction-ledger",
     "sha": "2d5fa6041825cc5161d4300f9b3056b948bd8029",
     "trees": {
-      "skills/implement-epic": "331d434f037ee7659a8e6ef15ebfa38d0758b0c7"
+      "skills/implement-epic": "331d434f037ee7659a8e6ef15ebfa38d0758b0c7",
+      "skills/implement-ticket": "d04ba5681c59f217a12115339a6fae3ccd17af65"
     },
     "worktree_clean": true
   },

--- a/skills/implement-epic/evals/results/2026-08-08T004209Z-0012-before.json
+++ b/skills/implement-epic/evals/results/2026-08-08T004209Z-0012-before.json
@@ -2,6 +2,9 @@
   "candidate": {
     "branch": "scott/133-compaction-ledger",
     "sha": "2d5fa6041825cc5161d4300f9b3056b948bd8029",
+    "trees": {
+      "skills/implement-epic": "331d434f037ee7659a8e6ef15ebfa38d0758b0c7"
+    },
     "worktree_clean": true
   },
   "case_evidence": {

--- a/skills/implement-ticket/evals/results/2026-08-04T175754Z-0003-baseline.json
+++ b/skills/implement-ticket/evals/results/2026-08-04T175754Z-0003-baseline.json
@@ -2,6 +2,9 @@
   "candidate": {
     "branch": "scott/145-real-model-baseline",
     "sha": "67ff0dbce8c534bcf82bde033f5534bb3f2db265",
+    "trees": {
+      "skills/implement-ticket": "a8088d3f89e0ccd770aae53150530940823b6c45"
+    },
     "worktree_clean": true
   },
   "cases": {

--- a/skills/implement-ticket/evals/results/2026-08-04T223733Z-0008-before.json
+++ b/skills/implement-ticket/evals/results/2026-08-04T223733Z-0008-before.json
@@ -2,6 +2,9 @@
   "candidate": {
     "branch": "scott/131-dispatch-guidance",
     "sha": "a1ee71cc43ab04af221667a184f7dbf3edac77f1",
+    "trees": {
+      "skills/implement-ticket": "0969370f3280dc3726a41805433d63331e066bbf"
+    },
     "worktree_clean": true
   },
   "cases": {},

--- a/skills/implement-ticket/evals/results/2026-08-04T224246Z-0009-before.json
+++ b/skills/implement-ticket/evals/results/2026-08-04T224246Z-0009-before.json
@@ -2,6 +2,9 @@
   "candidate": {
     "branch": "scott/131-dispatch-guidance",
     "sha": "a1ee71cc43ab04af221667a184f7dbf3edac77f1",
+    "trees": {
+      "skills/implement-ticket": "0969370f3280dc3726a41805433d63331e066bbf"
+    },
     "worktree_clean": false
   },
   "cases": {

--- a/skills/implement-ticket/evals/results/2026-08-05T070156Z-0014-before.json
+++ b/skills/implement-ticket/evals/results/2026-08-05T070156Z-0014-before.json
@@ -2,6 +2,9 @@
   "candidate": {
     "branch": "HEAD",
     "sha": "bb31f34d3d311ca5b1fd44c09ba57826de36f91d",
+    "trees": {
+      "skills/implement-ticket": "42075c533b0cd26428e7759b8d26d41988eefe4e"
+    },
     "worktree_clean": true
   },
   "case_evidence": {

--- a/skills/implement-ticket/evals/results/2026-08-06T123730Z-0020-before.json
+++ b/skills/implement-ticket/evals/results/2026-08-06T123730Z-0020-before.json
@@ -2,6 +2,9 @@
   "candidate": {
     "branch": "scott/ticket-103-implementation-981639",
     "sha": "8566327841d7d9d4b481367d4da6316ff2120ba0",
+    "trees": {
+      "skills/implement-ticket": "e3426dc8f455c3db220fd07364ed22e28650d540"
+    },
     "worktree_clean": true
   },
   "case_evidence": {

--- a/skills/implement-ticket/evals/results/2026-08-07T231926Z-0022-before.json
+++ b/skills/implement-ticket/evals/results/2026-08-07T231926Z-0022-before.json
@@ -2,6 +2,9 @@
   "candidate": {
     "branch": "HEAD",
     "sha": "20d05b0d49bb1e7930024ccc720c52ed4e320111",
+    "trees": {
+      "skills/implement-ticket": "5d7c435553dda5ed0dfa77a52ee59c4bdbda7be8"
+    },
     "worktree_clean": true
   },
   "case_evidence": {

--- a/skills/implement-ticket/evals/results/2026-08-08T200851Z-0024-before.json
+++ b/skills/implement-ticket/evals/results/2026-08-08T200851Z-0024-before.json
@@ -2,6 +2,9 @@
   "candidate": {
     "branch": "scott/134-worktree-isolation",
     "sha": "bb02ae01d16faa9fde1f40407ae77db2096de633",
+    "trees": {
+      "skills/implement-ticket": "d04ba5681c59f217a12115339a6fae3ccd17af65"
+    },
     "worktree_clean": true
   },
   "case_evidence": {

--- a/skills/implement-ticket/evals/results/2026-08-13T175223Z-0026-before.json
+++ b/skills/implement-ticket/evals/results/2026-08-13T175223Z-0026-before.json
@@ -3,6 +3,9 @@
     "branch": "HEAD",
     "sha": "42b52102530563ead17a1c17db227f32d50954f7",
     "tree": "ad0c07530ed66a58c5af7581675d725f44193eee",
+    "trees": {
+      "skills/implement-ticket": "402e915c924f85b7bf27a39e1aceebf67630b247"
+    },
     "worktree_clean": true
   },
   "case_evidence": {

--- a/skills/ready-ticket/evals/results/2026-08-15T173118Z-0003-before.json
+++ b/skills/ready-ticket/evals/results/2026-08-15T173118Z-0003-before.json
@@ -3,6 +3,9 @@
     "branch": "scott/ticket-197-975284",
     "sha": "1ce41875782ac2a8de04b70d39619493e919d1d5",
     "tree": "ed225d3a4d9022de7332b8798bc8ddec3297f992",
+    "trees": {
+      "skills/ready-ticket": "55f5500260ace2eaaba1f0dc231d905646570da4"
+    },
     "worktree_clean": true
   },
   "case_evidence": {

--- a/skills/ready-ticket/evals/results/2026-08-15T221346Z-0007-before.json
+++ b/skills/ready-ticket/evals/results/2026-08-15T221346Z-0007-before.json
@@ -3,6 +3,9 @@
     "branch": "scott/ticket-233-67b04e",
     "sha": "5bd36f550cd7c55251e47c947c102788a13e049b",
     "tree": "5c2179c31b40036759439e030afc4f3101f1a645",
+    "trees": {
+      "skills/ready-ticket": "94f2d6a8b3fdc5d8bed11f3a268854a7fdea2fa7"
+    },
     "worktree_clean": true
   },
   "case_evidence": {

--- a/skills/ready-ticket/evals/results/2026-08-15T224321Z-0008-after.json
+++ b/skills/ready-ticket/evals/results/2026-08-15T224321Z-0008-after.json
@@ -3,6 +3,9 @@
     "branch": "scott/ticket-233-67b04e",
     "sha": "94b9ae8ce43322a97c510c7f0c4ff16da586ad6d",
     "tree": "4e5fc9a7c951a6f287dadbf6378fea9ff6781bf6",
+    "trees": {
+      "skills/ready-ticket": "95d779854dc10bc5264c4707fc9fd40f8da289d1"
+    },
     "worktree_clean": true
   },
   "case_evidence": {

--- a/skills/ready-ticket/evals/results/2026-08-15T235404Z-0009-after-at-shipping-head.json
+++ b/skills/ready-ticket/evals/results/2026-08-15T235404Z-0009-after-at-shipping-head.json
@@ -3,6 +3,9 @@
     "branch": "scott/ticket-233-67b04e",
     "sha": "75cf01e09e740f7321f3a80f433951a7840b8065",
     "tree": "5ff3c3f5a347be232ba178e9669cfc1617360925",
+    "trees": {
+      "skills/ready-ticket": "5e4e7f7eecedf00c6f778cc9bcc31116858e05bd"
+    },
     "worktree_clean": true
   },
   "case_evidence": {

--- a/skills/review-fix-loop/evals/results/2026-08-04T224311Z-0001-before.json
+++ b/skills/review-fix-loop/evals/results/2026-08-04T224311Z-0001-before.json
@@ -2,6 +2,9 @@
   "candidate": {
     "branch": "scott/131-dispatch-guidance",
     "sha": "a1ee71cc43ab04af221667a184f7dbf3edac77f1",
+    "trees": {
+      "skills/review-fix-loop": "54d9a547d74cee845ab6e8cfc3f4bfa0d7d14993"
+    },
     "worktree_clean": false
   },
   "cases": {

--- a/skills/review-solution-simplicity/evals/results/2026-08-13T205155Z-0002-before-triggering.json
+++ b/skills/review-solution-simplicity/evals/results/2026-08-13T205155Z-0002-before-triggering.json
@@ -3,6 +3,10 @@
     "branch": "scott/ticket-188-319c64",
     "sha": "5405aab218db0f7e519667440392be33063a0ea5",
     "tree": "232dec6de8c4d803cbccbbc0602c53bb063b54cd",
+    "trees": {
+      "skills/review-solution-simplicity": "96f6b0187b2abc51424ac184eb5f9b5e0804bc87",
+      "triggering": "96797e1025c479cb9d38670109f69937dd59b499"
+    },
     "worktree_clean": true
   },
   "case_evidence": {

--- a/skills/review-solution-simplicity/evals/results/2026-08-14T000831Z-0002-before-s2-stratum.json
+++ b/skills/review-solution-simplicity/evals/results/2026-08-14T000831Z-0002-before-s2-stratum.json
@@ -3,6 +3,9 @@
     "branch": "HEAD",
     "sha": "5405aab218db0f7e519667440392be33063a0ea5",
     "tree": "232dec6de8c4d803cbccbbc0602c53bb063b54cd",
+    "trees": {
+      "skills/review-solution-simplicity": "96f6b0187b2abc51424ac184eb5f9b5e0804bc87"
+    },
     "worktree_clean": true
   },
   "case_evidence": {},


### PR DESCRIPTION
## Summary

- Record `candidate.trees` in every eval summary — a map from repository path to
  that path's subtree hash, derived from the run's own resolved command, so a
  run whose instrument lives elsewhere says so
- Backfill it into the 23 summaries whose recorded `sha` is still reachable, and
  leave the other 59 without it
- Add `scripts/tests/test_eval_candidate_citations.py`, which fails when a
  recorded subtree names content unreachable from `HEAD`
- Correct `AGENTS.md`, which claimed `candidate.tree` outlives `candidate.sha`,
  and make merge-commit the repository's merge method

## Why

This is the failure #236 repaired in `CHANGELOG.md`, present again in the eval
summaries and worse. `AGENTS.md` told a reader to trust `candidate.tree` over
`candidate.sha`, on the grounds that content is identical under rebase and
squash where a commit is not. It is not: `tree` is
`git rev-parse HEAD^{tree}`, the whole repository's, so a rebase onto a moved
`main` changes it through files outside the skill entirely.

59 of the 82 summaries already named a `sha` unreachable from `HEAD`, against 68
of 248 changelog citations before that repair. The loss is not spread evenly —
45 of 47 `after`-stage runs are gone, while 20 of 21 `before`-stage runs survive
only by accident, having been recorded at an untouched branch point that was
already a commit on `main`. The run that says how the shipped prose behaves is
the one this repository has lost every time.

Recording the skill's subtree instead of the repository's is necessary and not
sufficient. Verified against `scott/ticket-234-09af55`, five of five subtrees
survive the rebase that took all five commits — but simulating that branch's
squash-merge, none survives, with or without `evals/results/` excluded from the
hash. A `before` run measures a new corpus against old prose and a superseded
`after` run measures prose a later commit changed; neither state is on any
commit a squash keeps. Eval evidence is the one artifact class here whose value
depends on intermediate branch states staying resolvable, so the merge method is
the repair and the subtree only protects identity until the merge.

## The merge method

**This pull request must land as a merge commit.** It modifies 24 files under
`skills/*/evals/results/`, so squashing it would be the first violation of the
rule it installs, and the new guard would then fire on `main` with nothing to
point at. Squash merging is now disabled on the repository, so this is enforced
rather than remembered.

The rule is unconditional rather than scoped to eval-carrying pull requests
because a conditional one cannot be configured — GitHub's merge method is a
repository setting, not a per-pull-request one, so the conditional form would
rest entirely on whoever clicks merge classifying correctly every time, with no
mechanism catching a miss and no repair once missed. Since evals first landed,
20 of 46 commits on `main` touched `evals/results/`, so the classification would
have been live on nearly half of them.

Rebase merging is deliberately left enabled: it replays every commit rather than
collapsing them, so each intermediate subtree still lands. Verified in a scratch
repository rather than assumed.

## Evidence

`just format`, `just lint`, and `just test` pass — 1323 tests across 14 suites.

Both guards were verified capable of failing rather than trusted because they
are green. The reachability guard was mutated to cite a hash naming nothing and
turned red on the exact file and path; its anti-vacuity test was run against an
empty summary set and failed with its stated message. The rewritten rebase test
was checked against a mutant implementation keyed to "the last commit touching
each path" — the old test body passes that mutant, the rewrite kills it.

Every one of the 23 backfilled summaries was independently re-derived from its
own recorded `sha` during review rather than taken from the migration's report.

The final whole-branch review found two Important defects that four task-level
reviews had passed over, both the same species this change exists to fix.
`AGENTS.md` simultaneously asserted and denied that `sha` resolves — the
clean-tree rule still justified itself with the false claim. And
`candidate.trees` under-described `implement-epic`, whose runner, executor, and
corpus all live under `skills/implement-ticket/`: two of its three summaries
share a tree hash across different recording dates, so the instrument could have
changed underneath a re-recording invisibly. Both are fixed in `4c2dacb`, the
second generally — paths now come from the run's own command, with no
`implement-epic` special case.

## What this does not repair

59 summaries remain unresolvable. Unlike #236's citations, which were
recoverable because the history they should have named was still on `main`, the
content these measured exists in no clone but their author's. They are recorded
as branch-local and unresolvable rather than repaired, the treatment `AGENTS.md`
already gives summaries predating the `model` field.

## Deferred, not blocking

- `scripts/tests/test_record_eval_run.py` asserts `skills/*/evals/results/`
  appears in `AGENTS.md`. That glob now survives only in the paragraph
  explaining why the *conditional* rule was rejected, so tidying that rationale
  would fail a test whose stated subject is unaffected.
- `scripts/record_eval_run.py:434`'s `shlex.split` can raise on a token carrying
  an unbalanced quote in a hand-crafted `--executor` override. Pre-existing
  exposure, mirroring `model_for` at line 232.

______________________________________________________________________

No skill's normative prose changes, so the eval-evidence norm does not apply.
`AGENTS.md` is repository prose rather than a skill's, and the one
`skills/babysit-pr/SKILL.md` edit is an example output block brought into line
with the obligation its own line 357 already carried — it alters no obligation.
