### PR TITLE
docs: restate the citation guard's own account of the backfill rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ summary: Chronological history of repository and skill changes.
   branch's own run — it is only the squash-merged history behind that where the
   check was inherently late, because those citations died at the merge instead.
   The failure message names the same mechanism. No assertion, regex, or check
-  changes. The seven entries #238 and #243 landed without SHAs are backfilled to
+  changes. The eight entries #238 and #243 landed without SHAs are backfilled to
   their authoring commits, which is what the rule now names and what the guard
   confirms is reachable.
 
@@ -114,9 +114,10 @@ summary: Chronological history of repository and skill changes.
   tree, which is the one thing a real rebase never is; it now models a base that
   moved, and fails against the old behavior.
 
-- docs: design the eval candidate's durable identity — `AGENTS.md` tells a
-  reader to trust `candidate.tree` over `candidate.sha`, on the grounds that
-  content is identical under rebase and squash where a commit is not. It is not:
+- docs: design the eval candidate's durable identity
+  (5070c687497996fc179af24113126d3edd9f2177) — `AGENTS.md` tells a reader to
+  trust `candidate.tree` over `candidate.sha`, on the grounds that content is
+  identical under rebase and squash where a commit is not. It is not:
   `candidate.tree` is `git rev-parse HEAD^{tree}`, the whole-repository tree, so
   a rebase onto a moved `main` changes it through files outside the skill
   entirely. 59 of the repository's 82 summaries already name an unreachable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,16 +79,17 @@ summary: Chronological history of repository and skill changes.
   by construction. `babysit-pr`'s example output block is brought into line with
   the obligation its own prose already carried.
 
-- test(evals): hold every recorded subtree to reachability from `HEAD` —
+- test(evals): hold every recorded subtree to reachability from `HEAD`
+  (bc245d42e41d0023a73b71a2c1228abfeb1a599d) —
   `scripts/tests/test_eval_candidate_citations.py` fails when a summary's
   `candidate.trees` names content no commit reachable from `HEAD` carries, which
   is the same silent rot `scripts/tests/test_changelog_citations.py` catches for
   the changelog: a hash resolving to nothing reads exactly like one that
   resolves. Unlike its sibling it needs no unlanded-branch exemption, because a
   subtree recorded on an open branch stays reachable from that branch's own
-  history across a rebase. A summary carrying no `trees` passes
-  (bc245d42e41d0023a73b71a2c1228abfeb1a599d) — those predate the field and are
-  recorded as unresolvable rather than pretended into evidence.
+  history across a rebase. A summary carrying no `trees` passes — those predate
+  the field and are recorded as unresolvable rather than pretended into
+  evidence.
 
 - fix(evals): derive the durable identity of every summary that still names a
   reachable commit (3147edf22d662c84b08930cd0e32b732d4147dea) — 23 of the 82
@@ -102,17 +103,17 @@ summary: Chronological history of repository and skill changes.
   measured content that no longer exists in any clone but its author's; unlike
   the changelog's citations, there is nothing left to recover.
 
-- feat(evals): record the subtree identity that survives a rebase —
-  `candidate.tree` was `git rev-parse HEAD^{tree}`, the whole repository's, so a
-  rebase onto a moved `main` changed it through files outside the skill and the
-  recorded identity resolved to nothing. `candidate.trees` now maps each path
-  whose content decided what the run read
-  (8f52f24450c27bd0a29c85d2812000e4b73f05fa) — `skills/<skill>` always, and
-  `triggering` as well for a triggering-suite run, whose executors live outside
-  every skill — to that path's subtree hash. The test that had asserted the old
-  claim passed only by simulating a rebase as a new parent over an identical
-  tree, which is the one thing a real rebase never is; it now models a base that
-  moved, and fails against the old behavior.
+- feat(evals): record the subtree identity that survives a rebase
+  (8f52f24450c27bd0a29c85d2812000e4b73f05fa) — `candidate.tree` was
+  `git rev-parse HEAD^{tree}`, the whole repository's, so a rebase onto a moved
+  `main` changed it through files outside the skill and the recorded identity
+  resolved to nothing. `candidate.trees` now maps each path whose content
+  decided what the run read — `skills/<skill>` always, and `triggering` as well
+  for a triggering-suite run, whose executors live outside every skill — to that
+  path's subtree hash. The test that had asserted the old claim passed only by
+  simulating a rebase as a new parent over an identical tree, which is the one
+  thing a real rebase never is; it now models a base that moved, and fails
+  against the old behavior.
 
 - docs: design the eval candidate's durable identity
   (5070c687497996fc179af24113126d3edd9f2177) — `AGENTS.md` tells a reader to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,60 +4,80 @@ summary: Chronological history of repository and skill changes.
 
 # Changelog
 
-## 2026-08-16 — Made a ticket's stated assumptions answer for themselves at pickup, hardened the harness that measured it, and designed one owner for the policy that grades it
+## 2026-08-16 — Made a ticket's stated assumptions answer for themselves at pickup, hardened the harness that measured it, designed one owner for the policy that grades it, and brought the citation guard's own prose in line with the merge method
+
+- docs: restate the citation guard's own account of the backfill rule — the
+  merge-method change above left `scripts/tests/test_changelog_citations.py`
+  describing `main` as "almost entirely squash-merged" and naming the squash as
+  the only thing that makes a backfilled SHA unreachable, stale prose in the one
+  module that enforces the rule. Its docstring now records the squash rot as the
+  history it was written for, says that a merge commit preserves the authoring
+  commit an entry cites, and corrects what the old text had backwards once the
+  mechanism changed: when the guard actually fires. A SHA backfilled before
+  submission goes unreachable at the rebase onto `main` that precedes
+  submission, so `git rev-list HEAD` membership reddens on the authoring
+  branch's own run — it is only the squash-merged history behind that where the
+  check was inherently late, because those citations died at the merge instead.
+  The failure message names the same mechanism. No assertion, regex, or check
+  changes. The seven entries #238 and #243 landed without SHAs are backfilled to
+  their authoring commits, which is what the rule now names and what the guard
+  confirms is reachable.
 
 - fix(evals): name every path a run was measured through, and stop claiming
-  `sha` resolves — `subtree_paths` named `skills/<skill>` and, for a triggering
-  run, `triggering`, which under-describes any skill whose eval instrument lives
-  elsewhere. `implement-epic` is measured entirely through
-  `skills/implement-ticket`'s runner, executor, and corpus, so its corpus could
-  change, an `implement-epic` run be re-recorded, and the new summary's
-  `candidate.trees` come out byte-identical to the old — two runs on different
-  instruments with one recorded identity, which two committed summaries taken on
-  different dates already share. The paths are now derived from the run's own
-  resolved command, so a target self-describes and no hand-maintained mapping
-  can drift; the three affected backfilled summaries gain
-  `skills/implement-ticket`, derived from the commit each already names. A path
-  whose subtree cannot be read is recorded under `candidate.trees_unresolved`
-  rather than dropped, since a run that derived nothing otherwise reads exactly
-  like a summary predating the field and the reachability guard passes both. The
-  prose is corrected where it still asserted what this branch had just
-  disproved: the clean-tree rule kept its requirement but was resting on
-  `candidate.sha` resolving, the grandfathered 59 were said to name commits that
-  no longer resolve when the criterion applied was reachability from `HEAD`, and
-  the rebase-safety claim omitted the exception its own guard names — a rebase
-  resolving conflicts inside the skill directory. The rebase test now performs a
-  real rebase rather than committing an unrelated change on top, which proved
-  only that an untouched subtree survives an unrelated commit.
+  `sha` resolves (4c2dacb7ebeacc79f613c16b04c23775565c6ee6) — `subtree_paths`
+  named `skills/<skill>` and, for a triggering run, `triggering`, which
+  under-describes any skill whose eval instrument lives elsewhere.
+  `implement-epic` is measured entirely through `skills/implement-ticket`'s
+  runner, executor, and corpus, so its corpus could change, an `implement-epic`
+  run be re-recorded, and the new summary's `candidate.trees` come out
+  byte-identical to the old — two runs on different instruments with one
+  recorded identity, which two committed summaries taken on different dates
+  already share. The paths are now derived from the run's own resolved command,
+  so a target self-describes and no hand-maintained mapping can drift; the three
+  affected backfilled summaries gain `skills/implement-ticket`, derived from the
+  commit each already names. A path whose subtree cannot be read is recorded
+  under `candidate.trees_unresolved` rather than dropped, since a run that
+  derived nothing otherwise reads exactly like a summary predating the field and
+  the reachability guard passes both. The prose is corrected where it still
+  asserted what this branch had just disproved: the clean-tree rule kept its
+  requirement but was resting on `candidate.sha` resolving, the grandfathered 59
+  were said to name commits that no longer resolve when the criterion applied
+  was reachability from `HEAD`, and the rebase-safety claim omitted the
+  exception its own guard names — a rebase resolving conflicts inside the skill
+  directory. The rebase test now performs a real rebase rather than committing
+  an unrelated change on top, which proved only that an untouched subtree
+  survives an unrelated commit.
 
 - docs: make merge-commit the repository's merge method, not a rule about one
-  directory — the eval-evidence rule this replaces was conditional, applying to
-  pull requests that touch `skills/*/evals/results/`, and a conditional merge
-  method is one nothing can enforce. GitHub's merge method is a repository
-  setting rather than a per-pull-request one, so the conditional form rested
-  entirely on whoever clicked merge classifying the pull request correctly every
-  time, with no mechanism to catch a miss and no repair once missed. Since evals
-  first landed, 20 of 46 commits on `main` touched `evals/results/`, so the
-  classification would have been live on nearly half of them. The two failures
-  are not comparable either: squashing an eval-carrying pull request loses the
-  measured content permanently, while merge-committing one that carries none
-  costs a non-linear history `git log --first-parent` reads straight through.
-  The changelog's own backfill convention is updated to match — under a merge
-  commit the authoring commit is the landing commit, so new entries normally
-  cite distinct SHAs rather than sharing one, though the squash-merged history
-  behind this change still behaves the old way.
+  directory (bf30d2a650899bc69182c2d468ac6af8a75ba83c) — the eval-evidence rule
+  this replaces was conditional, applying to pull requests that touch
+  `skills/*/evals/results/`, and a conditional merge method is one nothing can
+  enforce. GitHub's merge method is a repository setting rather than a
+  per-pull-request one, so the conditional form rested entirely on whoever
+  clicked merge classifying the pull request correctly every time, with no
+  mechanism to catch a miss and no repair once missed. Since evals first landed,
+  20 of 46 commits on `main` touched `evals/results/`, so the classification
+  would have been live on nearly half of them. The two failures are not
+  comparable either: squashing an eval-carrying pull request loses the measured
+  content permanently, while merge-committing one that carries none costs a
+  non-linear history `git log --first-parent` reads straight through. The
+  changelog's own backfill convention is updated to match — under a merge commit
+  the authoring commit is the landing commit, so new entries normally cite
+  distinct SHAs rather than sharing one, though the squash-merged history behind
+  this change still behaves the old way.
 
 - docs: state the merge method the eval evidence depends on, and correct what
-  `AGENTS.md` claims survives — the file told a reader to trust `candidate.tree`
-  over `candidate.sha` on the grounds that content is identical under rebase and
-  squash where a commit is not. It is not: `tree` is the whole repository's, so
-  a rebase onto a moved `main` changes it through files outside the skill. Both
-  are now stated as branch-local, `candidate.trees` is named as the durable
-  half, and the rule that makes it durable is written down — a pull request
-  touching `skills/*/evals/results/` merges as a merge commit, because a squash
-  keeps one tree per pull request while the states eval evidence measures are
-  intermediate by construction. `babysit-pr`'s example output block is brought
-  into line with the obligation its own prose already carried.
+  `AGENTS.md` claims survives (c257f8b19cd69c5099472af201ef4d23e74a218c) — the
+  file told a reader to trust `candidate.tree` over `candidate.sha` on the
+  grounds that content is identical under rebase and squash where a commit is
+  not. It is not: `tree` is the whole repository's, so a rebase onto a moved
+  `main` changes it through files outside the skill. Both are now stated as
+  branch-local, `candidate.trees` is named as the durable half, and the rule
+  that makes it durable is written down — a pull request touching
+  `skills/*/evals/results/` merges as a merge commit, because a squash keeps one
+  tree per pull request while the states eval evidence measures are intermediate
+  by construction. `babysit-pr`'s example output block is brought into line with
+  the obligation its own prose already carried.
 
 - test(evals): hold every recorded subtree to reachability from `HEAD` —
   `scripts/tests/test_eval_candidate_citations.py` fails when a summary's
@@ -66,27 +86,28 @@ summary: Chronological history of repository and skill changes.
   the changelog: a hash resolving to nothing reads exactly like one that
   resolves. Unlike its sibling it needs no unlanded-branch exemption, because a
   subtree recorded on an open branch stays reachable from that branch's own
-  history across a rebase. A summary carrying no `trees` passes — those predate
-  the field and are recorded as unresolvable rather than pretended into
-  evidence.
+  history across a rebase. A summary carrying no `trees` passes
+  (bc245d42e41d0023a73b71a2c1228abfeb1a599d) — those predate the field and are
+  recorded as unresolvable rather than pretended into evidence.
 
 - fix(evals): derive the durable identity of every summary that still names a
-  reachable commit — 23 of the 82 summaries gain `candidate.trees` computed from
-  the commit each already carries, and the other 59 keep none. The derivation
-  asserts nothing the recorder did not hold:
-  `git rev-parse <recorded sha>:<path>` could not have come out differently had
-  the field existed when the summary was written, which is what separates it
-  from backfilling a landing commit — a fact decided after the run by a merge
-  that had not happened yet. One of the 23 is a triggering-suite run and needs
-  both its skill path and `triggering`. The 59 measured content that no longer
-  exists in any clone but its author's; unlike the changelog's citations, there
-  is nothing left to recover.
+  reachable commit (3147edf22d662c84b08930cd0e32b732d4147dea) — 23 of the 82
+  summaries gain `candidate.trees` computed from the commit each already
+  carries, and the other 59 keep none. The derivation asserts nothing the
+  recorder did not hold: `git rev-parse <recorded sha>:<path>` could not have
+  come out differently had the field existed when the summary was written, which
+  is what separates it from backfilling a landing commit — a fact decided after
+  the run by a merge that had not happened yet. One of the 23 is a
+  triggering-suite run and needs both its skill path and `triggering`. The 59
+  measured content that no longer exists in any clone but its author's; unlike
+  the changelog's citations, there is nothing left to recover.
 
 - feat(evals): record the subtree identity that survives a rebase —
   `candidate.tree` was `git rev-parse HEAD^{tree}`, the whole repository's, so a
   rebase onto a moved `main` changed it through files outside the skill and the
   recorded identity resolved to nothing. `candidate.trees` now maps each path
-  whose content decided what the run read — `skills/<skill>` always, and
+  whose content decided what the run read
+  (8f52f24450c27bd0a29c85d2812000e4b73f05fa) — `skills/<skill>` always, and
   `triggering` as well for a triggering-suite run, whose executors live outside
   every skill — to that path's subtree hash. The test that had asserted the old
   claim passed only by simulating a rebase as a new parent over an identical
@@ -118,24 +139,24 @@ summary: Chronological history of repository and skill changes.
   grandfathered: unlike the changelog's citations, the content they measured no
   longer exists to be recovered.
 
-- docs: design one owner for the eval sampling policy — the
-  repetition-and-majority-vote policy that turns repeated `claude -p` samples
-  into one graded answer exists in three independently maintained copies, and
-  they have drifted past features into results. `implement-ticket` breaks a tie
-  through `_modal`'s `min()` over the sorted candidates; `ready-ticket` uses
-  `Counter.most_common(1)[0]`, whose tie order follows insertion. On a 2–2 tie
-  the two record different answers, and `ready-ticket` records a different
-  answer again depending on which sample was drawn first — a silent difference
-  in recorded evidence rather than a missing feature. The design gives the
-  policy a canonical `sampling/core.py` at the root, in the transport, drawing,
-  and vote layers its four consumers need at different depths, distributed by
-  the `sync-contracts` mirror-and-drift-test pattern this repository already
-  uses for the review-suite contracts, the shaping doctrine, and
-  `ledger/core.py`. Only the two skills take a bundled copy, because only a
-  skill folder is a standalone distribution unit; `triggering/` and
-  `review-suite/` import the canonical and so cannot drift at all. Because
-  converging the tie-break changes the grader, a run also records the
-  `POLICY_VERSION` it was graded under, and a diff is drawn only when tier,
+- docs: design one owner for the eval sampling policy
+  (8661eb3488d6df16837b57b6b9a793a5ea41f0d3) — the repetition-and-majority-vote
+  policy that turns repeated `claude -p` samples into one graded answer exists
+  in three independently maintained copies, and they have drifted past features
+  into results. `implement-ticket` breaks a tie through `_modal`'s `min()` over
+  the sorted candidates; `ready-ticket` uses `Counter.most_common(1)[0]`, whose
+  tie order follows insertion. On a 2–2 tie the two record different answers,
+  and `ready-ticket` records a different answer again depending on which sample
+  was drawn first — a silent difference in recorded evidence rather than a
+  missing feature. The design gives the policy a canonical `sampling/core.py` at
+  the root, in the transport, drawing, and vote layers its four consumers need
+  at different depths, distributed by the `sync-contracts` mirror-and-drift-test
+  pattern this repository already uses for the review-suite contracts, the
+  shaping doctrine, and `ledger/core.py`. Only the two skills take a bundled
+  copy, because only a skill folder is a standalone distribution unit;
+  `triggering/` and `review-suite/` import the canonical and so cannot drift at
+  all. Because converging the tie-break changes the grader, a run also records
+  the `POLICY_VERSION` it was graded under, and a diff is drawn only when tier,
   suite, model, and policy all match — extending to a fourth field the rule that
   already keeps a model update from reading as behavioral movement. Deferred
   from #237's review as reaching beyond `skills/implement-ticket/`.

--- a/scripts/tests/test_changelog_citations.py
+++ b/scripts/tests/test_changelog_citations.py
@@ -5,18 +5,25 @@ narrative entry to the history that produced it, and its failure mode is
 silent: a citation that resolves to nothing reads exactly like one that
 resolves, so nobody discovers the rot until they try to follow it.
 
-`main` is almost entirely squash-merged. A pull request contributing several
-entries collapses to one commit, and every authoring SHA those entries had
-backfilled is discarded by the squash — which is how 68 of this file's 248
-citations came to point at nothing at once. `AGENTS.md` now requires a
-backfilled SHA to name the commit that carried the entry onto `main`, and this
-module is what holds the file to it.
+The rot this module was written for arrived through squash-merges: `main` was
+squash-merged for most of this file's history, so a pull request contributing
+several entries collapsed to one commit and every authoring SHA those entries
+had backfilled was discarded at once — which is how 68 of the 248 citations
+came to point at nothing. Squash merging is off now, and a merge commit
+preserves the authoring commits it carries, so a landed authoring commit is
+itself the SHA its entry cites. `AGENTS.md` requires a backfilled SHA to name
+the commit that carried the entry onto `main`, and this module is what holds
+the file to it.
 
-The check is reachability from `HEAD`, so it turns red on the first change
-made after a doomed citation lands rather than on the branch that wrote it: on
-its own branch an unlanded authoring commit is still reachable, and only the
-squash makes it unreachable. `AGENTS.md` closes that window from the other
-side by requiring a SHA to be backfilled only once its entry has landed.
+When the guard fires depends on which mechanism invalidated the SHA. The check
+is `git rev-list HEAD` membership, so a citation backfilled before its branch
+was submitted reddens on that same branch: submitting rebases onto `main`
+first, and a rebased `HEAD` no longer reaches the commit it replaced. It is the
+squash-merged history behind that where the check is inherently late — those
+citations stayed reachable on their own branch and died only at the merge, so
+nothing turned red until the first change made after they had landed.
+`AGENTS.md` closes the window from the other side by requiring a SHA to be
+backfilled only once its entry has landed.
 """
 
 from __future__ import annotations
@@ -99,9 +106,9 @@ class ChangelogCitationTests(unittest.TestCase):
                 for sha, line, title in dangling
             )
             + "\n\nA backfilled SHA names the commit that carried the entry onto "
-            "`main`\n(see AGENTS.md). Squash-merge discards the authoring commit, "
-            "so citing\nit leaves a citation resolving to nothing. Recover the "
-            "landing commit with:\n"
+            "`main`\n(see AGENTS.md). A SHA taken before the branch was rebased "
+            "and landed\nnames a commit no ref reaches. Recover the landing "
+            "commit with:\n"
             "  git log main --format='%H %s' -S'<the entry's first line>' -- "
             "CHANGELOG.md\nand take the last line, which is the commit that "
             "introduced that entry.",


### PR DESCRIPTION
## Summary

`main` now merges as a merge commit rather than a squash, and
[bf30d2a](https://github.com/shaug/compris/commit/bf30d2a650899bc69182c2d468ac6af8a75ba83c)
rewrote `AGENTS.md`'s changelog backfill bullets to match. It left the one
module that actually enforces the rule still describing the old world:
`scripts/tests/test_changelog_citations.py` opened by asserting that "`main` is
almost entirely squash-merged" and that "only the squash" makes a backfilled SHA
unreachable.

This brings the guard's own prose in line with the merge method, and backfills
the entries that landed without SHAs.

## What changed

- **The docstring's account of the rot** now reads as history: the squash is
  what produced the 68 dead citations, and a merge commit preserves the
  authoring commit an entry cites.
- **The docstring's timing claim** is split by mechanism, which is where the
  old text became self-contradictory once the invalidating event moved. A SHA
  backfilled before submission goes unreachable at the rebase onto `main` that
  precedes submission, so `git rev-list HEAD` membership reddens on the
  authoring branch's own run. Only the squash-merged history behind that made
  the check inherently late, because those citations died at the merge.
- **The failure message** names that same mechanism instead of the squash.
- **Eight landed entries** from #238 and #243 are backfilled to their authoring
  commits, each placed directly after the entry's commit title per
  `AGENTS.md`'s format rule.

No assertion, regex, or reachability behavior changes. Every parenthesised SHA
must still name a commit reachable from `HEAD`.

## Why this shape

The backfill is itself a demonstration of the rewritten rule: all eight
`git log -S` lookups return non-merge authoring commits, and all eight are
ancestors of `origin/main`, so each entry was backfilled only after it landed.
The one entry carrying no SHA is the one this PR adds, which the convention
requires to stay bare until it lands.

## Verification

`just format`, `just lint`, and `just test` pass at the head commit.

Driven to convergence through `review-fix-loop` (`local_commit`), three review
passes, each a fresh isolated reviewer running the complete
`review-code-change` lens sequence bound to the exact head and base:

| Pass | Head | Verdict |
| --- | --- | --- |
| 1 | `ecb17f4` | `changes_required` — a landed entry had no backfill, masked by an inline prose citation of `77011ed7` that a whole-entry SHA scan counted as its own |
| 2 | `120e52c` | `changes_required` — two backfilled SHAs sat mid-body rather than title-adjacent, one of them severing a sentence from its object |
| 3 | `d79e13a` | **clean**, all three lenses freshly executed |

Two fix cycles consumed of a budget of three; write isolation `enforced` on
every pass. Each fix was written in an isolated attempt worktree, validated
there, and fast-forward-promoted.

## Follow-up, not included here

Pass 3 retained one non-gating `defer` finding: the failure message now names
the pre-submit rebase as the cause but still prescribes
`git log main -S'<entry first line>'`, which returns nothing for an entry that
has not landed. The remedy for that case is to carry no SHA until it lands.
Left for a separate change rather than widened into this one.

## Eval evidence

Not applicable — this touches no skill's `SKILL.md` or `references/` prose, so
the eval-backed change norm does not attach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
