### PR TITLE
fix: give the citation guard's failure message a remedy for both ways it fires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,22 +6,35 @@ summary: Chronological history of repository and skill changes.
 
 ## 2026-08-16 — Made a ticket's stated assumptions answer for themselves at pickup, hardened the harness that measured it, designed one owner for the policy that grades it, and brought the citation guard's own prose in line with the merge method
 
-- docs: restate the citation guard's own account of the backfill rule — the
-  merge-method change above left `scripts/tests/test_changelog_citations.py`
-  describing `main` as "almost entirely squash-merged" and naming the squash as
-  the only thing that makes a backfilled SHA unreachable, stale prose in the one
-  module that enforces the rule. Its docstring now records the squash rot as the
-  history it was written for, says that a merge commit preserves the authoring
-  commit an entry cites, and corrects what the old text had backwards once the
-  mechanism changed: when the guard actually fires. A SHA backfilled before
-  submission goes unreachable at the rebase onto `main` that precedes
-  submission, so `git rev-list HEAD` membership reddens on the authoring
-  branch's own run — it is only the squash-merged history behind that where the
-  check was inherently late, because those citations died at the merge instead.
-  The failure message names the same mechanism. No assertion, regex, or check
-  changes. The eight entries #238 and #243 landed without SHAs are backfilled to
-  their authoring commits, which is what the rule now names and what the guard
-  confirms is reachable.
+- fix: give the citation guard's failure message a remedy for both ways it can
+  fire — the message now names an unlanded backfill as a cause, since a SHA
+  taken before the branch was rebased and landed reaches nothing on that same
+  branch, but it still prescribed only the recovery for an entry that has
+  landed: `git log main -S'<the entry's first line>' -- CHANGELOG.md`. Run
+  against an entry that has not landed, that command returns nothing at all —
+  the entry is not on `main` yet, so `git log main -S` has no match to find —
+  and the reader following the message is handed empty output and no next step.
+  The remedy now covers both firing modes: recover the landing commit for an
+  entry that has landed, and drop the SHA until it lands for one that has not,
+  which is what AGENTS.md requires of an entry added on the current branch. No
+  assertion, regex, or reachability behavior changes.
+
+- docs: restate the citation guard's own account of the backfill rule
+  (ecb17f4b3bfa3f3c66f3aff03b63cc956555d73c) — the merge-method change above
+  left `scripts/tests/test_changelog_citations.py` describing `main` as "almost
+  entirely squash-merged" and naming the squash as the only thing that makes a
+  backfilled SHA unreachable, stale prose in the one module that enforces the
+  rule. Its docstring now records the squash rot as the history it was written
+  for, says that a merge commit preserves the authoring commit an entry cites,
+  and corrects what the old text had backwards once the mechanism changed: when
+  the guard actually fires. A SHA backfilled before submission goes unreachable
+  at the rebase onto `main` that precedes submission, so `git rev-list HEAD`
+  membership reddens on the authoring branch's own run — it is only the
+  squash-merged history behind that where the check was inherently late, because
+  those citations died at the merge instead. The failure message names the same
+  mechanism. No assertion, regex, or check changes. The eight entries #238 and
+  #243 landed without SHAs are backfilled to their authoring commits, which is
+  what the rule now names and what the guard confirms is reachable.
 
 - fix(evals): name every path a run was measured through, and stop claiming
   `sha` resolves (4c2dacb7ebeacc79f613c16b04c23775565c6ee6) — `subtree_paths`

--- a/scripts/tests/test_changelog_citations.py
+++ b/scripts/tests/test_changelog_citations.py
@@ -107,11 +107,13 @@ class ChangelogCitationTests(unittest.TestCase):
             )
             + "\n\nA backfilled SHA names the commit that carried the entry onto "
             "`main`\n(see AGENTS.md). A SHA taken before the branch was rebased "
-            "and landed\nnames a commit no ref reaches. Recover the landing "
-            "commit with:\n"
+            "and landed\nnames a commit no ref reaches. If the entry has landed, "
+            "recover its\nlanding commit with:\n"
             "  git log main --format='%H %s' -S'<the entry's first line>' -- "
             "CHANGELOG.md\nand take the last line, which is the commit that "
-            "introduced that entry.",
+            "introduced that entry.\nIf it has not landed, that command returns "
+            "nothing, because the entry is\nnot on `main` yet: drop the SHA and "
+            "backfill it once the entry lands.",
         )
 
 


### PR DESCRIPTION
## Summary

[#244](https://github.com/shaug/compris/pull/244) rewrote the citation guard's
account of *when* it fires: a SHA backfilled before submission goes unreachable
at the rebase onto `main` that precedes submission, so the check reddens on the
authoring branch's own run. The failure message picked up that new cause but
kept its old remedy — recover the landing commit with
`git log main --format='%H %s' -S'<the entry's first line>' -- CHANGELOG.md`.

In the case the message now names, that command returns nothing. The entry is
not on `main` yet, so `git log main -S` has no match to find, and a reader
following the message is handed empty output and no next step. A
`review-code-change` pass surfaced this as a non-gating `defer` finding, left
for this follow-up.

## What changed

- **The remedy now branches on whether the entry has landed.** For one that
  has, the existing `git log main -S` recovery is unchanged. For one that has
  not, a new clause says the command returns nothing because the entry is not
  on `main` yet, and to drop the SHA and backfill it once the entry lands —
  which is what `AGENTS.md`'s "backfill an entry only once it has landed on
  `main`" already requires of an entry added on the current branch.

No assertion, no regex, and no reachability behavior changes; the diff touches
only the third argument of the `assertEqual`.

## Why

Both firing modes are now reachable, so a single-remedy message is wrong for
one of them. The empty-output case is the worse of the two to leave
unaddressed: a reader who follows the instruction and gets nothing back has no
signal distinguishing "this command is the wrong tool here" from "the history
is broken in some way I don't understand."

Both branches were verified against this repository rather than reasoned about.
The landed entry `docs: restate the citation guard's own account of the
backfill rule` returns exactly
[ecb17f4](https://github.com/shaug/compris/commit/ecb17f4b3bfa3f3c66f3aff03b63cc956555d73c),
which this PR backfills into it; the unlanded top entry returns empty.

## Reviewer notes

- **Changelog.** The entry this PR adds carries no SHA, per the convention. The
  one landed entry below it that still lacked one is backfilled to `ecb17f4`,
  placed directly after its commit title per the format rule.
- **No eval evidence.** This changes `scripts/tests/`, not any skill's `SKILL.md`
  or `references/` prose, so the eval-backed change norm does not apply.
- **Review.** `review-fix-loop` ran this candidate under `local_commit` and
  returned `converged` on the first pass: aggregate `clean`, 0 findings, write
  isolation `enforced`, 0 of 3 fix cycles consumed. `just format`, `just lint`,
  and `just test` all pass.
