### PR TITLE
fix(review-fix-loop): attribute reviewer mutation, not any local ref move

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,15 +14,15 @@ summary: Chronological history of repository and skill changes.
   with a tiered `WorktreeMutationReport`: a change to `HEAD`, the candidate
   branch ref, or this invocation's own attempt namespace still invalidates the
   candidate (`blocked/candidate_integrity_failure`), but every other local ref
-  is now a non-gating `observed_ref_changes` observation unless
-  `review_execution.exclusive_ref_store` opts a dedicated clone back into the
-  old behavior. Worktree path state and host-supplied tool-trace evidence remain
-  the only inputs that force `write_isolation: "violated"`, and a new
-  `integrity_evidence` field records whether the host actually inspected a tool
-  trace for a clean pass. Added an eval corpus scenario for the unattributed
-  third-party ref advance alongside the existing reviewer-mutation one, and
-  recorded before/after deterministic eval-corpus evidence per the eval-backed
-  change norm.
+  is now always a non-gating `observed_ref_changes` observation — no flag
+  restores the old flat comparison, since it was the source of the false
+  positives this fixes. Worktree path state and host-supplied tool-trace
+  evidence remain the only inputs that force `write_isolation: "violated"`, and
+  a new `integrity_evidence` field records whether the host actually inspected a
+  tool trace for a clean pass. Added an eval corpus scenario for the
+  unattributed third-party ref advance alongside the existing reviewer-mutation
+  one, and recorded before/after deterministic eval-corpus evidence per the
+  eval-backed change norm.
 
 ## 2026-08-16 — Gave `ready-ticket` the breakdown that decides how many tickets the work is, made a ticket's stated assumptions answer for themselves at pickup, hardened the harness that measured it, designed one owner for the policy that grades it, and brought the citation guard's own prose in line with the merge method
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ summary: Chronological history of repository and skill changes.
 
 ## 2026-08-19 — Taught `review-fix-loop` to attribute a reviewer mutation to the reviewer instead of to any local ref that happened to move
 
+- chore(review-fix-loop): re-record the after-stage run at the shipping head —
+  the first after run measured the prose before `exclusive_ref_store` was
+  removed below. Re-recorded at the head this branch ships: 21 of 21, unchanged,
+  so the review-driven simplification cost no measured behavior.
+
+- fix(review-fix-loop): drop exclusive_ref_store, the buggy legacy behavior had
+  no business surviving as an opt-in — review found that offering a flag to
+  restore the whole-local-ref-map comparison made no sense when that exact
+  comparison was the documented source of the false positives this ticket fixes.
+  Removed the flag from the schema, the tiering function, and the review-phase
+  call site: every Tier 2 ref change is now unconditionally a non-gating
+  `observed_ref_changes` observation, with no configuration path back to the old
+  behavior. A dedicated clone that wants stricter isolation already has tiers
+  1-3 of the write-prevention ladder (sandbox, restricted tool surface,
+  read-only commands) available to it.
+
+- chore(review-fix-loop): record after-stage eval evidence for #245 — commit the
+  after-stage deterministic eval-corpus summary for the candidate-ref-
+  attribution tiering, on top of the implementation commit, per the eval-backed
+  change norm's requirement that the run be recorded from a committed, clean
+  tree.
+
 - fix(review-fix-loop): attribute reviewer mutation, not any local ref move —
   `detect_worktree_mutation` compared the entire local ref map, so a checkout
   where several worktrees share one ref store — or any background automation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,94 +4,119 @@ summary: Chronological history of repository and skill changes.
 
 # Changelog
 
+## 2026-08-19 — Taught `review-fix-loop` to attribute a reviewer mutation to the reviewer instead of to any local ref that happened to move
+
+- fix(review-fix-loop): attribute reviewer mutation, not any local ref move —
+  `detect_worktree_mutation` compared the entire local ref map, so a checkout
+  where several worktrees share one ref store — or any background automation
+  touching a branch — made an unattributed ref advance indistinguishable from
+  reviewer misconduct and killed a valid review. Replaced the flat comparison
+  with a tiered `WorktreeMutationReport`: a change to `HEAD`, the candidate
+  branch ref, or this invocation's own attempt namespace still invalidates the
+  candidate (`blocked/candidate_integrity_failure`), but every other local ref
+  is now a non-gating `observed_ref_changes` observation unless
+  `review_execution.exclusive_ref_store` opts a dedicated clone back into the
+  old behavior. Worktree path state and host-supplied tool-trace evidence remain
+  the only inputs that force `write_isolation: "violated"`, and a new
+  `integrity_evidence` field records whether the host actually inspected a tool
+  trace for a clean pass. Added an eval corpus scenario for the unattributed
+  third-party ref advance alongside the existing reviewer-mutation one, and
+  recorded before/after deterministic eval-corpus evidence per the eval-backed
+  change norm.
+
 ## 2026-08-16 — Gave `ready-ticket` the breakdown that decides how many tickets the work is, made a ticket's stated assumptions answer for themselves at pickup, hardened the harness that measured it, designed one owner for the policy that grades it, and brought the citation guard's own prose in line with the merge method
 
-- refactor(tests): parse the sync-contracts block in one place — binding the
-  doctrine's bundle set to the recipe reused the prose contract's regex by
-  copying it, leaving one justfile's shell syntax parsed in two independently
-  maintained places. `scripts/tests/helpers.py` now owns `sync_block_skills`,
-  both drift checks call it, and it raises rather than asserts when its named
-  block is absent or duplicated — a caller asserting against an empty match
-  would otherwise pass for the wrong reason.
+- refactor(tests): parse the sync-contracts block in one place
+  (fecc1790fa1438817c6edf33866056ec7d1c2fe4) — binding the doctrine's bundle set
+  to the recipe reused the prose contract's regex by copying it, leaving one
+  justfile's shell syntax parsed in two independently maintained places.
+  `scripts/tests/helpers.py` now owns `sync_block_skills`, both drift checks
+  call it, and it raises rather than asserts when its named block is absent or
+  duplicated — a caller asserting against an empty match would otherwise pass
+  for the wrong reason.
 
-- docs(ready-ticket): re-record the after-stage run at the shipping head — the
-  first after run measured the prose as originally written, and the review fix
-  loop then tightened four cases and corrected the doctrine-restatement
-  paragraphs. Re-recorded at the head this branch ships: 18 of 18, with no case
-  newly passing or newly failing, so the review's corrections cost no measured
-  behavior.
+- docs(ready-ticket): re-record the after-stage run at the shipping head
+  (5f38895deb9a69f9508a7e815bead1687785148f) — the first after run measured the
+  prose as originally written, and the review fix loop then tightened four cases
+  and corrected the doctrine-restatement paragraphs. Re-recorded at the head
+  this branch ships: 18 of 18, with no case newly passing or newly failing, so
+  the review's corrections cost no measured behavior.
 
 - fix(ready-ticket): say that the section restates the doctrine, and bind what
-  it restates — the new breakdown section claimed to load the doctrine "rather
-  than restates" it and named three rules, while restating seven of eight. Both
-  claims were false about the prose directly beneath them. The restatement
-  stays, because this skill's forward eval hands the model `SKILL.md` alone and
-  a rule absent from that file cannot govern a measured run; what changes is
-  that the section says so and names the doctrine canonical where the two
-  disagree. Its three verbatim sentences are now bound to the canonical text, so
-  editing the doctrine and running `just sync-contracts` reddens instead of
-  leaving a superseded rule stated with every suite green.
+  it restates (72229a4465ab02d6bc4e49e2d4c714d20d077b07) — the new breakdown
+  section claimed to load the doctrine "rather than restates" it and named three
+  rules, while restating seven of eight. Both claims were false about the prose
+  directly beneath them. The restatement stays, because this skill's forward
+  eval hands the model `SKILL.md` alone and a rule absent from that file cannot
+  govern a measured run; what changes is that the section says so and names the
+  doctrine canonical where the two disagree. Its three verbatim sentences are
+  now bound to the canonical text, so editing the doctrine and running
+  `just sync-contracts` reddens instead of leaving a superseded rule stated with
+  every suite green.
 
 - test(ready-ticket): grade leaf-body altitude, and record the writing-plans
-  overlap — the acceptance criterion requiring every leaf body to be
-  surface-observable shipped with prose assertions as its only evidence. The
-  vocabulary term for that failure existed but appeared only in cases that
-  produce no graph, and therefore no leaf body, so a run could draft every leaf
-  against internal function signatures with all eighteen cases still passing.
-  The trigger-collision audit also gains the `ready-ticket` × `writing-plans`
-  row the reclassification below requires: without it a reader cannot tell a
-  considered disposition from a missed one.
+  overlap (2a6ebf5bff15ab0734b4bfc726ff1c5d7bf19d0b) — the acceptance criterion
+  requiring every leaf body to be surface-observable shipped with prose
+  assertions as its only evidence. The vocabulary term for that failure existed
+  but appeared only in cases that produce no graph, and therefore no leaf body,
+  so a run could draft every leaf against internal function signatures with all
+  eighteen cases still passing. The trigger-collision audit also gains the
+  `ready-ticket` × `writing-plans` row the reclassification below requires:
+  without it a reader cannot tell a considered disposition from a missed one.
 
-- test: bind the doctrine's three bundle lists to one source — which skills
-  bundle the cognitive-shaping doctrine was written by hand in the justfile, the
-  drift check, and the packaging validator, kept in lockstep by nothing. The one
-  guard that looked like it bound them searched the whole justfile for each
-  skill's name, and every bundling skill is named in other sync blocks too, so
-  dropping a skill from the doctrine block reddened nothing. The failure landed
-  where the remedy could not reach it: the drift check tells a reader to run
+- test: bind the doctrine's three bundle lists to one source
+  (ba2dc686d331ab6045a0e6a5830bec532a43c2cd) — which skills bundle the
+  cognitive-shaping doctrine was written by hand in the justfile, the drift
+  check, and the packaging validator, kept in lockstep by nothing. The one guard
+  that looked like it bound them searched the whole justfile for each skill's
+  name, and every bundling skill is named in other sync blocks too, so dropping
+  a skill from the doctrine block reddened nothing. The failure landed where the
+  remedy could not reach it: the drift check tells a reader to run
   `just sync-contracts`, which cannot refresh a copy the recipe was never told
   to make.
 
-- docs(ready-ticket): record the after-stage eval evidence for the draft graph —
-  18 of 18 at the shipping prose, every case unanimous across its five
-  repetitions. The four cases the before run failed are newly passing and
-  nothing that passed before regressed, which is the pairing the eval-backed
-  change norm asks a prose change to demonstrate.
+- docs(ready-ticket): record the after-stage eval evidence for the draft graph
+  (f1939624b73ac4d273a02bdf9f15583c13b4b7ad) — 18 of 18 at the shipping prose,
+  every case unanimous across its five repetitions. The four cases the before
+  run failed are newly passing and nothing that passed before regressed, which
+  is the pairing the eval-backed change norm asks a prose change to demonstrate.
 
-- feat(ready-ticket): return a draft ticket graph instead of a rationale —
-  `decomposition_recommended` named each independently valuable part and stopped
-  there, which left the operator holding a diagnosis and no route: the parts
-  were named, the graph that would carry them was not. The skill now breaks the
-  work down before any body is drafted, judging shape against
-  `docs/cognitive-shaping-doctrine.md`, which it bundles by stable path rather
-  than restating. The draft names every proposed parent, child, leaf, sub-issue
-  edge, blocker edge, and re-split trigger, and every leaf carries a complete
-  body that passes all four self-review scans on its own. Nothing is created:
-  ticket-management authority still governs one body and grants no graph
-  mutation. The doctrine's rules that most often go wrong are stated in the
-  skill itself, because a run that settles the shape without opening the
-  reference still has to obey them — one ticket stays one ticket, a parent never
-  holds a single child, and recorded machine-generated evidence does not count
-  toward size. `superpowers:writing-plans` moves from house territory to a
-  bounded referenced peer: it supplies the file map, task boundaries, and
-  sequencing when present, while the breakdown outcome stays house-owned, its
-  plan is never written to disk, and its unit-level altitude is lifted to the
-  public surface before anything reaches a leaf body.
+- feat(ready-ticket): return a draft ticket graph instead of a rationale
+  (e67dd3aecafefec50824656a10fa65c5aec72c5d) — `decomposition_recommended` named
+  each independently valuable part and stopped there, which left the operator
+  holding a diagnosis and no route: the parts were named, the graph that would
+  carry them was not. The skill now breaks the work down before any body is
+  drafted, judging shape against `docs/cognitive-shaping-doctrine.md`, which it
+  bundles by stable path rather than restating. The draft names every proposed
+  parent, child, leaf, sub-issue edge, blocker edge, and re-split trigger, and
+  every leaf carries a complete body that passes all four self-review scans on
+  its own. Nothing is created: ticket-management authority still governs one
+  body and grants no graph mutation. The doctrine's rules that most often go
+  wrong are stated in the skill itself, because a run that settles the shape
+  without opening the reference still has to obey them — one ticket stays one
+  ticket, a parent never holds a single child, and recorded machine-generated
+  evidence does not count toward size. `superpowers:writing-plans` moves from
+  house territory to a bounded referenced peer: it supplies the file map, task
+  boundaries, and sequencing when present, while the breakdown outcome stays
+  house-owned, its plan is never written to disk, and its unit-level altitude is
+  lifted to the public surface before anything reaches a leaf body.
 
 - docs(ready-ticket): record the before-stage eval evidence for the draft graph
-  — the new corpus measured against the prose as it stood: 14 of 18. The four
-  failures are every decomposition case, none of which named a node, an edge, a
-  re-split trigger, or drafted a leaf body. That is the gap the after run is
-  measured against, and recording it first is what makes the pair comparable.
+  (040391c7efd52797a46d358d1e6940b120e5a9b6) — the new corpus measured against
+  the prose as it stood: 14 of 18. The four failures are every decomposition
+  case, none of which named a node, an edge, a re-split trigger, or drafted a
+  leaf body. That is the gap the after run is measured against, and recording it
+  first is what makes the pair comparable.
 
 - test(ready-ticket): add the five breakdown cases the draft graph is graded on
-  — cases for fits-as-one, unrelated concerns, the mechanical-versus-behavioral
-  seam, validation placement, and generated evidence, each built around a
-  specific bait: an epic leadership wants to see, a shared sprint, a team habit
-  of landing test scaffolding separately, a raw line count dominated by
-  committed eval results. A corpus that only rewards good answers measures very
-  little. They land before the prose they grade so the before run measures the
-  new corpus against the old prose.
+  (ad458e2af5170b86dc3b4df2794fad3443651d4a) — cases for fits-as-one, unrelated
+  concerns, the mechanical-versus-behavioral seam, validation placement, and
+  generated evidence, each built around a specific bait: an epic leadership
+  wants to see, a shared sprint, a team habit of landing test scaffolding
+  separately, a raw line count dominated by committed eval results. A corpus
+  that only rewards good answers measures very little. They land before the
+  prose they grade so the before run measures the new corpus against the old
+  prose.
 
 - fix: give the citation guard's failure message a remedy for both ways it can
   fire (ba638ef040b4535e170cf50c3c8e94689d30f9ef) — the message now names an

--- a/skills/review-fix-loop/SKILL.md
+++ b/skills/review-fix-loop/SKILL.md
@@ -133,18 +133,18 @@ summary:
    remote-write tool.
 4. Capture worktree state, including local refs (excluding `refs/remotes/*`),
    immediately before and after the pass and run `detect_worktree_mutation` on
-   the two snapshots, passing `candidate_branch_ref`, `attempt_namespace_prefix`
-   (from `local_execution.attempt_namespace_ref_prefix`), and
-   `review_execution.exclusive_ref_store` (it raises if either snapshot is
-   missing a required capture key, rather than silently treating an uncaptured
-   dimension as unchanged). It returns a `WorktreeMutationReport`, not a flat
-   list: a Tier 1 `candidate_mutations` entry (`head_sha`, the candidate branch
-   ref, or this invocation's own attempt namespace) means the candidate itself
-   moved — stop immediately and return `blocked/candidate_integrity_failure`
-   without building a `review_records` entry, since the packet's expected head
-   and base are now stale. Everything else — worktree path state plus, under
-   `exclusive_ref_store`, every other local ref — lands in `mutation_attempts`;
-   every remaining local ref lands in non-gating `observed_ref_changes`. See
+   the two snapshots, passing `candidate_branch_ref` and
+   `attempt_namespace_prefix` (from
+   `local_execution.attempt_namespace_ref_prefix`) (it raises if either snapshot
+   is missing a required capture key, rather than silently treating an
+   uncaptured dimension as unchanged). It returns a `WorktreeMutationReport`,
+   not a flat list: a Tier 1 `candidate_mutations` entry (`head_sha`, the
+   candidate branch ref, or this invocation's own attempt namespace) means the
+   candidate itself moved — stop immediately and return
+   `blocked/candidate_integrity_failure` without building a `review_records`
+   entry, since the packet's expected head and base are now stale. Worktree path
+   state lands in `mutation_attempts`; every other local ref lands in non-gating
+   `observed_ref_changes`. See
    [`references/reviewer-orchestration.md`](references/reviewer-orchestration.md)'s
    "Reviewer write prevention" tier 4 for the full attribution rationale.
 5. Build one `review_records` entry with `build_review_record`, passing both the

--- a/skills/review-fix-loop/SKILL.md
+++ b/skills/review-fix-loop/SKILL.md
@@ -133,19 +133,35 @@ summary:
    remote-write tool.
 4. Capture worktree state, including local refs (excluding `refs/remotes/*`),
    immediately before and after the pass and run `detect_worktree_mutation` on
-   the two snapshots (it raises if either snapshot is missing a required capture
-   key, rather than silently treating an uncaptured dimension as unchanged).
+   the two snapshots, passing `candidate_branch_ref`, `attempt_namespace_prefix`
+   (from `local_execution.attempt_namespace_ref_prefix`), and
+   `review_execution.exclusive_ref_store` (it raises if either snapshot is
+   missing a required capture key, rather than silently treating an uncaptured
+   dimension as unchanged). It returns a `WorktreeMutationReport`, not a flat
+   list: a Tier 1 `candidate_mutations` entry (`head_sha`, the candidate branch
+   ref, or this invocation's own attempt namespace) means the candidate itself
+   moved — stop immediately and return `blocked/candidate_integrity_failure`
+   without building a `review_records` entry, since the packet's expected head
+   and base are now stale. Everything else — worktree path state plus, under
+   `exclusive_ref_store`, every other local ref — lands in `mutation_attempts`;
+   every remaining local ref lands in non-gating `observed_ref_changes`. See
+   [`references/reviewer-orchestration.md`](references/reviewer-orchestration.md)'s
+   "Reviewer write prevention" tier 4 for the full attribution rationale.
 5. Build one `review_records` entry with `build_review_record`, passing both the
    exact packet handed to the reviewer (`packet=...`, required) and its result,
-   feeding in every detected mutation. This validates the packet and result
-   together — including catching a `clean` verdict paired with a packet whose
-   own required validation entry was `failed` or `unavailable`, which a
-   result-only check cannot see — and raises `ReviewIntegrityError` instead of
-   returning a partially trusted record. A non-empty `mutation_attempts` always
-   yields `write_isolation: "violated"`, even when the aggregate verdict itself
-   looked clean — stop immediately and return
-   `blocked/reviewer_integrity_failure` rather than continuing to iterate on
-   that pass's findings.
+   feeding in `mutation_attempts` (worktree state plus any tool-trace evidence),
+   `observed_ref_changes`, and `integrity_evidence` (`"tool_trace"` when the
+   host performed tool-trace inspection for this pass, `"surface_only"`
+   otherwise). This validates the packet and result together — including
+   catching a `clean` verdict paired with a packet whose own required validation
+   entry was `failed` or `unavailable`, which a result-only check cannot see —
+   and raises `ReviewIntegrityError` instead of returning a partially trusted
+   record. A non-empty `mutation_attempts` always yields
+   `write_isolation: "violated"`, even when the aggregate verdict itself looked
+   clean — stop immediately and return `blocked/reviewer_integrity_failure`
+   rather than continuing to iterate on that pass's findings.
+   `observed_ref_changes` never affects `write_isolation`; a `surface_only`
+   `integrity_evidence` still reaches `converged`.
 6. When the verdict is not `clean`, use `normalize_findings` and
    `select_next_finding` to identify the next finding in one deterministic order
    — selecting a finding is not disposing or fixing it; that remains a later

--- a/skills/review-fix-loop/evals/results/2026-08-19T205043Z-0005-before.json
+++ b/skills/review-fix-loop/evals/results/2026-08-19T205043Z-0005-before.json
@@ -1,0 +1,627 @@
+{
+  "candidate": {
+    "branch": "scott/ticket-245-0251fb",
+    "sha": "d934771797e256568c9e31169f3a0f6844e63753",
+    "tree": "61e657c165bb192561c6f7d0c47225b33e6442b7",
+    "trees": {
+      "skills/review-fix-loop": "0434bd06d4cdc1f04c94285e183c928e636707af"
+    },
+    "trees_unresolved": [],
+    "worktree_clean": true
+  },
+  "case_evidence": {
+    "lc-budget-exhausted-persistent-finding": {
+      "category": "budget_exhaustion",
+      "checks": {
+        "exactly_one_attempt_committed": {
+          "expected": 1,
+          "observed": 1
+        },
+        "finding_genuinely_unresolved_at_final_head": {
+          "expected": false,
+          "observed": false
+        },
+        "reason": {
+          "expected": "cycle_budget_exhausted",
+          "observed": "cycle_budget_exhausted"
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "changes_remaining",
+          "observed": "changes_remaining"
+        },
+        "worktree_clean": {
+          "expected": true,
+          "observed": true
+        }
+      },
+      "id": "lc-budget-exhausted-persistent-finding",
+      "policy": "local_commit"
+    },
+    "lc-checkpoint-mismatch-resume-blocked": {
+      "category": "recovery",
+      "checks": {
+        "candidate_never_advanced": {
+          "expected": "4ab6d99fd10cb293df5ef582ec9e6b0a22df82b9",
+          "observed": "4ab6d99fd10cb293df5ef582ec9e6b0a22df82b9"
+        },
+        "reason": {
+          "expected": "checkpoint_mismatch",
+          "observed": "checkpoint_mismatch"
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "blocked",
+          "observed": "blocked"
+        }
+      },
+      "id": "lc-checkpoint-mismatch-resume-blocked",
+      "policy": "local_commit"
+    },
+    "lc-converged-after-one-fix": {
+      "category": "convergence",
+      "checks": {
+        "canonical_branch_matches_reported_final_head": {
+          "expected": "99235cd9e3a50ef0971f63c34516c08a340e7057",
+          "observed": "99235cd9e3a50ef0971f63c34516c08a340e7057"
+        },
+        "default_review_independence": {
+          "expected": "fresh_subagent",
+          "observed": "fresh_subagent"
+        },
+        "exactly_one_new_commit": {
+          "expected": 1,
+          "observed": 1
+        },
+        "marker_at_final_head": {
+          "expected": "fixed",
+          "observed": "fixed"
+        },
+        "reason": {
+          "expected": null,
+          "observed": null
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "converged",
+          "observed": "converged"
+        },
+        "worktree_clean": {
+          "expected": true,
+          "observed": true
+        }
+      },
+      "id": "lc-converged-after-one-fix",
+      "policy": "local_commit"
+    },
+    "lc-converged-clean-initial": {
+      "category": "convergence",
+      "checks": {
+        "marker_at_final_head": {
+          "expected": "fixed",
+          "observed": "fixed"
+        },
+        "no_new_commit_on_canonical_branch": {
+          "expected": 0,
+          "observed": 0
+        },
+        "reason": {
+          "expected": null,
+          "observed": null
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "converged",
+          "observed": "converged"
+        },
+        "worktree_clean": {
+          "expected": true,
+          "observed": true
+        }
+      },
+      "id": "lc-converged-clean-initial",
+      "policy": "local_commit"
+    },
+    "lc-declined-finding-blocked": {
+      "category": "declined_findings",
+      "checks": {
+        "no_commit_was_made": {
+          "expected": "d27ecf3aebe046ad8ce5da32f6da02fc560281d0",
+          "observed": "d27ecf3aebe046ad8ce5da32f6da02fc560281d0"
+        },
+        "reason": {
+          "expected": "operator_input_required",
+          "observed": "operator_input_required"
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "blocked",
+          "observed": "blocked"
+        },
+        "worktree_clean": {
+          "expected": true,
+          "observed": true
+        }
+      },
+      "id": "lc-declined-finding-blocked",
+      "policy": "local_commit"
+    },
+    "lc-in-agent-override-bypasses-missing-capability": {
+      "category": "review_mode",
+      "checks": {
+        "exactly_one_new_commit": {
+          "expected": 1,
+          "observed": 1
+        },
+        "marker_at_final_head": {
+          "expected": "fixed",
+          "observed": "fixed"
+        },
+        "reason": {
+          "expected": null,
+          "observed": null
+        },
+        "review_independence_is_in_agent_override": {
+          "expected": "in_agent_override",
+          "observed": "in_agent_override"
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "converged",
+          "observed": "converged"
+        }
+      },
+      "id": "lc-in-agent-override-bypasses-missing-capability",
+      "policy": "local_commit"
+    },
+    "lc-incomplete-review-blocked-verdict": {
+      "category": "invalid_review",
+      "checks": {
+        "candidate_never_advanced": {
+          "expected": "72b6fc7f6acb0124fd732b9c1540bad0953150da",
+          "observed": "72b6fc7f6acb0124fd732b9c1540bad0953150da"
+        },
+        "reason": {
+          "expected": "missing_capability",
+          "observed": "missing_capability"
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "blocked",
+          "observed": "blocked"
+        }
+      },
+      "id": "lc-incomplete-review-blocked-verdict",
+      "policy": "local_commit"
+    },
+    "lc-interrupted-attempt-recovered-without-losing-commit": {
+      "category": "recovery",
+      "checks": {
+        "exactly_one_promoted_commit": {
+          "expected": 1,
+          "observed": 1
+        },
+        "interrupted_attempt_branch_still_points_at_it": {
+          "expected": "3d030418c41d42621046d4fc354f07487a0a19c6",
+          "observed": "3d030418c41d42621046d4fc354f07487a0a19c6"
+        },
+        "interrupted_attempt_recorded_as_preserved": {
+          "expected": true,
+          "observed": true
+        },
+        "interrupted_commit_object_preserved": {
+          "expected": true,
+          "observed": true
+        },
+        "marker_at_final_head": {
+          "expected": "fixed",
+          "observed": "fixed"
+        },
+        "reason": {
+          "expected": null,
+          "observed": null
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "converged",
+          "observed": "converged"
+        }
+      },
+      "id": "lc-interrupted-attempt-recovered-without-losing-commit",
+      "policy": "local_commit"
+    },
+    "lc-invalid-stale-review-result-blocked": {
+      "category": "invalid_review",
+      "checks": {
+        "candidate_never_advanced": {
+          "expected": "72b6fc7f6acb0124fd732b9c1540bad0953150da",
+          "observed": "72b6fc7f6acb0124fd732b9c1540bad0953150da"
+        },
+        "reason": {
+          "expected": "reviewer_integrity_failure",
+          "observed": "reviewer_integrity_failure"
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "blocked",
+          "observed": "blocked"
+        }
+      },
+      "id": "lc-invalid-stale-review-result-blocked",
+      "policy": "local_commit"
+    },
+    "lc-missing-capability-without-override": {
+      "category": "review_mode",
+      "checks": {
+        "candidate_never_advanced": {
+          "expected": "248249a6e9861f4e524fd8f3aaa11848e0357f74",
+          "observed": "248249a6e9861f4e524fd8f3aaa11848e0357f74"
+        },
+        "reason": {
+          "expected": "missing_capability",
+          "observed": "missing_capability"
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "blocked",
+          "observed": "blocked"
+        }
+      },
+      "id": "lc-missing-capability-without-override",
+      "policy": "local_commit"
+    },
+    "lc-reviewer-mutation-blocked": {
+      "category": "reviewer_mutation",
+      "checks": {
+        "candidate_never_advanced": {
+          "expected": "cd00502af9fd617e4d13df8b4900847d4df18a28",
+          "observed": "cd00502af9fd617e4d13df8b4900847d4df18a28"
+        },
+        "mutation_attempt_preserved_for_inspection": {
+          "expected": true,
+          "observed": true
+        },
+        "reason": {
+          "expected": "reviewer_integrity_failure",
+          "observed": "reviewer_integrity_failure"
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "blocked",
+          "observed": "blocked"
+        }
+      },
+      "id": "lc-reviewer-mutation-blocked",
+      "policy": "local_commit"
+    },
+    "lc-scope-expanding-finding-blocked": {
+      "category": "declined_findings",
+      "checks": {
+        "no_commit_was_made": {
+          "expected": "d27ecf3aebe046ad8ce5da32f6da02fc560281d0",
+          "observed": "d27ecf3aebe046ad8ce5da32f6da02fc560281d0"
+        },
+        "reason": {
+          "expected": "scope_decision_required",
+          "observed": "scope_decision_required"
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "blocked",
+          "observed": "blocked"
+        }
+      },
+      "id": "lc-scope-expanding-finding-blocked",
+      "policy": "local_commit"
+    },
+    "lc-validation-failure-not-tractable": {
+      "category": "validation_failure",
+      "checks": {
+        "no_commit_was_made": {
+          "expected": "7ff90098c8031b808aa7a64e69b3fbe84aa62d25",
+          "observed": "7ff90098c8031b808aa7a64e69b3fbe84aa62d25"
+        },
+        "reason": {
+          "expected": "current_candidate_validation_failure",
+          "observed": "current_candidate_validation_failure"
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "changes_remaining",
+          "observed": "changes_remaining"
+        }
+      },
+      "id": "lc-validation-failure-not-tractable",
+      "policy": "local_commit"
+    },
+    "lc-validation-failure-tractable-converges": {
+      "category": "validation_failure",
+      "checks": {
+        "exactly_one_new_commit": {
+          "expected": 1,
+          "observed": 1
+        },
+        "reason": {
+          "expected": null,
+          "observed": null
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "converged",
+          "observed": "converged"
+        },
+        "validation_flag_actually_repaired": {
+          "expected": "pass",
+          "observed": "pass"
+        }
+      },
+      "id": "lc-validation-failure-tractable-converges",
+      "policy": "local_commit"
+    },
+    "lc-validation-unavailable-blocked": {
+      "category": "validation_failure",
+      "checks": {
+        "no_commit_was_made": {
+          "expected": "8c58d7abb20ae3eaaf8a2e17277bea16fce57cea",
+          "observed": "8c58d7abb20ae3eaaf8a2e17277bea16fce57cea"
+        },
+        "reason": {
+          "expected": "validation_unavailable",
+          "observed": "validation_unavailable"
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "blocked",
+          "observed": "blocked"
+        }
+      },
+      "id": "lc-validation-unavailable-blocked",
+      "policy": "local_commit"
+    },
+    "up-converged-published": {
+      "category": "convergence",
+      "checks": {
+        "marker_at_published_head": {
+          "expected": "fixed",
+          "observed": "fixed"
+        },
+        "reason": {
+          "expected": null,
+          "observed": null
+        },
+        "remote_advanced_to_exact_local_head": {
+          "expected": "9dabc3393a790ece4c5c7f501f86f8ba81153914",
+          "observed": "9dabc3393a790ece4c5c7f501f86f8ba81153914"
+        },
+        "remote_started_at_expected_old_head": {
+          "expected": "7902b82343bb1d541740de322db3c4ff3fec920c",
+          "observed": "7902b82343bb1d541740de322db3c4ff3fec920c"
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "converged",
+          "observed": "converged"
+        }
+      },
+      "id": "up-converged-published",
+      "policy": "update_pr"
+    },
+    "up-mismatched-grant-blocked": {
+      "category": "publication_target",
+      "checks": {
+        "reason": {
+          "expected": "missing_authority",
+          "observed": "missing_authority"
+        },
+        "remote_untouched_before_any_lock": {
+          "expected": "260972b4d858055630f70d8002f50bddf7c6f124",
+          "observed": "260972b4d858055630f70d8002f50bddf7c6f124"
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "blocked",
+          "observed": "blocked"
+        }
+      },
+      "id": "up-mismatched-grant-blocked",
+      "policy": "update_pr"
+    },
+    "up-missing-authority-target-mismatch-blocked": {
+      "category": "publication_target",
+      "checks": {
+        "no_cycle_was_ever_consumed": {
+          "expected": 0,
+          "observed": 0
+        },
+        "reason": {
+          "expected": "missing_authority",
+          "observed": "missing_authority"
+        },
+        "remote_untouched_before_any_lock": {
+          "expected": "af9f32cc67018161b0b38c88a402ed05e21ab1c0",
+          "observed": "af9f32cc67018161b0b38c88a402ed05e21ab1c0"
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "blocked",
+          "observed": "blocked"
+        }
+      },
+      "id": "up-missing-authority-target-mismatch-blocked",
+      "policy": "update_pr"
+    },
+    "up-remote-advanced-stale-target-blocked": {
+      "category": "publication_race",
+      "checks": {
+        "local_converged_commit_not_lost": {
+          "expected": true,
+          "observed": true
+        },
+        "reason": {
+          "expected": "remote_advanced",
+          "observed": "remote_advanced"
+        },
+        "remote_untouched_by_the_losing_invocation": {
+          "expected": "fe8707952efd3bbfa7f4b7a55e90c4fa90dc9346",
+          "observed": "fe8707952efd3bbfa7f4b7a55e90c4fa90dc9346"
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "blocked",
+          "observed": "blocked"
+        }
+      },
+      "id": "up-remote-advanced-stale-target-blocked",
+      "policy": "update_pr"
+    },
+    "up-sequential-publication-race-second-clone-loses": {
+      "category": "publication_race",
+      "checks": {
+        "loser_publication_status": {
+          "expected": "failed",
+          "observed": "failed"
+        },
+        "loser_reason": {
+          "expected": "remote_advanced",
+          "observed": "remote_advanced"
+        },
+        "loser_terminal_state": {
+          "expected": "blocked",
+          "observed": "blocked"
+        },
+        "losers_local_commit_exists": {
+          "expected": true,
+          "observed": true
+        },
+        "losers_local_commit_object_preserved": {
+          "expected": true,
+          "observed": true
+        },
+        "remote_does_not_equal_losers_local_head": {
+          "expected": true,
+          "observed": true
+        },
+        "remote_equals_winners_local_head": {
+          "expected": "017f9ea29382f9449812dac40e1de70938cdd6f1",
+          "observed": "017f9ea29382f9449812dac40e1de70938cdd6f1"
+        },
+        "winner_terminal_state": {
+          "expected": "converged",
+          "observed": "converged"
+        }
+      },
+      "id": "up-sequential-publication-race-second-clone-loses",
+      "policy": "update_pr"
+    }
+  },
+  "cases": {
+    "lc-budget-exhausted-persistent-finding": "pass",
+    "lc-checkpoint-mismatch-resume-blocked": "pass",
+    "lc-converged-after-one-fix": "pass",
+    "lc-converged-clean-initial": "pass",
+    "lc-declined-finding-blocked": "pass",
+    "lc-in-agent-override-bypasses-missing-capability": "pass",
+    "lc-incomplete-review-blocked-verdict": "pass",
+    "lc-interrupted-attempt-recovered-without-losing-commit": "pass",
+    "lc-invalid-stale-review-result-blocked": "pass",
+    "lc-missing-capability-without-override": "pass",
+    "lc-reviewer-mutation-blocked": "pass",
+    "lc-scope-expanding-finding-blocked": "pass",
+    "lc-validation-failure-not-tractable": "pass",
+    "lc-validation-failure-tractable-converges": "pass",
+    "lc-validation-unavailable-blocked": "pass",
+    "up-converged-published": "pass",
+    "up-mismatched-grant-blocked": "pass",
+    "up-missing-authority-target-mismatch-blocked": "pass",
+    "up-remote-advanced-stale-target-blocked": "pass",
+    "up-sequential-publication-race-second-clone-loses": "pass"
+  },
+  "command": [
+    "/Users/scott/.local/share/mise/installs/python/3.11/bin/python3",
+    "skills/review-fix-loop/scripts/evals/runner.py"
+  ],
+  "compared_to": "2026-08-05T014858Z-0004-after.json",
+  "diff": {
+    "newly_failing": [],
+    "newly_passing": [],
+    "still_failing": [],
+    "unchanged": 20
+  },
+  "exit_code": 0,
+  "failures": [],
+  "forward_evals": false,
+  "gap": "recorded tier is deterministic, so no model read the prose and the model-behavior evidence is absent No real-model executor is registered for this skill, so this tier is the only one available here.",
+  "limitation": null,
+  "model": null,
+  "note": null,
+  "output_tail": "{\n  \"failed\": 0,\n  \"failures\": [],\n  \"passed\": 20,\n  \"total\": 20\n}",
+  "recorded_at": "2026-08-19T20:50:43Z",
+  "schema": "eval-run-summary/1",
+  "skill": "review-fix-loop",
+  "stage": "before",
+  "status": "completed",
+  "suite": "forward",
+  "tier": "deterministic",
+  "totals": {
+    "failed": 0,
+    "passed": 20,
+    "total": 20
+  }
+}

--- a/skills/review-fix-loop/evals/results/2026-08-19T205130Z-0006-after.json
+++ b/skills/review-fix-loop/evals/results/2026-08-19T205130Z-0006-after.json
@@ -1,0 +1,667 @@
+{
+  "candidate": {
+    "branch": "scott/ticket-245-0251fb",
+    "sha": "0dc4af2b9a5e2146b78404af48c612db3e0f7a9a",
+    "tree": "09ee1c75bd2ebe9ecc78064725e2a1cd58502e9b",
+    "trees": {
+      "skills/review-fix-loop": "b66588c8d7aa3af10125de318c0aa874b9262697"
+    },
+    "trees_unresolved": [],
+    "worktree_clean": true
+  },
+  "case_evidence": {
+    "lc-budget-exhausted-persistent-finding": {
+      "category": "budget_exhaustion",
+      "checks": {
+        "exactly_one_attempt_committed": {
+          "expected": 1,
+          "observed": 1
+        },
+        "finding_genuinely_unresolved_at_final_head": {
+          "expected": false,
+          "observed": false
+        },
+        "reason": {
+          "expected": "cycle_budget_exhausted",
+          "observed": "cycle_budget_exhausted"
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "changes_remaining",
+          "observed": "changes_remaining"
+        },
+        "worktree_clean": {
+          "expected": true,
+          "observed": true
+        }
+      },
+      "id": "lc-budget-exhausted-persistent-finding",
+      "policy": "local_commit"
+    },
+    "lc-checkpoint-mismatch-resume-blocked": {
+      "category": "recovery",
+      "checks": {
+        "candidate_never_advanced": {
+          "expected": "cb70d783da826a6094fd9281498b0ce484a636ef",
+          "observed": "cb70d783da826a6094fd9281498b0ce484a636ef"
+        },
+        "reason": {
+          "expected": "checkpoint_mismatch",
+          "observed": "checkpoint_mismatch"
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "blocked",
+          "observed": "blocked"
+        }
+      },
+      "id": "lc-checkpoint-mismatch-resume-blocked",
+      "policy": "local_commit"
+    },
+    "lc-converged-after-one-fix": {
+      "category": "convergence",
+      "checks": {
+        "canonical_branch_matches_reported_final_head": {
+          "expected": "b678f99608867117d0bc2af0b8b525cf48ef69e7",
+          "observed": "b678f99608867117d0bc2af0b8b525cf48ef69e7"
+        },
+        "default_review_independence": {
+          "expected": "fresh_subagent",
+          "observed": "fresh_subagent"
+        },
+        "exactly_one_new_commit": {
+          "expected": 1,
+          "observed": 1
+        },
+        "marker_at_final_head": {
+          "expected": "fixed",
+          "observed": "fixed"
+        },
+        "reason": {
+          "expected": null,
+          "observed": null
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "converged",
+          "observed": "converged"
+        },
+        "worktree_clean": {
+          "expected": true,
+          "observed": true
+        }
+      },
+      "id": "lc-converged-after-one-fix",
+      "policy": "local_commit"
+    },
+    "lc-converged-clean-initial": {
+      "category": "convergence",
+      "checks": {
+        "marker_at_final_head": {
+          "expected": "fixed",
+          "observed": "fixed"
+        },
+        "no_new_commit_on_canonical_branch": {
+          "expected": 0,
+          "observed": 0
+        },
+        "reason": {
+          "expected": null,
+          "observed": null
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "converged",
+          "observed": "converged"
+        },
+        "worktree_clean": {
+          "expected": true,
+          "observed": true
+        }
+      },
+      "id": "lc-converged-clean-initial",
+      "policy": "local_commit"
+    },
+    "lc-declined-finding-blocked": {
+      "category": "declined_findings",
+      "checks": {
+        "no_commit_was_made": {
+          "expected": "0259739fa0b13f9254ae89751ff7a14077259c1e",
+          "observed": "0259739fa0b13f9254ae89751ff7a14077259c1e"
+        },
+        "reason": {
+          "expected": "operator_input_required",
+          "observed": "operator_input_required"
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "blocked",
+          "observed": "blocked"
+        },
+        "worktree_clean": {
+          "expected": true,
+          "observed": true
+        }
+      },
+      "id": "lc-declined-finding-blocked",
+      "policy": "local_commit"
+    },
+    "lc-in-agent-override-bypasses-missing-capability": {
+      "category": "review_mode",
+      "checks": {
+        "exactly_one_new_commit": {
+          "expected": 1,
+          "observed": 1
+        },
+        "marker_at_final_head": {
+          "expected": "fixed",
+          "observed": "fixed"
+        },
+        "reason": {
+          "expected": null,
+          "observed": null
+        },
+        "review_independence_is_in_agent_override": {
+          "expected": "in_agent_override",
+          "observed": "in_agent_override"
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "converged",
+          "observed": "converged"
+        }
+      },
+      "id": "lc-in-agent-override-bypasses-missing-capability",
+      "policy": "local_commit"
+    },
+    "lc-incomplete-review-blocked-verdict": {
+      "category": "invalid_review",
+      "checks": {
+        "candidate_never_advanced": {
+          "expected": "f29270ddd95de4e06471621dfbab4abc23fd8420",
+          "observed": "f29270ddd95de4e06471621dfbab4abc23fd8420"
+        },
+        "reason": {
+          "expected": "missing_capability",
+          "observed": "missing_capability"
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "blocked",
+          "observed": "blocked"
+        }
+      },
+      "id": "lc-incomplete-review-blocked-verdict",
+      "policy": "local_commit"
+    },
+    "lc-interrupted-attempt-recovered-without-losing-commit": {
+      "category": "recovery",
+      "checks": {
+        "exactly_one_promoted_commit": {
+          "expected": 1,
+          "observed": 1
+        },
+        "interrupted_attempt_branch_still_points_at_it": {
+          "expected": "349a4c58faa38f9cfdc4ff4864766960814b15d3",
+          "observed": "349a4c58faa38f9cfdc4ff4864766960814b15d3"
+        },
+        "interrupted_attempt_recorded_as_preserved": {
+          "expected": true,
+          "observed": true
+        },
+        "interrupted_commit_object_preserved": {
+          "expected": true,
+          "observed": true
+        },
+        "marker_at_final_head": {
+          "expected": "fixed",
+          "observed": "fixed"
+        },
+        "reason": {
+          "expected": null,
+          "observed": null
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "converged",
+          "observed": "converged"
+        }
+      },
+      "id": "lc-interrupted-attempt-recovered-without-losing-commit",
+      "policy": "local_commit"
+    },
+    "lc-invalid-stale-review-result-blocked": {
+      "category": "invalid_review",
+      "checks": {
+        "candidate_never_advanced": {
+          "expected": "dd8ee67c890a087ece015b694515cdb2c8afb81f",
+          "observed": "dd8ee67c890a087ece015b694515cdb2c8afb81f"
+        },
+        "reason": {
+          "expected": "reviewer_integrity_failure",
+          "observed": "reviewer_integrity_failure"
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "blocked",
+          "observed": "blocked"
+        }
+      },
+      "id": "lc-invalid-stale-review-result-blocked",
+      "policy": "local_commit"
+    },
+    "lc-missing-capability-without-override": {
+      "category": "review_mode",
+      "checks": {
+        "candidate_never_advanced": {
+          "expected": "fd5a9b300c4a69561ec75d31ff2e435c01f4a956",
+          "observed": "fd5a9b300c4a69561ec75d31ff2e435c01f4a956"
+        },
+        "reason": {
+          "expected": "missing_capability",
+          "observed": "missing_capability"
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "blocked",
+          "observed": "blocked"
+        }
+      },
+      "id": "lc-missing-capability-without-override",
+      "policy": "local_commit"
+    },
+    "lc-reviewer-mutation-blocked": {
+      "category": "reviewer_mutation",
+      "checks": {
+        "candidate_never_advanced": {
+          "expected": "f7bb0bf7fba339f8df98f27c47efbf428b55d444",
+          "observed": "f7bb0bf7fba339f8df98f27c47efbf428b55d444"
+        },
+        "mutation_attempt_preserved_for_inspection": {
+          "expected": true,
+          "observed": true
+        },
+        "reason": {
+          "expected": "reviewer_integrity_failure",
+          "observed": "reviewer_integrity_failure"
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "blocked",
+          "observed": "blocked"
+        }
+      },
+      "id": "lc-reviewer-mutation-blocked",
+      "policy": "local_commit"
+    },
+    "lc-scope-expanding-finding-blocked": {
+      "category": "declined_findings",
+      "checks": {
+        "no_commit_was_made": {
+          "expected": "0259739fa0b13f9254ae89751ff7a14077259c1e",
+          "observed": "0259739fa0b13f9254ae89751ff7a14077259c1e"
+        },
+        "reason": {
+          "expected": "scope_decision_required",
+          "observed": "scope_decision_required"
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "blocked",
+          "observed": "blocked"
+        }
+      },
+      "id": "lc-scope-expanding-finding-blocked",
+      "policy": "local_commit"
+    },
+    "lc-unattributed-ref-advance-converges": {
+      "category": "reviewer_mutation",
+      "checks": {
+        "candidate_branch_unaffected": {
+          "expected": "54915bee8d2050ea5cd9f094a00e71a8dee36a0f",
+          "observed": "54915bee8d2050ea5cd9f094a00e71a8dee36a0f"
+        },
+        "no_mutation_attempts": {
+          "expected": [],
+          "observed": []
+        },
+        "reason": {
+          "expected": null,
+          "observed": null
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "converged",
+          "observed": "converged"
+        },
+        "third_party_ref_actually_advanced": {
+          "expected": "54915bee8d2050ea5cd9f094a00e71a8dee36a0f",
+          "observed": "54915bee8d2050ea5cd9f094a00e71a8dee36a0f"
+        },
+        "third_party_ref_observed": {
+          "expected": true,
+          "observed": true
+        },
+        "write_isolation_enforced": {
+          "expected": "enforced",
+          "observed": "enforced"
+        }
+      },
+      "id": "lc-unattributed-ref-advance-converges",
+      "policy": "local_commit"
+    },
+    "lc-validation-failure-not-tractable": {
+      "category": "validation_failure",
+      "checks": {
+        "no_commit_was_made": {
+          "expected": "2bad1d2b6c6493d8a264003161aec0d2e74c42ba",
+          "observed": "2bad1d2b6c6493d8a264003161aec0d2e74c42ba"
+        },
+        "reason": {
+          "expected": "current_candidate_validation_failure",
+          "observed": "current_candidate_validation_failure"
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "changes_remaining",
+          "observed": "changes_remaining"
+        }
+      },
+      "id": "lc-validation-failure-not-tractable",
+      "policy": "local_commit"
+    },
+    "lc-validation-failure-tractable-converges": {
+      "category": "validation_failure",
+      "checks": {
+        "exactly_one_new_commit": {
+          "expected": 1,
+          "observed": 1
+        },
+        "reason": {
+          "expected": null,
+          "observed": null
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "converged",
+          "observed": "converged"
+        },
+        "validation_flag_actually_repaired": {
+          "expected": "pass",
+          "observed": "pass"
+        }
+      },
+      "id": "lc-validation-failure-tractable-converges",
+      "policy": "local_commit"
+    },
+    "lc-validation-unavailable-blocked": {
+      "category": "validation_failure",
+      "checks": {
+        "no_commit_was_made": {
+          "expected": "9db78e830a0ccacfe2c0a22267cb4ed4e455699e",
+          "observed": "9db78e830a0ccacfe2c0a22267cb4ed4e455699e"
+        },
+        "reason": {
+          "expected": "validation_unavailable",
+          "observed": "validation_unavailable"
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "blocked",
+          "observed": "blocked"
+        }
+      },
+      "id": "lc-validation-unavailable-blocked",
+      "policy": "local_commit"
+    },
+    "up-converged-published": {
+      "category": "convergence",
+      "checks": {
+        "marker_at_published_head": {
+          "expected": "fixed",
+          "observed": "fixed"
+        },
+        "reason": {
+          "expected": null,
+          "observed": null
+        },
+        "remote_advanced_to_exact_local_head": {
+          "expected": "6378ab4c8bbfbf6838c408277adcb74f032a176e",
+          "observed": "6378ab4c8bbfbf6838c408277adcb74f032a176e"
+        },
+        "remote_started_at_expected_old_head": {
+          "expected": "104c9746a3ef2ff20627d377c6e9d76d597878cd",
+          "observed": "104c9746a3ef2ff20627d377c6e9d76d597878cd"
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "converged",
+          "observed": "converged"
+        }
+      },
+      "id": "up-converged-published",
+      "policy": "update_pr"
+    },
+    "up-mismatched-grant-blocked": {
+      "category": "publication_target",
+      "checks": {
+        "reason": {
+          "expected": "missing_authority",
+          "observed": "missing_authority"
+        },
+        "remote_untouched_before_any_lock": {
+          "expected": "2c1c729346e2ed4cdd1b727ddb6ba4e594a36d24",
+          "observed": "2c1c729346e2ed4cdd1b727ddb6ba4e594a36d24"
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "blocked",
+          "observed": "blocked"
+        }
+      },
+      "id": "up-mismatched-grant-blocked",
+      "policy": "update_pr"
+    },
+    "up-missing-authority-target-mismatch-blocked": {
+      "category": "publication_target",
+      "checks": {
+        "no_cycle_was_ever_consumed": {
+          "expected": 0,
+          "observed": 0
+        },
+        "reason": {
+          "expected": "missing_authority",
+          "observed": "missing_authority"
+        },
+        "remote_untouched_before_any_lock": {
+          "expected": "2c1c729346e2ed4cdd1b727ddb6ba4e594a36d24",
+          "observed": "2c1c729346e2ed4cdd1b727ddb6ba4e594a36d24"
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "blocked",
+          "observed": "blocked"
+        }
+      },
+      "id": "up-missing-authority-target-mismatch-blocked",
+      "policy": "update_pr"
+    },
+    "up-remote-advanced-stale-target-blocked": {
+      "category": "publication_race",
+      "checks": {
+        "local_converged_commit_not_lost": {
+          "expected": true,
+          "observed": true
+        },
+        "reason": {
+          "expected": "remote_advanced",
+          "observed": "remote_advanced"
+        },
+        "remote_untouched_by_the_losing_invocation": {
+          "expected": "fd5cc1ba8046d33a74fbb4a22e66b8528367d39d",
+          "observed": "fd5cc1ba8046d33a74fbb4a22e66b8528367d39d"
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "blocked",
+          "observed": "blocked"
+        }
+      },
+      "id": "up-remote-advanced-stale-target-blocked",
+      "policy": "update_pr"
+    },
+    "up-sequential-publication-race-second-clone-loses": {
+      "category": "publication_race",
+      "checks": {
+        "loser_publication_status": {
+          "expected": "failed",
+          "observed": "failed"
+        },
+        "loser_reason": {
+          "expected": "remote_advanced",
+          "observed": "remote_advanced"
+        },
+        "loser_terminal_state": {
+          "expected": "blocked",
+          "observed": "blocked"
+        },
+        "losers_local_commit_exists": {
+          "expected": true,
+          "observed": true
+        },
+        "losers_local_commit_object_preserved": {
+          "expected": true,
+          "observed": true
+        },
+        "remote_does_not_equal_losers_local_head": {
+          "expected": true,
+          "observed": true
+        },
+        "remote_equals_winners_local_head": {
+          "expected": "5df337277f7d19346d7d13e3766017ba340d48e0",
+          "observed": "5df337277f7d19346d7d13e3766017ba340d48e0"
+        },
+        "winner_terminal_state": {
+          "expected": "converged",
+          "observed": "converged"
+        }
+      },
+      "id": "up-sequential-publication-race-second-clone-loses",
+      "policy": "update_pr"
+    }
+  },
+  "cases": {
+    "lc-budget-exhausted-persistent-finding": "pass",
+    "lc-checkpoint-mismatch-resume-blocked": "pass",
+    "lc-converged-after-one-fix": "pass",
+    "lc-converged-clean-initial": "pass",
+    "lc-declined-finding-blocked": "pass",
+    "lc-in-agent-override-bypasses-missing-capability": "pass",
+    "lc-incomplete-review-blocked-verdict": "pass",
+    "lc-interrupted-attempt-recovered-without-losing-commit": "pass",
+    "lc-invalid-stale-review-result-blocked": "pass",
+    "lc-missing-capability-without-override": "pass",
+    "lc-reviewer-mutation-blocked": "pass",
+    "lc-scope-expanding-finding-blocked": "pass",
+    "lc-unattributed-ref-advance-converges": "pass",
+    "lc-validation-failure-not-tractable": "pass",
+    "lc-validation-failure-tractable-converges": "pass",
+    "lc-validation-unavailable-blocked": "pass",
+    "up-converged-published": "pass",
+    "up-mismatched-grant-blocked": "pass",
+    "up-missing-authority-target-mismatch-blocked": "pass",
+    "up-remote-advanced-stale-target-blocked": "pass",
+    "up-sequential-publication-race-second-clone-loses": "pass"
+  },
+  "command": [
+    "/Users/scott/.local/share/mise/installs/python/3.11/bin/python3",
+    "skills/review-fix-loop/scripts/evals/runner.py"
+  ],
+  "compared_to": "2026-08-19T205043Z-0005-before.json",
+  "diff": {
+    "newly_failing": [],
+    "newly_passing": [],
+    "still_failing": [],
+    "unchanged": 20
+  },
+  "exit_code": 0,
+  "failures": [],
+  "forward_evals": false,
+  "gap": "recorded tier is deterministic, so no model read the prose and the model-behavior evidence is absent No real-model executor is registered for this skill, so this tier is the only one available here.",
+  "limitation": null,
+  "model": null,
+  "note": null,
+  "output_tail": "{\n  \"failed\": 0,\n  \"failures\": [],\n  \"passed\": 21,\n  \"total\": 21\n}",
+  "recorded_at": "2026-08-19T20:51:30Z",
+  "schema": "eval-run-summary/1",
+  "skill": "review-fix-loop",
+  "stage": "after",
+  "status": "completed",
+  "suite": "forward",
+  "tier": "deterministic",
+  "totals": {
+    "failed": 0,
+    "passed": 21,
+    "total": 21
+  }
+}

--- a/skills/review-fix-loop/evals/results/2026-08-19T225454Z-0007-after.json
+++ b/skills/review-fix-loop/evals/results/2026-08-19T225454Z-0007-after.json
@@ -1,0 +1,667 @@
+{
+  "candidate": {
+    "branch": "scott/ticket-245-0251fb",
+    "sha": "3841b1e29f3eff61ddfad3c2275c2df70ee561fe",
+    "tree": "806655412bbe2dd6c788b8f7b2b2b799f40e53c9",
+    "trees": {
+      "skills/review-fix-loop": "4a8a3c67710714f8e41e145346dea525d1e26413"
+    },
+    "trees_unresolved": [],
+    "worktree_clean": true
+  },
+  "case_evidence": {
+    "lc-budget-exhausted-persistent-finding": {
+      "category": "budget_exhaustion",
+      "checks": {
+        "exactly_one_attempt_committed": {
+          "expected": 1,
+          "observed": 1
+        },
+        "finding_genuinely_unresolved_at_final_head": {
+          "expected": false,
+          "observed": false
+        },
+        "reason": {
+          "expected": "cycle_budget_exhausted",
+          "observed": "cycle_budget_exhausted"
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "changes_remaining",
+          "observed": "changes_remaining"
+        },
+        "worktree_clean": {
+          "expected": true,
+          "observed": true
+        }
+      },
+      "id": "lc-budget-exhausted-persistent-finding",
+      "policy": "local_commit"
+    },
+    "lc-checkpoint-mismatch-resume-blocked": {
+      "category": "recovery",
+      "checks": {
+        "candidate_never_advanced": {
+          "expected": "f4b2f44ff3900064bf07f1202128914e4acd6561",
+          "observed": "f4b2f44ff3900064bf07f1202128914e4acd6561"
+        },
+        "reason": {
+          "expected": "checkpoint_mismatch",
+          "observed": "checkpoint_mismatch"
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "blocked",
+          "observed": "blocked"
+        }
+      },
+      "id": "lc-checkpoint-mismatch-resume-blocked",
+      "policy": "local_commit"
+    },
+    "lc-converged-after-one-fix": {
+      "category": "convergence",
+      "checks": {
+        "canonical_branch_matches_reported_final_head": {
+          "expected": "e5ce620f52e770645351353e70d91974da9d4e40",
+          "observed": "e5ce620f52e770645351353e70d91974da9d4e40"
+        },
+        "default_review_independence": {
+          "expected": "fresh_subagent",
+          "observed": "fresh_subagent"
+        },
+        "exactly_one_new_commit": {
+          "expected": 1,
+          "observed": 1
+        },
+        "marker_at_final_head": {
+          "expected": "fixed",
+          "observed": "fixed"
+        },
+        "reason": {
+          "expected": null,
+          "observed": null
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "converged",
+          "observed": "converged"
+        },
+        "worktree_clean": {
+          "expected": true,
+          "observed": true
+        }
+      },
+      "id": "lc-converged-after-one-fix",
+      "policy": "local_commit"
+    },
+    "lc-converged-clean-initial": {
+      "category": "convergence",
+      "checks": {
+        "marker_at_final_head": {
+          "expected": "fixed",
+          "observed": "fixed"
+        },
+        "no_new_commit_on_canonical_branch": {
+          "expected": 0,
+          "observed": 0
+        },
+        "reason": {
+          "expected": null,
+          "observed": null
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "converged",
+          "observed": "converged"
+        },
+        "worktree_clean": {
+          "expected": true,
+          "observed": true
+        }
+      },
+      "id": "lc-converged-clean-initial",
+      "policy": "local_commit"
+    },
+    "lc-declined-finding-blocked": {
+      "category": "declined_findings",
+      "checks": {
+        "no_commit_was_made": {
+          "expected": "02e1680adb4aeeb5d63c39b084aeec2c72945efb",
+          "observed": "02e1680adb4aeeb5d63c39b084aeec2c72945efb"
+        },
+        "reason": {
+          "expected": "operator_input_required",
+          "observed": "operator_input_required"
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "blocked",
+          "observed": "blocked"
+        },
+        "worktree_clean": {
+          "expected": true,
+          "observed": true
+        }
+      },
+      "id": "lc-declined-finding-blocked",
+      "policy": "local_commit"
+    },
+    "lc-in-agent-override-bypasses-missing-capability": {
+      "category": "review_mode",
+      "checks": {
+        "exactly_one_new_commit": {
+          "expected": 1,
+          "observed": 1
+        },
+        "marker_at_final_head": {
+          "expected": "fixed",
+          "observed": "fixed"
+        },
+        "reason": {
+          "expected": null,
+          "observed": null
+        },
+        "review_independence_is_in_agent_override": {
+          "expected": "in_agent_override",
+          "observed": "in_agent_override"
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "converged",
+          "observed": "converged"
+        }
+      },
+      "id": "lc-in-agent-override-bypasses-missing-capability",
+      "policy": "local_commit"
+    },
+    "lc-incomplete-review-blocked-verdict": {
+      "category": "invalid_review",
+      "checks": {
+        "candidate_never_advanced": {
+          "expected": "4a596f6929f3b2d2a18f8f24d09079777e364e4c",
+          "observed": "4a596f6929f3b2d2a18f8f24d09079777e364e4c"
+        },
+        "reason": {
+          "expected": "missing_capability",
+          "observed": "missing_capability"
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "blocked",
+          "observed": "blocked"
+        }
+      },
+      "id": "lc-incomplete-review-blocked-verdict",
+      "policy": "local_commit"
+    },
+    "lc-interrupted-attempt-recovered-without-losing-commit": {
+      "category": "recovery",
+      "checks": {
+        "exactly_one_promoted_commit": {
+          "expected": 1,
+          "observed": 1
+        },
+        "interrupted_attempt_branch_still_points_at_it": {
+          "expected": "c807b04079485328755d834cb745938334b4cecc",
+          "observed": "c807b04079485328755d834cb745938334b4cecc"
+        },
+        "interrupted_attempt_recorded_as_preserved": {
+          "expected": true,
+          "observed": true
+        },
+        "interrupted_commit_object_preserved": {
+          "expected": true,
+          "observed": true
+        },
+        "marker_at_final_head": {
+          "expected": "fixed",
+          "observed": "fixed"
+        },
+        "reason": {
+          "expected": null,
+          "observed": null
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "converged",
+          "observed": "converged"
+        }
+      },
+      "id": "lc-interrupted-attempt-recovered-without-losing-commit",
+      "policy": "local_commit"
+    },
+    "lc-invalid-stale-review-result-blocked": {
+      "category": "invalid_review",
+      "checks": {
+        "candidate_never_advanced": {
+          "expected": "f6deaff138c548edf260c9394af3332c07e0866d",
+          "observed": "f6deaff138c548edf260c9394af3332c07e0866d"
+        },
+        "reason": {
+          "expected": "reviewer_integrity_failure",
+          "observed": "reviewer_integrity_failure"
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "blocked",
+          "observed": "blocked"
+        }
+      },
+      "id": "lc-invalid-stale-review-result-blocked",
+      "policy": "local_commit"
+    },
+    "lc-missing-capability-without-override": {
+      "category": "review_mode",
+      "checks": {
+        "candidate_never_advanced": {
+          "expected": "f432bbe93628554a9b8e43f922a2d76d22dce724",
+          "observed": "f432bbe93628554a9b8e43f922a2d76d22dce724"
+        },
+        "reason": {
+          "expected": "missing_capability",
+          "observed": "missing_capability"
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "blocked",
+          "observed": "blocked"
+        }
+      },
+      "id": "lc-missing-capability-without-override",
+      "policy": "local_commit"
+    },
+    "lc-reviewer-mutation-blocked": {
+      "category": "reviewer_mutation",
+      "checks": {
+        "candidate_never_advanced": {
+          "expected": "001f106371d9cf336d3080fff220ae1df709eac1",
+          "observed": "001f106371d9cf336d3080fff220ae1df709eac1"
+        },
+        "mutation_attempt_preserved_for_inspection": {
+          "expected": true,
+          "observed": true
+        },
+        "reason": {
+          "expected": "reviewer_integrity_failure",
+          "observed": "reviewer_integrity_failure"
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "blocked",
+          "observed": "blocked"
+        }
+      },
+      "id": "lc-reviewer-mutation-blocked",
+      "policy": "local_commit"
+    },
+    "lc-scope-expanding-finding-blocked": {
+      "category": "declined_findings",
+      "checks": {
+        "no_commit_was_made": {
+          "expected": "02e1680adb4aeeb5d63c39b084aeec2c72945efb",
+          "observed": "02e1680adb4aeeb5d63c39b084aeec2c72945efb"
+        },
+        "reason": {
+          "expected": "scope_decision_required",
+          "observed": "scope_decision_required"
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "blocked",
+          "observed": "blocked"
+        }
+      },
+      "id": "lc-scope-expanding-finding-blocked",
+      "policy": "local_commit"
+    },
+    "lc-unattributed-ref-advance-converges": {
+      "category": "reviewer_mutation",
+      "checks": {
+        "candidate_branch_unaffected": {
+          "expected": "edbf297147b9c5cf079f81af2d6dfa20692755cb",
+          "observed": "edbf297147b9c5cf079f81af2d6dfa20692755cb"
+        },
+        "no_mutation_attempts": {
+          "expected": [],
+          "observed": []
+        },
+        "reason": {
+          "expected": null,
+          "observed": null
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "converged",
+          "observed": "converged"
+        },
+        "third_party_ref_actually_advanced": {
+          "expected": "edbf297147b9c5cf079f81af2d6dfa20692755cb",
+          "observed": "edbf297147b9c5cf079f81af2d6dfa20692755cb"
+        },
+        "third_party_ref_observed": {
+          "expected": true,
+          "observed": true
+        },
+        "write_isolation_enforced": {
+          "expected": "enforced",
+          "observed": "enforced"
+        }
+      },
+      "id": "lc-unattributed-ref-advance-converges",
+      "policy": "local_commit"
+    },
+    "lc-validation-failure-not-tractable": {
+      "category": "validation_failure",
+      "checks": {
+        "no_commit_was_made": {
+          "expected": "af23edc089995c5ce24602bb1b987f09c0cf1d22",
+          "observed": "af23edc089995c5ce24602bb1b987f09c0cf1d22"
+        },
+        "reason": {
+          "expected": "current_candidate_validation_failure",
+          "observed": "current_candidate_validation_failure"
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "changes_remaining",
+          "observed": "changes_remaining"
+        }
+      },
+      "id": "lc-validation-failure-not-tractable",
+      "policy": "local_commit"
+    },
+    "lc-validation-failure-tractable-converges": {
+      "category": "validation_failure",
+      "checks": {
+        "exactly_one_new_commit": {
+          "expected": 1,
+          "observed": 1
+        },
+        "reason": {
+          "expected": null,
+          "observed": null
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "converged",
+          "observed": "converged"
+        },
+        "validation_flag_actually_repaired": {
+          "expected": "pass",
+          "observed": "pass"
+        }
+      },
+      "id": "lc-validation-failure-tractable-converges",
+      "policy": "local_commit"
+    },
+    "lc-validation-unavailable-blocked": {
+      "category": "validation_failure",
+      "checks": {
+        "no_commit_was_made": {
+          "expected": "c2726fd9f36f3b04b2f8bc6456cce3e1b9eda915",
+          "observed": "c2726fd9f36f3b04b2f8bc6456cce3e1b9eda915"
+        },
+        "reason": {
+          "expected": "validation_unavailable",
+          "observed": "validation_unavailable"
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "blocked",
+          "observed": "blocked"
+        }
+      },
+      "id": "lc-validation-unavailable-blocked",
+      "policy": "local_commit"
+    },
+    "up-converged-published": {
+      "category": "convergence",
+      "checks": {
+        "marker_at_published_head": {
+          "expected": "fixed",
+          "observed": "fixed"
+        },
+        "reason": {
+          "expected": null,
+          "observed": null
+        },
+        "remote_advanced_to_exact_local_head": {
+          "expected": "4684b58e48383b7a1a7d4c2d04417c7062e60d8f",
+          "observed": "4684b58e48383b7a1a7d4c2d04417c7062e60d8f"
+        },
+        "remote_started_at_expected_old_head": {
+          "expected": "84279c5687a0f3b7586947d4435d9bcf91f97aa2",
+          "observed": "84279c5687a0f3b7586947d4435d9bcf91f97aa2"
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "converged",
+          "observed": "converged"
+        }
+      },
+      "id": "up-converged-published",
+      "policy": "update_pr"
+    },
+    "up-mismatched-grant-blocked": {
+      "category": "publication_target",
+      "checks": {
+        "reason": {
+          "expected": "missing_authority",
+          "observed": "missing_authority"
+        },
+        "remote_untouched_before_any_lock": {
+          "expected": "24f011899794eb04d48a3c7dda726532ec7e085b",
+          "observed": "24f011899794eb04d48a3c7dda726532ec7e085b"
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "blocked",
+          "observed": "blocked"
+        }
+      },
+      "id": "up-mismatched-grant-blocked",
+      "policy": "update_pr"
+    },
+    "up-missing-authority-target-mismatch-blocked": {
+      "category": "publication_target",
+      "checks": {
+        "no_cycle_was_ever_consumed": {
+          "expected": 0,
+          "observed": 0
+        },
+        "reason": {
+          "expected": "missing_authority",
+          "observed": "missing_authority"
+        },
+        "remote_untouched_before_any_lock": {
+          "expected": "24f011899794eb04d48a3c7dda726532ec7e085b",
+          "observed": "24f011899794eb04d48a3c7dda726532ec7e085b"
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "blocked",
+          "observed": "blocked"
+        }
+      },
+      "id": "up-missing-authority-target-mismatch-blocked",
+      "policy": "update_pr"
+    },
+    "up-remote-advanced-stale-target-blocked": {
+      "category": "publication_race",
+      "checks": {
+        "local_converged_commit_not_lost": {
+          "expected": true,
+          "observed": true
+        },
+        "reason": {
+          "expected": "remote_advanced",
+          "observed": "remote_advanced"
+        },
+        "remote_untouched_by_the_losing_invocation": {
+          "expected": "dc06bd3c8bea0c5b68d39c224ff41b8a4936c1ec",
+          "observed": "dc06bd3c8bea0c5b68d39c224ff41b8a4936c1ec"
+        },
+        "schema_valid": {
+          "expected": [],
+          "observed": []
+        },
+        "terminal_state": {
+          "expected": "blocked",
+          "observed": "blocked"
+        }
+      },
+      "id": "up-remote-advanced-stale-target-blocked",
+      "policy": "update_pr"
+    },
+    "up-sequential-publication-race-second-clone-loses": {
+      "category": "publication_race",
+      "checks": {
+        "loser_publication_status": {
+          "expected": "failed",
+          "observed": "failed"
+        },
+        "loser_reason": {
+          "expected": "remote_advanced",
+          "observed": "remote_advanced"
+        },
+        "loser_terminal_state": {
+          "expected": "blocked",
+          "observed": "blocked"
+        },
+        "losers_local_commit_exists": {
+          "expected": true,
+          "observed": true
+        },
+        "losers_local_commit_object_preserved": {
+          "expected": true,
+          "observed": true
+        },
+        "remote_does_not_equal_losers_local_head": {
+          "expected": true,
+          "observed": true
+        },
+        "remote_equals_winners_local_head": {
+          "expected": "ddf9fa240f404364b9d9b63a88addf8297641197",
+          "observed": "ddf9fa240f404364b9d9b63a88addf8297641197"
+        },
+        "winner_terminal_state": {
+          "expected": "converged",
+          "observed": "converged"
+        }
+      },
+      "id": "up-sequential-publication-race-second-clone-loses",
+      "policy": "update_pr"
+    }
+  },
+  "cases": {
+    "lc-budget-exhausted-persistent-finding": "pass",
+    "lc-checkpoint-mismatch-resume-blocked": "pass",
+    "lc-converged-after-one-fix": "pass",
+    "lc-converged-clean-initial": "pass",
+    "lc-declined-finding-blocked": "pass",
+    "lc-in-agent-override-bypasses-missing-capability": "pass",
+    "lc-incomplete-review-blocked-verdict": "pass",
+    "lc-interrupted-attempt-recovered-without-losing-commit": "pass",
+    "lc-invalid-stale-review-result-blocked": "pass",
+    "lc-missing-capability-without-override": "pass",
+    "lc-reviewer-mutation-blocked": "pass",
+    "lc-scope-expanding-finding-blocked": "pass",
+    "lc-unattributed-ref-advance-converges": "pass",
+    "lc-validation-failure-not-tractable": "pass",
+    "lc-validation-failure-tractable-converges": "pass",
+    "lc-validation-unavailable-blocked": "pass",
+    "up-converged-published": "pass",
+    "up-mismatched-grant-blocked": "pass",
+    "up-missing-authority-target-mismatch-blocked": "pass",
+    "up-remote-advanced-stale-target-blocked": "pass",
+    "up-sequential-publication-race-second-clone-loses": "pass"
+  },
+  "command": [
+    "/Users/scott/.local/share/mise/installs/python/3.11/bin/python3",
+    "skills/review-fix-loop/scripts/evals/runner.py"
+  ],
+  "compared_to": "2026-08-19T205130Z-0006-after.json",
+  "diff": {
+    "newly_failing": [],
+    "newly_passing": [],
+    "still_failing": [],
+    "unchanged": 21
+  },
+  "exit_code": 0,
+  "failures": [],
+  "forward_evals": false,
+  "gap": "recorded tier is deterministic, so no model read the prose and the model-behavior evidence is absent No real-model executor is registered for this skill, so this tier is the only one available here.",
+  "limitation": null,
+  "model": null,
+  "note": "re-recorded after removing exclusive_ref_store per review feedback",
+  "output_tail": "{\n  \"failed\": 0,\n  \"failures\": [],\n  \"passed\": 21,\n  \"total\": 21\n}",
+  "recorded_at": "2026-08-19T22:54:54Z",
+  "schema": "eval-run-summary/1",
+  "skill": "review-fix-loop",
+  "stage": "after",
+  "status": "completed",
+  "suite": "forward",
+  "tier": "deterministic",
+  "totals": {
+    "failed": 0,
+    "passed": 21,
+    "total": 21
+  }
+}

--- a/skills/review-fix-loop/references/CONTRACT.md
+++ b/skills/review-fix-loop/references/CONTRACT.md
@@ -153,25 +153,23 @@ exceeds `original_cycle_budget`.
   complete cross-document invariant set described above.
 - `review_records` bind every review pass to the exact head and base it
   reviewed. `write_isolation: violated` records an attempted mutation this pass
-  can be attributed to — worktree path state, a local ref change while
-  `review_execution.exclusive_ref_store` is `true`, or host-supplied tool-trace
+  can be attributed to — worktree path state, or host-supplied tool-trace
   evidence (`integrity_evidence: tool_trace`) — never an unattributed ref change
   alone; it does not by itself imply which terminal `blocked` reason applies —
   that judgment belongs to the phase that observed it. An unattributed local ref
   change (any ref other than `HEAD`, the candidate branch ref, or this
-  invocation's own attempt namespace, when `exclusive_ref_store` is not `true`)
-  is instead recorded verbatim on `observed_ref_changes` — a non-gating
-  observation, since the ref store may be shared with other worktrees or
-  unrelated background automation — while a change to one of those three
-  candidate-bound refs invalidates the candidate itself and is never reflected
-  in `write_isolation` at all: it stops the invocation with
-  `blocked/candidate_integrity_failure` before a review record for that pass is
-  even built. `integrity_evidence` (`tool_trace` or `surface_only`) records
-  whether the host performed tool-trace inspection for this pass at all,
-  distinct from whether it found anything — a `surface_only` record still
-  supports `converged`. `reviewer_identity` (required, non-empty) is the
-  design's "reviewer identities" content: a per-pass identifier distinct from
-  the invocation-invariant `review_independence` enum, so a fresh-subagent
+  invocation's own attempt namespace) is instead recorded verbatim on
+  `observed_ref_changes` — a non-gating observation, since the ref store may be
+  shared with other worktrees or unrelated background automation — while a
+  change to one of those three candidate-bound refs invalidates the candidate
+  itself and is never reflected in `write_isolation` at all: it stops the
+  invocation with `blocked/candidate_integrity_failure` before a review record
+  for that pass is even built. `integrity_evidence` (`tool_trace` or
+  `surface_only`) records whether the host performed tool-trace inspection for
+  this pass at all, distinct from whether it found anything — a `surface_only`
+  record still supports `converged`. `reviewer_identity` (required, non-empty)
+  is the design's "reviewer identities" content: a per-pass identifier distinct
+  from the invocation-invariant `review_independence` enum, so a fresh-subagent
   reviewer's identity can actually differ from one head's review pass to the
   next, matching the design's validation-strategy requirement for "different
   reviewer identities per head."

--- a/skills/review-fix-loop/references/CONTRACT.md
+++ b/skills/review-fix-loop/references/CONTRACT.md
@@ -152,12 +152,26 @@ exceeds `original_cycle_budget`.
   `validate_checkpoint_against_invocation(invocation, checkpoint)` for the
   complete cross-document invariant set described above.
 - `review_records` bind every review pass to the exact head and base it
-  reviewed. `write_isolation: violated` records an attempted or unattributed
-  reviewer mutation; it does not by itself imply which terminal `blocked` reason
-  applies — that judgment belongs to the phase that observed it.
-  `reviewer_identity` (required, non-empty) is the design's "reviewer
-  identities" content: a per-pass identifier distinct from the
-  invocation-invariant `review_independence` enum, so a fresh-subagent
+  reviewed. `write_isolation: violated` records an attempted mutation this pass
+  can be attributed to — worktree path state, a local ref change while
+  `review_execution.exclusive_ref_store` is `true`, or host-supplied tool-trace
+  evidence (`integrity_evidence: tool_trace`) — never an unattributed ref change
+  alone; it does not by itself imply which terminal `blocked` reason applies —
+  that judgment belongs to the phase that observed it. An unattributed local ref
+  change (any ref other than `HEAD`, the candidate branch ref, or this
+  invocation's own attempt namespace, when `exclusive_ref_store` is not `true`)
+  is instead recorded verbatim on `observed_ref_changes` — a non-gating
+  observation, since the ref store may be shared with other worktrees or
+  unrelated background automation — while a change to one of those three
+  candidate-bound refs invalidates the candidate itself and is never reflected
+  in `write_isolation` at all: it stops the invocation with
+  `blocked/candidate_integrity_failure` before a review record for that pass is
+  even built. `integrity_evidence` (`tool_trace` or `surface_only`) records
+  whether the host performed tool-trace inspection for this pass at all,
+  distinct from whether it found anything — a `surface_only` record still
+  supports `converged`. `reviewer_identity` (required, non-empty) is the
+  design's "reviewer identities" content: a per-pass identifier distinct from
+  the invocation-invariant `review_independence` enum, so a fresh-subagent
   reviewer's identity can actually differ from one head's review pass to the
   next, matching the design's validation-strategy requirement for "different
   reviewer identities per head."

--- a/skills/review-fix-loop/references/checkpoint.schema.json
+++ b/skills/review-fix-loop/references/checkpoint.schema.json
@@ -162,7 +162,12 @@
           "mutation_attempts": {
             "type": "array",
             "items": {"type": "string", "minLength": 1}
-          }
+          },
+          "observed_ref_changes": {
+            "type": "array",
+            "items": {"type": "string", "minLength": 1}
+          },
+          "integrity_evidence": {"enum": ["tool_trace", "surface_only"]}
         }
       }
     },

--- a/skills/review-fix-loop/references/invocation.schema.json
+++ b/skills/review-fix-loop/references/invocation.schema.json
@@ -174,8 +174,7 @@
       "required": ["mode"],
       "properties": {
         "mode": {"enum": ["fresh_subagent", "in_agent_override"]},
-        "override_authorization": {"type": "string", "minLength": 1},
-        "exclusive_ref_store": {"type": "boolean"}
+        "override_authorization": {"type": "string", "minLength": 1}
       }
     },
     "fix_cycle_budget": {

--- a/skills/review-fix-loop/references/invocation.schema.json
+++ b/skills/review-fix-loop/references/invocation.schema.json
@@ -174,7 +174,8 @@
       "required": ["mode"],
       "properties": {
         "mode": {"enum": ["fresh_subagent", "in_agent_override"]},
-        "override_authorization": {"type": "string", "minLength": 1}
+        "override_authorization": {"type": "string", "minLength": 1},
+        "exclusive_ref_store": {"type": "boolean"}
       }
     },
     "fix_cycle_budget": {

--- a/skills/review-fix-loop/references/local-commit.md
+++ b/skills/review-fix-loop/references/local-commit.md
@@ -60,9 +60,12 @@ agent supplies exactly the judgment the design assigns to it, nothing more:
   `Read, Grep, Glob, Bash, Agent, Task, Skill` per
   [`references/reviewer-orchestration.md`](reviewer-orchestration.md) and
   returning its raw aggregate result. `run_local_commit` still performs the
-  before/after mutation snapshot, `evaluate_review_result` binding, and
+  tiered before/after mutation snapshot, `evaluate_review_result` binding, and
   `write_isolation` recording around this call — the port only needs to return
-  the raw result (plus any tool-trace mutation evidence the runtime observed).
+  the raw result, plus any tool-trace mutation evidence the runtime observed
+  (`ReviewPass.mutation_attempts`) and whether it performed tool-trace
+  inspection at all for this pass (`ReviewPass.tool_trace_available`, recorded
+  as the review record's `integrity_evidence`).
 - `decide(*, finding, change_contract, attempt_number) -> FixDecision` — verify
   the selected finding's evidence against the candidate, confirm it is within
   `change_contract.allowed_remediation_scope`, and return `accepted`,

--- a/skills/review-fix-loop/references/reviewer-orchestration.md
+++ b/skills/review-fix-loop/references/reviewer-orchestration.md
@@ -127,7 +127,7 @@ tier the runtime supports, strongest first:
    tracked/staged/unstaged/untracked/ignored worktree state immediately before
    spawning the reviewer and immediately after it returns — every key
    `REQUIRED_SNAPSHOT_KEYS` names. Pass both snapshots to
-   `detect_worktree_mutation(before, after, candidate_branch_ref=..., attempt_namespace_prefix=..., exclusive_ref_store=...)`,
+   `detect_worktree_mutation(before, after, candidate_branch_ref=..., attempt_namespace_prefix=...)`,
    which raises `ValueError` if either snapshot is missing a required key (fails
    closed rather than silently treating an uncaptured dimension as unchanged)
    and otherwise returns a `WorktreeMutationReport` that separates *what
@@ -148,18 +148,17 @@ tier the runtime supports, strongest first:
      `review_records` entry: the packet's `expected_head`/`expected_base` are
      now stale, so a record bound to them would misrepresent the live candidate
      rather than describe it.
-   - **Tier 2 — every other local ref** (`observed_ref_changes` by default,
-     including the comparison base ref and another invocation's own attempt
-     namespace): unattributable from the ref map alone — the ref store may be
-     shared across several worktrees, or unrelated background automation (a
-     `pull --ff-only` of `main`, a sibling worktree's own branch) may be running
-     concurrently. Non-gating: record it verbatim on the review record's
+   - **Tier 2 — every other local ref** (`observed_ref_changes`, including the
+     comparison base ref and another invocation's own attempt namespace):
+     unattributable from the ref map alone — the ref store may be shared across
+     several worktrees, or unrelated background automation (a `pull --ff-only`
+     of `main`, a sibling worktree's own branch) may be running concurrently.
+     Always non-gating: record it verbatim on the review record's
      `observed_ref_changes` and continue — `write_isolation` stays `enforced`
-     and the pass can still reach `converged`. Set
-     `review_execution.exclusive_ref_store: true` on the invocation only for a
-     dedicated clone this invocation genuinely owns exclusively; that folds
-     every Tier 2 ref change back into `mutation_attempts` below, reproducing
-     the flat behavior this tiering replaces.
+     and the pass can still reach `converged`. There is no opt-out: the
+     whole-local-ref-map comparison this tiering replaces produced enough false
+     positives in ordinary practice (issue #245's own observed evidence) that no
+     configuration is offered to restore it.
    - Worktree path state — `tracked`/`staged`/`unstaged`/`untracked`
      (`mutation_attempts`) — is compared exactly as before this tiering existed
      and is never subject to Tier 1/Tier 2 attribution: a worktree's index and

--- a/skills/review-fix-loop/references/reviewer-orchestration.md
+++ b/skills/review-fix-loop/references/reviewer-orchestration.md
@@ -122,54 +122,106 @@ tier the runtime supports, strongest first:
 3. **Read-only inspection commands only** inside the reviewer context —
    validation and diagnostic commands the invocation already recorded, never an
    ad hoc write.
-4. **Before/after state capture**: snapshot `head_sha`, local `refs` (for
-   example via `git for-each-ref`), and tracked/staged/unstaged/untracked/
-   ignored worktree state immediately before spawning the reviewer and
-   immediately after it returns — every key `REQUIRED_SNAPSHOT_KEYS` names. Pass
-   both snapshots to `detect_worktree_mutation(before, after)`, which raises
-   `ValueError` if either snapshot is missing a required key (fails closed
-   rather than silently treating an uncaptured dimension as unchanged) and
-   otherwise compares `head_sha`, `refs`, and tracked/staged/unstaged/untracked
-   paths — a reviewer that runs `git stash` or force-moves a branch without
-   touching `HEAD` or any tracked path is still caught. `refs/remotes/*` entries
-   are excluded from the comparison: an unattributed remote-tracking-ref advance
-   is the ordinary `remote_advanced` publication-race contract (issue #97/#100's
-   scope), not reviewer misconduct. `ignored` is captured (required above) but
-   deliberately not compared: authorized recorded validation commands
-   legitimately create or change ignored build artifacts (`__pycache__/`,
-   `.ruff_cache/`, `.venv/`), so comparing it would make every review pass that
-   runs validation falsely report a mutation — this mirrors the
-   invocation-cleanliness contract's own rule that ignored files "do not
-   represent an uncommitted change and are not part of what 'clean' means here."
+4. **Before/after state capture, attributed by tier**: snapshot `head_sha`,
+   local `refs` (for example via `git for-each-ref`), and
+   tracked/staged/unstaged/untracked/ignored worktree state immediately before
+   spawning the reviewer and immediately after it returns — every key
+   `REQUIRED_SNAPSHOT_KEYS` names. Pass both snapshots to
+   `detect_worktree_mutation(before, after, candidate_branch_ref=..., attempt_namespace_prefix=..., exclusive_ref_store=...)`,
+   which raises `ValueError` if either snapshot is missing a required key (fails
+   closed rather than silently treating an uncaptured dimension as unchanged)
+   and otherwise returns a `WorktreeMutationReport` that separates *what
+   changed* from *what can be attributed to this pass* — a single before/after
+   diff cannot itself tell a candidate-defining ref moving under the reviewer
+   from an unrelated ref moving beside it, so this function classifies rather
+   than flattening both into one undifferentiated mutation list:
+   - **Tier 1 — candidate-bound refs** (`candidate_mutations`): `head_sha`, the
+     candidate branch ref (`candidate_branch_ref`), and this invocation's own
+     `refs/heads/review-fix-loop/attempt/<invocation_id>/*` namespace
+     (`attempt_namespace_prefix`, from
+     `local_execution.attempt_namespace_ref_prefix(invocation_id)`). A change
+     here invalidates the candidate itself regardless of who caused it — the
+     evidence this pass reviewed no longer describes the live candidate. Stop
+     immediately and return `blocked/candidate_integrity_failure`, the same
+     reason the "resolve" workflow step already uses when a resumed live head
+     doesn't match its checkpoint, without building or appending a
+     `review_records` entry: the packet's `expected_head`/`expected_base` are
+     now stale, so a record bound to them would misrepresent the live candidate
+     rather than describe it.
+   - **Tier 2 — every other local ref** (`observed_ref_changes` by default,
+     including the comparison base ref and another invocation's own attempt
+     namespace): unattributable from the ref map alone — the ref store may be
+     shared across several worktrees, or unrelated background automation (a
+     `pull --ff-only` of `main`, a sibling worktree's own branch) may be running
+     concurrently. Non-gating: record it verbatim on the review record's
+     `observed_ref_changes` and continue — `write_isolation` stays `enforced`
+     and the pass can still reach `converged`. Set
+     `review_execution.exclusive_ref_store: true` on the invocation only for a
+     dedicated clone this invocation genuinely owns exclusively; that folds
+     every Tier 2 ref change back into `mutation_attempts` below, reproducing
+     the flat behavior this tiering replaces.
+   - Worktree path state — `tracked`/`staged`/`unstaged`/`untracked`
+     (`mutation_attempts`) — is compared exactly as before this tiering existed
+     and is never subject to Tier 1/Tier 2 attribution: a worktree's index and
+     working directory are never shared across worktrees the way a ref store can
+     be, so a path-state change stays fully attributable to this pass.
+     `refs/remotes/*` entries are excluded from every tier: an unattributed
+     remote-tracking-ref advance is the ordinary `remote_advanced`
+     publication-race contract (issue #97/#100's scope), not reviewer
+     misconduct. `ignored` is captured (required above) but deliberately not
+     compared: authorized recorded validation commands legitimately create or
+     change ignored build artifacts (`__pycache__/`, `.ruff_cache/`, `.venv/`),
+     so comparing it would make every review pass that runs validation falsely
+     report a mutation — this mirrors the invocation-cleanliness contract's own
+     rule that ignored files "do not represent an uncommitted change and are not
+     part of what 'clean' means here."
 5. **Tool-trace inspection**, when the runtime exposes one, for an attempted
-   mutation that a capability boundary already blocked.
+   mutation that a capability boundary already blocked. This is the only channel
+   that can attribute a Tier 2-shaped observation (a mutation the before/after
+   ref diff alone could not pin on this pass) to the reviewer: feed it through
+   `ReviewPass.mutation_attempts`, and set
+   `ReviewPass.tool_trace_available = True` whenever the host actually performed
+   this inspection for the pass — whether or not it found anything — so
+   `build_review_record`'s `integrity_evidence` can record `"tool_trace"` rather
+   than the default `"surface_only"`. A reader can then tell "inspected and
+   clean" from "never inspected"; a `surface_only` pass still reaches
+   `converged` when otherwise clean.
 
 Certification requires enforced write isolation; before/after verification alone
 is not sufficient by itself — it is tier 4 of five, not a replacement for tiers
 1–3 where the runtime supports them.
 
 An attempted prohibited mutation invalidates the review even when the runtime
-blocked it. Feed every mutation description `detect_worktree_mutation` returns
-(plus any tool-trace evidence) into `build_review_record`'s `mutation_attempts`.
-A non-empty `mutation_attempts` always sets `write_isolation: "violated"`,
-regardless of the aggregate verdict, and `scripts/validate.py`'s
+blocked it. Feed `detect_worktree_mutation`'s `mutation_attempts` (Tier 1 refs
+are handled separately, above) plus any tool-trace evidence into
+`build_review_record`'s own `mutation_attempts` parameter, and its
+`observed_ref_changes` into the same-named parameter. A non-empty
+`mutation_attempts` always sets `write_isolation: "violated"`, regardless of the
+aggregate verdict, and `scripts/validate.py`'s
 `_check_converged_requires_clean_evidence` already rejects `converged` for *any*
 `review_records` entry with a non-empty `mutation_attempts` — not only the
-final-head-bound one. An unattributed remote-ref advance by itself is not proof
-of reviewer misconduct; that is the ordinary `remote_advanced` publication-race
-contract (issue #97/#100's scope), not a reviewer-integrity failure.
+final-head-bound one. `observed_ref_changes` never affects `write_isolation` —
+an unattributed Tier 2 ref advance by itself is not proof of reviewer
+misconduct, exactly as an unattributed remote-ref advance already wasn't; that
+is the ordinary `remote_advanced` publication-race contract (issue #97/#100's
+scope) or unrelated concurrent activity in a shared ref store (issue #245's
+scope), not a reviewer-integrity failure.
 
 **Stop immediately on a mutation attributable to this pass.** Design assigns
 that judgment to "the phase that observed it" — this phase, the moment
-`detect_worktree_mutation` (or tool-trace evidence) returns non-empty for a pass
-this cycle just ran. Do not keep iterating on that pass's findings, and do not
-wait for a later phase to notice the tainted `review_records` entry indirectly.
-Stop the invocation and return `blocked/reviewer_integrity_failure` immediately,
-preserving the unexpected worktree/ref state for operator inspection rather than
-resetting or repairing it. The `mutation_attempts`/`write_isolation: "violated"`
-chain into `_check_converged_requires_clean_evidence` is a backstop that keeps a
-stale checkpoint from ever certifying `converged` later — it is not a substitute
-for this immediate stop.
+`detect_worktree_mutation`'s `mutation_attempts` (or tool-trace evidence)
+returns non-empty for a pass this cycle just ran. Do not keep iterating on that
+pass's findings, and do not wait for a later phase to notice the tainted
+`review_records` entry indirectly. Stop the invocation and return
+`blocked/reviewer_integrity_failure` immediately, preserving the unexpected
+worktree/ref state for operator inspection rather than resetting or repairing
+it. The `mutation_attempts`/`write_isolation: "violated"` chain into
+`_check_converged_requires_clean_evidence` is a backstop that keeps a stale
+checkpoint from ever certifying `converged` later — it is not a substitute for
+this immediate stop. A Tier 1 `candidate_mutations` change stops the invocation
+the same way, but with `blocked/candidate_integrity_failure` instead: that
+judgment is about the candidate's own identity, not about what the reviewer
+attempted, so it never touches `write_isolation` or `mutation_attempts` at all.
 
 ### The reviewer briefing
 

--- a/skills/review-fix-loop/references/terminal-result.schema.json
+++ b/skills/review-fix-loop/references/terminal-result.schema.json
@@ -190,7 +190,12 @@
           "mutation_attempts": {
             "type": "array",
             "items": {"type": "string", "minLength": 1}
-          }
+          },
+          "observed_ref_changes": {
+            "type": "array",
+            "items": {"type": "string", "minLength": 1}
+          },
+          "integrity_evidence": {"enum": ["tool_trace", "surface_only"]}
         }
       }
     },

--- a/skills/review-fix-loop/scripts/evals/corpus.py
+++ b/skills/review-fix-loop/scripts/evals/corpus.py
@@ -20,7 +20,11 @@ publication races, plus fresh-subagent defaults and the explicit in-agent
 override. It deliberately does not re-cover `oscillation` or
 `repeated_failed_attempt`: those `changes_remaining` reasons are already
 exercised by `scripts/tests/test_local_commit.py`, the capability-owned unit
-suite this ticket's own body says not to duplicate.
+suite this ticket's own body says not to duplicate. Issue #245 adds one
+scenario beyond #101's original list, alongside the existing reviewer-mutation
+one: an unattributed third-party ref advance
+(`lc_unattributed_ref_advance_converges`) that must converge rather than
+block, per the tiered write-isolation attribution that issue introduces.
 
 Every scenario is a plain function `(tmp_dir: Path) -> dict` so `runner.py`
 can execute each one inside its own disposable temporary directory and so
@@ -469,6 +473,77 @@ def lc_reviewer_mutation_blocked(tmp_dir: Path) -> dict[str, Any]:
     )
     return _case(
         "lc-reviewer-mutation-blocked",
+        category="reviewer_mutation",
+        policy="local_commit",
+        result=result,
+        checks=checks,
+    )
+
+
+def lc_unattributed_ref_advance_converges(tmp_dir: Path) -> dict[str, Any]:
+    """The unattributed third-party ref advance this ticket (#245) adds
+    alongside `lc_reviewer_mutation_blocked`: a local ref unrelated to the
+    candidate — not the candidate branch, not `HEAD`, not this invocation's
+    own attempt namespace — force-advances mid-review, the way a concurrent
+    worktree's own branch or an unattended background `pull --ff-only` would
+    in a checkout where several worktrees share one ref store. The review
+    must still converge, and the change must be recorded verbatim in the
+    final review record's `observed_ref_changes` — non-gating, never a
+    reviewer-integrity failure."""
+    repo = tmp_dir / "repo"
+    H.init_repo(repo)
+    base_sha, head_sha = H.start_candidate(
+        repo, branch="lc/unattributed-ref", marker="fixed"
+    )
+    invocation = H.make_invocation(
+        repo,
+        policy="local_commit",
+        branch="lc/unattributed-ref",
+        base_sha=base_sha,
+        head_sha=head_sha,
+        invocation_id="lc-unattributed-ref",
+    )
+    result = LC.run_local_commit(
+        invocation,
+        repo=repo,
+        reviewer=H.make_third_party_ref_advancing_reviewer(
+            repo, H.make_marker_reviewer(repo)
+        ),
+        decide=H.accepting_decide,
+        apply_fix=H.fixing_apply_fix,
+    )
+    checks = _terminal_checks(result, terminal_state="converged", reason=None)
+    final_records = [
+        record
+        for record in result.get("review_records", [])
+        if record.get("head_sha") == head_sha
+    ]
+    final_record = final_records[-1] if final_records else {}
+    third_party_ref_sha = G.rev_parse(repo, "background/automation")
+    candidate_branch_sha = G.rev_parse(repo, "lc/unattributed-ref")
+    checks.update(
+        {
+            "write_isolation_enforced": (
+                "enforced",
+                final_record.get("write_isolation"),
+            ),
+            "no_mutation_attempts": ([], final_record.get("mutation_attempts")),
+            "third_party_ref_observed": (
+                True,
+                any(
+                    "background/automation" in change
+                    for change in final_record.get("observed_ref_changes", [])
+                ),
+            ),
+            # Independent Git evidence: the third-party ref genuinely
+            # advanced (the mutation really happened, not merely un-reported)
+            # while the candidate branch itself never moved.
+            "third_party_ref_actually_advanced": (head_sha, third_party_ref_sha),
+            "candidate_branch_unaffected": (head_sha, candidate_branch_sha),
+        }
+    )
+    return _case(
+        "lc-unattributed-ref-advance-converges",
         category="reviewer_mutation",
         policy="local_commit",
         result=result,
@@ -1142,6 +1217,7 @@ SCENARIOS: list[Callable[[Path], dict[str, Any]]] = [
     lc_validation_failure_not_tractable,
     lc_validation_failure_tractable_converges,
     lc_reviewer_mutation_blocked,
+    lc_unattributed_ref_advance_converges,
     lc_incomplete_review_blocked_verdict,
     lc_invalid_stale_review_result_blocked,
     lc_missing_capability_without_override,

--- a/skills/review-fix-loop/scripts/evals/helpers.py
+++ b/skills/review-fix-loop/scripts/evals/helpers.py
@@ -339,6 +339,28 @@ def make_mutating_reviewer(repo: Path, inner: Callable[..., Any]) -> Callable[..
     return reviewer
 
 
+def make_third_party_ref_advancing_reviewer(
+    repo: Path,
+    inner: Callable[..., Any],
+    *,
+    ref: str = "refs/heads/background/automation",
+) -> Callable[..., Any]:
+    """Wraps `inner` but also force-advances an unrelated local ref before
+    returning — simulating background automation (a concurrent worktree's own
+    branch, an unattended `pull --ff-only`) sharing this checkout's ref store,
+    never the reviewer itself. `ref` is neither the candidate branch, `HEAD`,
+    nor this invocation's own attempt namespace, so this is Tier 2 by design
+    (issue #245): unattributable from the ref map alone, and must not gate a
+    clean review the way `make_mutating_reviewer`'s Tier 1/worktree mutation
+    does."""
+
+    def reviewer(**kwargs):
+        LE.git("update-ref", ref, kwargs["head_sha"], cwd=repo)
+        return inner(**kwargs)
+
+    return reviewer
+
+
 # ---------------------------------------------------------------------------
 # Decide fixtures
 # ---------------------------------------------------------------------------

--- a/skills/review-fix-loop/scripts/local_commit.py
+++ b/skills/review-fix-loop/scripts/local_commit.py
@@ -1129,9 +1129,6 @@ def _run_engine(
                         sequence=review_sequence,
                     )
                     after = _worktree_snapshot(state.repo)
-                    exclusive_ref_store = bool(
-                        invocation["review_execution"].get("exclusive_ref_store", False)
-                    )
                     mutation_report = ORCH.detect_worktree_mutation(
                         before,
                         after,
@@ -1139,7 +1136,6 @@ def _run_engine(
                         attempt_namespace_prefix=LE.attempt_namespace_ref_prefix(
                             invocation["invocation_id"]
                         ),
-                        exclusive_ref_store=exclusive_ref_store,
                     )
                     if mutation_report.candidate_mutations:
                         return _finalize(

--- a/skills/review-fix-loop/scripts/local_commit.py
+++ b/skills/review-fix-loop/scripts/local_commit.py
@@ -115,11 +115,20 @@ class LocalCommitError(RuntimeError):
 
 @dataclasses.dataclass
 class ReviewPass:
-    """One raw review-code-change pass and its isolation evidence."""
+    """One raw review-code-change pass and its isolation evidence.
+
+    `mutation_attempts` is host-supplied tool-trace evidence of an attempted
+    write (tier 5 of the write-prevention ladder) — leave it empty when the
+    host observed no attempt. `tool_trace_available` is `True` only when the
+    host actually performed tool-trace inspection for this pass (whether or
+    not it found anything); the default `False` means no tool trace was
+    supplied at all, distinct from "inspected and clean."
+    """
 
     result: Mapping[str, Any]
     reviewer_identity: str | None = None
     mutation_attempts: Sequence[str] = ()
+    tool_trace_available: bool = False
 
 
 @dataclasses.dataclass
@@ -1120,9 +1129,38 @@ def _run_engine(
                         sequence=review_sequence,
                     )
                     after = _worktree_snapshot(state.repo)
-                    mutation_attempts = list(
-                        ORCH.detect_worktree_mutation(before, after)
-                    ) + list(review_pass.mutation_attempts)
+                    exclusive_ref_store = bool(
+                        invocation["review_execution"].get("exclusive_ref_store", False)
+                    )
+                    mutation_report = ORCH.detect_worktree_mutation(
+                        before,
+                        after,
+                        candidate_branch_ref=f"refs/heads/{state.branch}",
+                        attempt_namespace_prefix=LE.attempt_namespace_ref_prefix(
+                            invocation["invocation_id"]
+                        ),
+                        exclusive_ref_store=exclusive_ref_store,
+                    )
+                    if mutation_report.candidate_mutations:
+                        return _finalize(
+                            state,
+                            terminal_state="blocked",
+                            reason="candidate_integrity_failure",
+                            operator_action=(
+                                "the candidate's own refs moved during the review "
+                                "pass, regardless of attribution: "
+                                + "; ".join(mutation_report.candidate_mutations)
+                            ),
+                            phase="review",
+                        )
+                    mutation_attempts = list(mutation_report.mutation_attempts) + list(
+                        review_pass.mutation_attempts
+                    )
+                    integrity_evidence = (
+                        "tool_trace"
+                        if review_pass.tool_trace_available
+                        else "surface_only"
+                    )
                     reviewer_identity = ORCH.generate_reviewer_identity(
                         independence,
                         review_sequence,
@@ -1138,6 +1176,8 @@ def _run_engine(
                             independence=independence,
                             reviewer_identity=reviewer_identity,
                             mutation_attempts=mutation_attempts,
+                            observed_ref_changes=mutation_report.observed_ref_changes,
+                            integrity_evidence=integrity_evidence,
                         )
                     except ORCH.ReviewIntegrityError as exc:
                         return _finalize(

--- a/skills/review-fix-loop/scripts/local_execution.py
+++ b/skills/review-fix-loop/scripts/local_execution.py
@@ -473,6 +473,19 @@ def attempt_branch_name(invocation_id: str, sequence: int) -> str:
     return f"{ATTEMPT_BRANCH_PREFIX}{_sanitize_component(invocation_id)}/{sequence}"
 
 
+def attempt_namespace_ref_prefix(invocation_id: str) -> str:
+    """Return the full-ref prefix covering every attempt branch this
+    invocation could create — `refs/heads/review-fix-loop/attempt/<id>/`.
+
+    Used by `reviewer_orchestration.detect_worktree_mutation`'s
+    `attempt_namespace_prefix` to classify a ref change inside this
+    invocation's own attempt namespace as Tier 1 (candidate-bound), while a
+    change inside a *different* invocation's attempt namespace — which does
+    not share this prefix — stays Tier 2.
+    """
+    return f"refs/heads/{ATTEMPT_BRANCH_PREFIX}{_sanitize_component(invocation_id)}/"
+
+
 def create_attempt(
     *,
     repo: Path,

--- a/skills/review-fix-loop/scripts/reviewer_orchestration.py
+++ b/skills/review-fix-loop/scripts/reviewer_orchestration.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 import importlib.util
 from pathlib import Path
-from typing import Any, Iterable, Mapping, Sequence
+from typing import Any, Iterable, Mapping, NamedTuple, Sequence
 
 HERE = Path(__file__).resolve().parent
 REVIEW_SUITE_VALIDATE_PATH = HERE.parent / "references" / "review-suite" / "validate.py"
@@ -219,10 +219,53 @@ def generate_reviewer_identity(
     return f"{independence.replace('_', '-')}-review-{sequence}"
 
 
+class WorktreeMutationReport(NamedTuple):
+    """Tiered result of `detect_worktree_mutation`.
+
+    `candidate_mutations` (Tier 1: `head_sha`, the candidate branch ref, and
+    this invocation's own attempt namespace) invalidates the candidate itself
+    regardless of who caused it — callers map a non-empty list to
+    `blocked/candidate_integrity_failure`, not `write_isolation`.
+
+    `mutation_attempts` (worktree path state — `tracked`/`staged`/`unstaged`/
+    `untracked` — plus, under `exclusive_ref_store`, every other local ref)
+    is attributable to this reviewer pass exactly as before this tiering
+    existed: feed it into `build_review_record`'s `mutation_attempts` to force
+    `write_isolation: "violated"`.
+
+    `observed_ref_changes` (Tier 2: every other local ref, when
+    `exclusive_ref_store` is `False`) is a non-gating observation only — a
+    ref this check cannot attribute to the reviewer because the ref store may
+    be shared with other worktrees or background automation.
+    """
+
+    candidate_mutations: list[str]
+    mutation_attempts: list[str]
+    observed_ref_changes: list[str]
+
+
+def _format_ref_detail(
+    *, added: Sequence[str], removed: Sequence[str], changed: Sequence[str]
+) -> str:
+    detail = []
+    if added:
+        detail.append(f"added {list(added)}")
+    if removed:
+        detail.append(f"removed {list(removed)}")
+    if changed:
+        detail.append(f"changed {list(changed)}")
+    return "refs: " + "; ".join(detail)
+
+
 def detect_worktree_mutation(
-    before: Mapping[str, Any], after: Mapping[str, Any]
-) -> list[str]:
-    """Return mutation descriptions found between two worktree snapshots.
+    before: Mapping[str, Any],
+    after: Mapping[str, Any],
+    *,
+    candidate_branch_ref: str | None = None,
+    attempt_namespace_prefix: str | None = None,
+    exclusive_ref_store: bool = False,
+) -> WorktreeMutationReport:
+    """Return a tiered `WorktreeMutationReport` between two worktree snapshots.
 
     `before`/`after` must each carry every `REQUIRED_SNAPSHOT_KEYS` entry:
     `head_sha`, a `refs` mapping (ref name to object ID), and the
@@ -230,17 +273,31 @@ def detect_worktree_mutation(
     `ValueError` if either is missing a key — fails closed rather than
     treating an uncaptured dimension as unchanged.
 
-    Compares `head_sha`, every `COMPARED_WORKTREE_CATEGORIES` path list, and
-    local `refs` (excluding `refs/remotes/*`, since an unattributed
+    `head_sha` and every `COMPARED_WORKTREE_CATEGORIES` path list are
+    compared exactly as before this tiering existed; `head_sha` lands in
+    `candidate_mutations` (it is always candidate-bound — Tier 1), and the
+    path lists land in `mutation_attempts` (worktree state is never shared
+    across worktrees, so it stays fully attributable to this pass). `ignored`
+    is captured but never compared. See references/reviewer-orchestration.md
+    for the full rationale.
+
+    Local `refs` (excluding `refs/remotes/*`, since an unattributed
     remote-tracking-ref advance is the ordinary `remote_advanced`
     publication-race contract, not reviewer misconduct — issue #97/#100's
-    scope). See references/reviewer-orchestration.md for the full rationale,
-    including why `ignored` is captured but not compared.
+    scope) are classified Tier 1 when the ref is `candidate_branch_ref` or
+    starts with `attempt_namespace_prefix`, and Tier 2 otherwise. A Tier 2 ref
+    change is unattributable by construction — the ref store may be shared
+    with other worktrees or unrelated background automation — so it is
+    recorded in `observed_ref_changes` rather than gating, unless
+    `exclusive_ref_store` is `True` (a dedicated clone this invocation
+    genuinely owns), which folds every Tier 2 ref change back into
+    `mutation_attempts`, reproducing the pre-tiering behavior exactly.
 
-    An empty return means no attributable change per *this* check; design
+    Every list empty means no attributable change per *this* check; design
     also requires the stronger filesystem-boundary and tool-surface controls
-    this function cannot see. A non-empty return must fail the cycle closed:
-    `build_review_record` forces `write_isolation: "violated"`, and
+    this function cannot see. A non-empty `candidate_mutations` invalidates
+    the candidate itself; a non-empty `mutation_attempts` must fail the cycle
+    closed: `build_review_record` forces `write_isolation: "violated"`, and
     `validate.py`'s `_check_converged_requires_clean_evidence` rejects
     `converged` for any review record with a non-empty `mutation_attempts`.
     """
@@ -253,11 +310,16 @@ def detect_worktree_mutation(
             f"missing {missing_after!r}"
         )
 
-    mutations: list[str] = []
+    candidate_mutations: list[str] = []
+    mutation_attempts: list[str] = []
+    observed_ref_changes: list[str] = []
+
     before_head = before["head_sha"]
     after_head = after["head_sha"]
     if before_head != after_head:
-        mutations.append(f"head_sha advanced from {before_head!r} to {after_head!r}")
+        candidate_mutations.append(
+            f"head_sha advanced from {before_head!r} to {after_head!r}"
+        )
     for category in COMPARED_WORKTREE_CATEGORIES:
         before_paths = set(before[category] or [])
         after_paths = set(after[category] or [])
@@ -269,7 +331,7 @@ def detect_worktree_mutation(
                 detail.append(f"added {added}")
             if removed:
                 detail.append(f"removed {removed}")
-            mutations.append(f"{category}: " + "; ".join(detail))
+            mutation_attempts.append(f"{category}: " + "; ".join(detail))
 
     def _local_refs(snapshot: Mapping[str, Any]) -> dict[str, str]:
         refs = snapshot["refs"] or {}
@@ -278,6 +340,13 @@ def detect_worktree_mutation(
             for name, value in refs.items()
             if not name.startswith("refs/remotes/")
         }
+
+    def _is_candidate_bound(ref_name: str) -> bool:
+        if candidate_branch_ref is not None and ref_name == candidate_branch_ref:
+            return True
+        if attempt_namespace_prefix and ref_name.startswith(attempt_namespace_prefix):
+            return True
+        return False
 
     before_refs = _local_refs(before)
     after_refs = _local_refs(after)
@@ -289,16 +358,34 @@ def detect_worktree_mutation(
             for name in set(before_refs) & set(after_refs)
             if before_refs[name] != after_refs[name]
         )
-        detail = []
-        if added:
-            detail.append(f"added {added}")
-        if removed:
-            detail.append(f"removed {removed}")
-        if changed:
-            detail.append(f"changed {changed}")
-        mutations.append("refs: " + "; ".join(detail))
 
-    return mutations
+        tier1_added = [name for name in added if _is_candidate_bound(name)]
+        tier1_removed = [name for name in removed if _is_candidate_bound(name)]
+        tier1_changed = [name for name in changed if _is_candidate_bound(name)]
+        if tier1_added or tier1_removed or tier1_changed:
+            candidate_mutations.append(
+                _format_ref_detail(
+                    added=tier1_added, removed=tier1_removed, changed=tier1_changed
+                )
+            )
+
+        tier2_added = [name for name in added if not _is_candidate_bound(name)]
+        tier2_removed = [name for name in removed if not _is_candidate_bound(name)]
+        tier2_changed = [name for name in changed if not _is_candidate_bound(name)]
+        if tier2_added or tier2_removed or tier2_changed:
+            ref_detail = _format_ref_detail(
+                added=tier2_added, removed=tier2_removed, changed=tier2_changed
+            )
+            if exclusive_ref_store:
+                mutation_attempts.append(ref_detail)
+            else:
+                observed_ref_changes.append(ref_detail)
+
+    return WorktreeMutationReport(
+        candidate_mutations=candidate_mutations,
+        mutation_attempts=mutation_attempts,
+        observed_ref_changes=observed_ref_changes,
+    )
 
 
 def build_review_record(
@@ -311,6 +398,8 @@ def build_review_record(
     independence: str,
     reviewer_identity: str,
     mutation_attempts: Sequence[str] = (),
+    observed_ref_changes: Sequence[str] = (),
+    integrity_evidence: str = "surface_only",
 ) -> dict[str, Any]:
     """Build one checkpoint-shaped `review_records` entry from a raw result.
 
@@ -319,7 +408,21 @@ def build_review_record(
 
     Any non-empty `mutation_attempts` forces `write_isolation: "violated"`
     regardless of the aggregate verdict — an attempted prohibited mutation
-    invalidates the review even if the runtime blocked it.
+    invalidates the review even if the runtime blocked it. `mutation_attempts`
+    is the attributable channel only (worktree path state and, under
+    `exclusive_ref_store`, any local ref, plus host-supplied tool-trace
+    evidence) — an unattributed Tier 2 ref change belongs in
+    `observed_ref_changes` instead and never affects `write_isolation`.
+
+    `observed_ref_changes` is recorded verbatim when non-empty and omitted
+    otherwise — a non-gating record of every local ref this pass could not
+    attribute to the reviewer.
+
+    `integrity_evidence` is `"tool_trace"` when the host supplied tool-trace
+    inspection for this pass (whether or not it found anything) and
+    `"surface_only"` (the default) when it did not, so a reader can tell
+    "inspected and clean" from "never inspected." Always recorded — a
+    `surface_only` run still reaches `converged`.
 
     `finding_dispositions` starts empty: disposing a finding
     (`accepted`/`rejected`/`deferred`) is design's "Decide" step, a later
@@ -329,7 +432,7 @@ def build_review_record(
     if errors:
         raise ReviewIntegrityError(errors)
 
-    return {
+    record: dict[str, Any] = {
         "sequence": sequence,
         "head_sha": expected_head,
         "comparison_base_sha": expected_base,
@@ -339,7 +442,13 @@ def build_review_record(
         "aggregate_verdict": result["verdict"],
         "finding_dispositions": [],
         "mutation_attempts": list(mutation_attempts),
+        "integrity_evidence": (
+            "tool_trace" if integrity_evidence == "tool_trace" else "surface_only"
+        ),
     }
+    if observed_ref_changes:
+        record["observed_ref_changes"] = list(observed_ref_changes)
+    return record
 
 
 def normalize_findings(findings: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:

--- a/skills/review-fix-loop/scripts/reviewer_orchestration.py
+++ b/skills/review-fix-loop/scripts/reviewer_orchestration.py
@@ -228,15 +228,14 @@ class WorktreeMutationReport(NamedTuple):
     `blocked/candidate_integrity_failure`, not `write_isolation`.
 
     `mutation_attempts` (worktree path state — `tracked`/`staged`/`unstaged`/
-    `untracked` — plus, under `exclusive_ref_store`, every other local ref)
-    is attributable to this reviewer pass exactly as before this tiering
-    existed: feed it into `build_review_record`'s `mutation_attempts` to force
-    `write_isolation: "violated"`.
+    `untracked`) is attributable to this reviewer pass exactly as before this
+    tiering existed: feed it into `build_review_record`'s `mutation_attempts`
+    to force `write_isolation: "violated"`.
 
-    `observed_ref_changes` (Tier 2: every other local ref, when
-    `exclusive_ref_store` is `False`) is a non-gating observation only — a
-    ref this check cannot attribute to the reviewer because the ref store may
-    be shared with other worktrees or background automation.
+    `observed_ref_changes` (Tier 2: every other local ref) is a non-gating
+    observation only — a ref this check cannot attribute to the reviewer
+    because the ref store may be shared with other worktrees or background
+    automation.
     """
 
     candidate_mutations: list[str]
@@ -263,7 +262,6 @@ def detect_worktree_mutation(
     *,
     candidate_branch_ref: str | None = None,
     attempt_namespace_prefix: str | None = None,
-    exclusive_ref_store: bool = False,
 ) -> WorktreeMutationReport:
     """Return a tiered `WorktreeMutationReport` between two worktree snapshots.
 
@@ -288,10 +286,7 @@ def detect_worktree_mutation(
     starts with `attempt_namespace_prefix`, and Tier 2 otherwise. A Tier 2 ref
     change is unattributable by construction — the ref store may be shared
     with other worktrees or unrelated background automation — so it is
-    recorded in `observed_ref_changes` rather than gating, unless
-    `exclusive_ref_store` is `True` (a dedicated clone this invocation
-    genuinely owns), which folds every Tier 2 ref change back into
-    `mutation_attempts`, reproducing the pre-tiering behavior exactly.
+    always recorded in `observed_ref_changes` rather than gating.
 
     Every list empty means no attributable change per *this* check; design
     also requires the stronger filesystem-boundary and tool-surface controls
@@ -373,13 +368,11 @@ def detect_worktree_mutation(
         tier2_removed = [name for name in removed if not _is_candidate_bound(name)]
         tier2_changed = [name for name in changed if not _is_candidate_bound(name)]
         if tier2_added or tier2_removed or tier2_changed:
-            ref_detail = _format_ref_detail(
-                added=tier2_added, removed=tier2_removed, changed=tier2_changed
+            observed_ref_changes.append(
+                _format_ref_detail(
+                    added=tier2_added, removed=tier2_removed, changed=tier2_changed
+                )
             )
-            if exclusive_ref_store:
-                mutation_attempts.append(ref_detail)
-            else:
-                observed_ref_changes.append(ref_detail)
 
     return WorktreeMutationReport(
         candidate_mutations=candidate_mutations,
@@ -409,9 +402,8 @@ def build_review_record(
     Any non-empty `mutation_attempts` forces `write_isolation: "violated"`
     regardless of the aggregate verdict — an attempted prohibited mutation
     invalidates the review even if the runtime blocked it. `mutation_attempts`
-    is the attributable channel only (worktree path state and, under
-    `exclusive_ref_store`, any local ref, plus host-supplied tool-trace
-    evidence) — an unattributed Tier 2 ref change belongs in
+    is the attributable channel only (worktree path state plus host-supplied
+    tool-trace evidence) — an unattributed Tier 2 ref change belongs in
     `observed_ref_changes` instead and never affects `write_isolation`.
 
     `observed_ref_changes` is recorded verbatim when non-empty and omitted

--- a/skills/review-fix-loop/scripts/tests/test_evals.py
+++ b/skills/review-fix-loop/scripts/tests/test_evals.py
@@ -51,6 +51,7 @@ EXPECTED_SCENARIO_IDS = {
     "lc-validation-failure-not-tractable",
     "lc-validation-failure-tractable-converges",
     "lc-reviewer-mutation-blocked",
+    "lc-unattributed-ref-advance-converges",
     "lc-incomplete-review-blocked-verdict",
     "lc-invalid-stale-review-result-blocked",
     "lc-missing-capability-without-override",

--- a/skills/review-fix-loop/scripts/tests/test_local_commit.py
+++ b/skills/review-fix-loop/scripts/tests/test_local_commit.py
@@ -113,7 +113,6 @@ def make_invocation(
     invocation_id: str = "local-commit-test",
     max_fix_cycles: int = 3,
     validation: list[dict[str, str]] | None = None,
-    review_execution: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     common_dir = LE.git_common_dir(repo)
     diff = LE.git("diff", base_sha, head_sha, cwd=repo).stdout
@@ -146,7 +145,7 @@ def make_invocation(
                 "nearby_patterns": [],
             },
         },
-        "review_execution": review_execution or {"mode": "fresh_subagent"},
+        "review_execution": {"mode": "fresh_subagent"},
         "fix_cycle_budget": {"max_fix_cycles": max_fix_cycles},
         "validation": validation or ALWAYS_PASS_VALIDATION,
         "publication": {"policy": "local_commit"},
@@ -1151,45 +1150,6 @@ class UnattributedRefAdvanceTests(LocalCommitRepoTestCase):
                 for change in final_record.get("observed_ref_changes", [])
             )
         )
-
-    def test_exclusive_ref_store_folds_unrelated_advance_into_reviewer_integrity_failure(
-        self,
-    ):
-        base_sha, head_sha = start_candidate(self.repo, marker="fixed")
-        invocation = make_invocation(
-            self.repo,
-            branch="fix/99-example",
-            base_sha=base_sha,
-            head_sha=head_sha,
-            review_execution={"mode": "fresh_subagent", "exclusive_ref_store": True},
-        )
-        LE.git("branch", "background/automation", base_sha, cwd=self.repo)
-
-        def reviewer(
-            *, packet, briefing, head_sha, comparison_base_sha, independence, sequence
-        ):
-            del packet, briefing, independence, sequence
-            LE.git(
-                "update-ref",
-                "refs/heads/background/automation",
-                head_sha,
-                cwd=self.repo,
-            )
-            return _clean_review_pass(head_sha, comparison_base_sha)
-
-        result = LC.run_local_commit(
-            invocation,
-            repo=self.repo,
-            reviewer=reviewer,
-            decide=accepting_decide,
-            apply_fix=fixing_apply_fix,
-        )
-        self.assertEqual(result["terminal_state"], "blocked")
-        self.assertEqual(result["reason"], "reviewer_integrity_failure")
-        self.assertEqual(VALIDATE.validate_terminal_result(result), [])
-        # Preserved for operator inspection, not silently cleaned up.
-        LE.git("reset", "-q", "--hard", "HEAD", cwd=self.repo)
-        LE.git("clean", "-fdq", cwd=self.repo)
 
 
 class IntegrityEvidenceTests(LocalCommitRepoTestCase):

--- a/skills/review-fix-loop/scripts/tests/test_local_commit.py
+++ b/skills/review-fix-loop/scripts/tests/test_local_commit.py
@@ -113,6 +113,7 @@ def make_invocation(
     invocation_id: str = "local-commit-test",
     max_fix_cycles: int = 3,
     validation: list[dict[str, str]] | None = None,
+    review_execution: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     common_dir = LE.git_common_dir(repo)
     diff = LE.git("diff", base_sha, head_sha, cwd=repo).stdout
@@ -145,7 +146,7 @@ def make_invocation(
                 "nearby_patterns": [],
             },
         },
-        "review_execution": {"mode": "fresh_subagent"},
+        "review_execution": review_execution or {"mode": "fresh_subagent"},
         "fix_cycle_budget": {"max_fix_cycles": max_fix_cycles},
         "validation": validation or ALWAYS_PASS_VALIDATION,
         "publication": {"policy": "local_commit"},
@@ -971,6 +972,310 @@ class ReviewerMutationTests(LocalCommitRepoTestCase):
         # Preserved for operator inspection, not silently cleaned up.
         LE.git("reset", "-q", "--hard", "HEAD", cwd=self.repo)
         LE.git("clean", "-fdq", cwd=self.repo)
+
+
+def _clean_review_pass(head_sha, comparison_base_sha, **kwargs):
+    candidate = {"head_sha": head_sha, "comparison_base_sha": comparison_base_sha}
+    result = {
+        **CLEAN_TEMPLATE,
+        "candidate": candidate,
+        "lens_executions": [
+            {
+                "lens": lens,
+                "head_sha": head_sha,
+                "comparison_base_sha": comparison_base_sha,
+                "verdict": "clean",
+                "freshly_executed": True,
+            }
+            for lens in ("solution_simplicity", "correctness", "code_simplicity")
+        ],
+    }
+    return LC.ReviewPass(result=result, **kwargs)
+
+
+class CandidateRefIntegrityTests(LocalCommitRepoTestCase):
+    """Tier 1 (issue #245): a change to `HEAD`, the candidate branch ref, or
+    this invocation's own attempt namespace invalidates the candidate itself
+    — `blocked/candidate_integrity_failure` — regardless of who caused it."""
+
+    def test_candidate_branch_ref_move_during_review_blocks_candidate_integrity(self):
+        base_sha, head_sha = start_candidate(self.repo, marker="fixed")
+        invocation = make_invocation(
+            self.repo, branch="fix/99-example", base_sha=base_sha, head_sha=head_sha
+        )
+
+        def reviewer(
+            *, packet, briefing, head_sha, comparison_base_sha, independence, sequence
+        ):
+            del packet, briefing, independence, sequence
+            # Simulate a concurrent advance of the very branch this candidate
+            # is defined by — e.g. a background `pull --ff-only` of the
+            # checked-out branch.
+            LE.git(
+                "update-ref",
+                "refs/heads/fix/99-example",
+                base_sha,
+                cwd=self.repo,
+            )
+            return _clean_review_pass(head_sha, comparison_base_sha)
+
+        result = LC.run_local_commit(
+            invocation,
+            repo=self.repo,
+            reviewer=reviewer,
+            decide=accepting_decide,
+            apply_fix=fixing_apply_fix,
+        )
+        self.assertEqual(result["terminal_state"], "blocked")
+        self.assertEqual(result["reason"], "candidate_integrity_failure")
+        self.assertEqual(VALIDATE.validate_terminal_result(result), [])
+        # Restore for cleanup.
+        LE.git("update-ref", "refs/heads/fix/99-example", head_sha, cwd=self.repo)
+
+    def test_own_attempt_namespace_change_during_review_blocks_candidate_integrity(
+        self,
+    ):
+        base_sha, head_sha = start_candidate(self.repo, marker="fixed")
+        invocation = make_invocation(
+            self.repo,
+            branch="fix/99-example",
+            base_sha=base_sha,
+            head_sha=head_sha,
+            invocation_id="lc-attempt-ns-test",
+        )
+
+        def reviewer(
+            *, packet, briefing, head_sha, comparison_base_sha, independence, sequence
+        ):
+            del packet, briefing, independence, sequence
+            LE.git(
+                "update-ref",
+                "refs/heads/review-fix-loop/attempt/lc-attempt-ns-test/1",
+                head_sha,
+                cwd=self.repo,
+            )
+            return _clean_review_pass(head_sha, comparison_base_sha)
+
+        result = LC.run_local_commit(
+            invocation,
+            repo=self.repo,
+            reviewer=reviewer,
+            decide=accepting_decide,
+            apply_fix=fixing_apply_fix,
+        )
+        self.assertEqual(result["terminal_state"], "blocked")
+        self.assertEqual(result["reason"], "candidate_integrity_failure")
+        self.assertEqual(VALIDATE.validate_terminal_result(result), [])
+
+
+class UnattributedRefAdvanceTests(LocalCommitRepoTestCase):
+    """Tier 2 (issue #245): an unattributed local ref change — one that is
+    not the candidate branch ref, not `HEAD`, and not this invocation's own
+    attempt namespace — is a non-gating observation by default, since the
+    ref store may be shared with other worktrees or background automation."""
+
+    def test_unrelated_local_branch_advance_still_converges(self):
+        base_sha, head_sha = start_candidate(self.repo, marker="fixed")
+        invocation = make_invocation(
+            self.repo, branch="fix/99-example", base_sha=base_sha, head_sha=head_sha
+        )
+        LE.git("branch", "background/automation", base_sha, cwd=self.repo)
+
+        def reviewer(
+            *, packet, briefing, head_sha, comparison_base_sha, independence, sequence
+        ):
+            del packet, briefing, independence, sequence
+            # A concurrent process — not this reviewer pass — advances an
+            # unrelated branch while the review runs.
+            LE.git(
+                "update-ref",
+                "refs/heads/background/automation",
+                head_sha,
+                cwd=self.repo,
+            )
+            return _clean_review_pass(head_sha, comparison_base_sha)
+
+        result = LC.run_local_commit(
+            invocation,
+            repo=self.repo,
+            reviewer=reviewer,
+            decide=accepting_decide,
+            apply_fix=fixing_apply_fix,
+        )
+        self.assertEqual(result["terminal_state"], "converged")
+        self.assertEqual(VALIDATE.validate_terminal_result(result), [])
+        final_record = result["review_records"][-1]
+        self.assertEqual([], final_record["mutation_attempts"])
+        self.assertEqual("enforced", final_record["write_isolation"])
+        self.assertTrue(
+            any(
+                "background/automation" in change
+                for change in final_record.get("observed_ref_changes", [])
+            )
+        )
+
+    def test_another_invocations_attempt_namespace_advance_still_converges(self):
+        base_sha, head_sha = start_candidate(self.repo, marker="fixed")
+        invocation = make_invocation(
+            self.repo,
+            branch="fix/99-example",
+            base_sha=base_sha,
+            head_sha=head_sha,
+            invocation_id="lc-this-invocation",
+        )
+
+        def reviewer(
+            *, packet, briefing, head_sha, comparison_base_sha, independence, sequence
+        ):
+            del packet, briefing, independence, sequence
+            LE.git(
+                "update-ref",
+                "refs/heads/review-fix-loop/attempt/other-invocation/1",
+                head_sha,
+                cwd=self.repo,
+            )
+            return _clean_review_pass(head_sha, comparison_base_sha)
+
+        result = LC.run_local_commit(
+            invocation,
+            repo=self.repo,
+            reviewer=reviewer,
+            decide=accepting_decide,
+            apply_fix=fixing_apply_fix,
+        )
+        self.assertEqual(result["terminal_state"], "converged")
+        final_record = result["review_records"][-1]
+        self.assertTrue(
+            any(
+                "other-invocation" in change
+                for change in final_record.get("observed_ref_changes", [])
+            )
+        )
+
+    def test_exclusive_ref_store_folds_unrelated_advance_into_reviewer_integrity_failure(
+        self,
+    ):
+        base_sha, head_sha = start_candidate(self.repo, marker="fixed")
+        invocation = make_invocation(
+            self.repo,
+            branch="fix/99-example",
+            base_sha=base_sha,
+            head_sha=head_sha,
+            review_execution={"mode": "fresh_subagent", "exclusive_ref_store": True},
+        )
+        LE.git("branch", "background/automation", base_sha, cwd=self.repo)
+
+        def reviewer(
+            *, packet, briefing, head_sha, comparison_base_sha, independence, sequence
+        ):
+            del packet, briefing, independence, sequence
+            LE.git(
+                "update-ref",
+                "refs/heads/background/automation",
+                head_sha,
+                cwd=self.repo,
+            )
+            return _clean_review_pass(head_sha, comparison_base_sha)
+
+        result = LC.run_local_commit(
+            invocation,
+            repo=self.repo,
+            reviewer=reviewer,
+            decide=accepting_decide,
+            apply_fix=fixing_apply_fix,
+        )
+        self.assertEqual(result["terminal_state"], "blocked")
+        self.assertEqual(result["reason"], "reviewer_integrity_failure")
+        self.assertEqual(VALIDATE.validate_terminal_result(result), [])
+        # Preserved for operator inspection, not silently cleaned up.
+        LE.git("reset", "-q", "--hard", "HEAD", cwd=self.repo)
+        LE.git("clean", "-fdq", cwd=self.repo)
+
+
+class IntegrityEvidenceTests(LocalCommitRepoTestCase):
+    """`integrity_evidence` (issue #245) distinguishes host-supplied
+    tool-trace inspection from a surface-only (snapshot-only) pass; either
+    way a clean pass converges."""
+
+    def test_no_tool_trace_supplied_records_surface_only_and_converges(self):
+        base_sha, head_sha = start_candidate(self.repo, marker="fixed")
+        invocation = make_invocation(
+            self.repo, branch="fix/99-example", base_sha=base_sha, head_sha=head_sha
+        )
+
+        def reviewer(
+            *, packet, briefing, head_sha, comparison_base_sha, independence, sequence
+        ):
+            del packet, briefing, independence, sequence
+            return _clean_review_pass(head_sha, comparison_base_sha)
+
+        result = LC.run_local_commit(
+            invocation,
+            repo=self.repo,
+            reviewer=reviewer,
+            decide=accepting_decide,
+            apply_fix=fixing_apply_fix,
+        )
+        self.assertEqual(result["terminal_state"], "converged")
+        self.assertEqual(
+            "surface_only", result["review_records"][-1]["integrity_evidence"]
+        )
+
+    def test_tool_trace_supplied_and_clean_records_tool_trace_and_converges(self):
+        base_sha, head_sha = start_candidate(self.repo, marker="fixed")
+        invocation = make_invocation(
+            self.repo, branch="fix/99-example", base_sha=base_sha, head_sha=head_sha
+        )
+
+        def reviewer(
+            *, packet, briefing, head_sha, comparison_base_sha, independence, sequence
+        ):
+            del packet, briefing, independence, sequence
+            return _clean_review_pass(
+                head_sha, comparison_base_sha, tool_trace_available=True
+            )
+
+        result = LC.run_local_commit(
+            invocation,
+            repo=self.repo,
+            reviewer=reviewer,
+            decide=accepting_decide,
+            apply_fix=fixing_apply_fix,
+        )
+        self.assertEqual(result["terminal_state"], "converged")
+        self.assertEqual(
+            "tool_trace", result["review_records"][-1]["integrity_evidence"]
+        )
+
+    def test_tool_trace_mutation_blocks_even_with_no_snapshot_change(self):
+        base_sha, head_sha = start_candidate(self.repo, marker="fixed")
+        invocation = make_invocation(
+            self.repo, branch="fix/99-example", base_sha=base_sha, head_sha=head_sha
+        )
+
+        def reviewer(
+            *, packet, briefing, head_sha, comparison_base_sha, independence, sequence
+        ):
+            del packet, briefing, independence, sequence
+            return _clean_review_pass(
+                head_sha,
+                comparison_base_sha,
+                tool_trace_available=True,
+                mutation_attempts=["tool trace: attempted `git push origin main`"],
+            )
+
+        result = LC.run_local_commit(
+            invocation,
+            repo=self.repo,
+            reviewer=reviewer,
+            decide=accepting_decide,
+            apply_fix=fixing_apply_fix,
+        )
+        self.assertEqual(result["terminal_state"], "blocked")
+        self.assertEqual(result["reason"], "reviewer_integrity_failure")
+        final_record = result["review_records"][-1]
+        self.assertEqual("violated", final_record["write_isolation"])
+        self.assertEqual("tool_trace", final_record["integrity_evidence"])
 
 
 class MissingCapabilityTests(LocalCommitRepoTestCase):

--- a/skills/review-fix-loop/scripts/tests/test_reviewer_orchestration.py
+++ b/skills/review-fix-loop/scripts/tests/test_reviewer_orchestration.py
@@ -320,6 +320,15 @@ class GenerateReviewerIdentityTests(unittest.TestCase):
 
 
 class DetectWorktreeMutationTests(unittest.TestCase):
+    """Covers the tiered `WorktreeMutationReport` this ticket introduces:
+
+    Tier 1 (`head_sha`, the candidate branch ref, and this invocation's own
+    attempt namespace) lands in `candidate_mutations`; worktree path state
+    lands in `mutation_attempts` exactly as before this tiering existed; every
+    other local ref (Tier 2) lands in `observed_ref_changes` by default, or
+    folds into `mutation_attempts` under `exclusive_ref_store=True`.
+    """
+
     CLEAN_STATE = {
         "head_sha": HEAD,
         "refs": {"refs/heads/main": HEAD},
@@ -329,40 +338,61 @@ class DetectWorktreeMutationTests(unittest.TestCase):
         "untracked": [],
         "ignored": [],
     }
+    CANDIDATE_BRANCH_REF = "refs/heads/lc/example"
+    ATTEMPT_NAMESPACE_PREFIX = "refs/heads/review-fix-loop/attempt/lc-example/"
+
+    def _detect(self, before, after, **kwargs):
+        kwargs.setdefault("candidate_branch_ref", self.CANDIDATE_BRANCH_REF)
+        kwargs.setdefault("attempt_namespace_prefix", self.ATTEMPT_NAMESPACE_PREFIX)
+        return ORCH.detect_worktree_mutation(before, after, **kwargs)
 
     def test_identical_snapshots_report_no_mutation(self):
         before = copy.deepcopy(self.CLEAN_STATE)
         after = copy.deepcopy(self.CLEAN_STATE)
-        self.assertEqual([], ORCH.detect_worktree_mutation(before, after))
+        report = self._detect(before, after)
+        self.assertEqual([], report.candidate_mutations)
+        self.assertEqual([], report.mutation_attempts)
+        self.assertEqual([], report.observed_ref_changes)
 
-    def test_head_advance_is_detected(self):
+    def test_head_advance_is_candidate_bound(self):
         before = copy.deepcopy(self.CLEAN_STATE)
         after = copy.deepcopy(self.CLEAN_STATE)
         after["head_sha"] = OTHER_HEAD
-        mutations = ORCH.detect_worktree_mutation(before, after)
-        self.assertTrue(any("head_sha advanced" in m for m in mutations))
+        report = self._detect(before, after)
+        self.assertTrue(
+            any("head_sha advanced" in m for m in report.candidate_mutations)
+        )
+        self.assertEqual([], report.mutation_attempts)
+        self.assertEqual([], report.observed_ref_changes)
 
-    def test_staged_addition_is_detected(self):
+    def test_staged_addition_is_a_mutation_attempt(self):
         before = copy.deepcopy(self.CLEAN_STATE)
         after = copy.deepcopy(self.CLEAN_STATE)
         after["staged"] = ["evil.py"]
-        mutations = ORCH.detect_worktree_mutation(before, after)
-        self.assertTrue(any(m.startswith("staged:") for m in mutations))
+        report = self._detect(before, after)
+        self.assertTrue(any(m.startswith("staged:") for m in report.mutation_attempts))
+        self.assertEqual([], report.candidate_mutations)
 
-    def test_untracked_addition_is_detected(self):
+    def test_untracked_addition_is_a_mutation_attempt(self):
         before = copy.deepcopy(self.CLEAN_STATE)
         after = copy.deepcopy(self.CLEAN_STATE)
         after["untracked"] = ["stray.py"]
-        mutations = ORCH.detect_worktree_mutation(before, after)
-        self.assertTrue(any(m.startswith("untracked:") for m in mutations))
+        report = self._detect(before, after)
+        self.assertTrue(
+            any(m.startswith("untracked:") for m in report.mutation_attempts)
+        )
+        self.assertEqual([], report.candidate_mutations)
 
-    def test_tracked_removal_is_detected(self):
+    def test_tracked_removal_is_a_mutation_attempt(self):
         before = copy.deepcopy(self.CLEAN_STATE)
         after = copy.deepcopy(self.CLEAN_STATE)
         after["tracked"] = []
-        mutations = ORCH.detect_worktree_mutation(before, after)
+        report = self._detect(before, after)
         self.assertTrue(
-            any("removed" in m and m.startswith("tracked:") for m in mutations)
+            any(
+                "removed" in m and m.startswith("tracked:")
+                for m in report.mutation_attempts
+            )
         )
 
     def test_ignored_changes_are_not_flagged(self):
@@ -374,38 +404,133 @@ class DetectWorktreeMutationTests(unittest.TestCase):
         before = copy.deepcopy(self.CLEAN_STATE)
         after = copy.deepcopy(self.CLEAN_STATE)
         after["ignored"] = ["build/output.bin"]
-        self.assertEqual([], ORCH.detect_worktree_mutation(before, after))
+        report = self._detect(before, after)
+        self.assertEqual([], report.candidate_mutations)
+        self.assertEqual([], report.mutation_attempts)
+        self.assertEqual([], report.observed_ref_changes)
 
-    def test_new_local_ref_is_detected(self):
-        # A reviewer that runs `git stash` or creates a branch without
-        # touching HEAD or any tracked path is still a write-isolation
-        # violation.
+    def test_candidate_branch_ref_change_is_candidate_bound(self):
+        # Tier 1: the ref that *defines the candidate* moved. Gating
+        # regardless of who caused it — this is `candidate_integrity_failure`
+        # territory, not an ordinary reviewer mutation.
+        before = copy.deepcopy(self.CLEAN_STATE)
+        before["refs"] = {self.CANDIDATE_BRANCH_REF: HEAD}
+        after = copy.deepcopy(self.CLEAN_STATE)
+        after["refs"] = {self.CANDIDATE_BRANCH_REF: OTHER_HEAD}
+        report = self._detect(before, after)
+        self.assertTrue(
+            any(
+                m.startswith("refs:") and "changed" in m
+                for m in report.candidate_mutations
+            )
+        )
+        self.assertEqual([], report.mutation_attempts)
+        self.assertEqual([], report.observed_ref_changes)
+
+    def test_own_attempt_namespace_change_is_candidate_bound(self):
+        # Tier 1: this invocation's own attempt branch.
+        before = copy.deepcopy(self.CLEAN_STATE)
+        before["refs"] = {"refs/heads/main": HEAD}
+        after = copy.deepcopy(before)
+        after["refs"] = {
+            "refs/heads/main": HEAD,
+            f"{self.ATTEMPT_NAMESPACE_PREFIX}1": OTHER_HEAD,
+        }
+        report = self._detect(before, after)
+        self.assertTrue(
+            any(
+                m.startswith("refs:") and "added" in m
+                for m in report.candidate_mutations
+            )
+        )
+        self.assertEqual([], report.observed_ref_changes)
+
+    def test_another_invocations_attempt_namespace_is_tier_two(self):
+        # A sibling invocation's own attempt branch does not share this
+        # invocation's prefix — Tier 2, non-gating.
+        before = copy.deepcopy(self.CLEAN_STATE)
+        before["refs"] = {"refs/heads/main": HEAD}
+        after = copy.deepcopy(before)
+        after["refs"] = {
+            "refs/heads/main": HEAD,
+            "refs/heads/review-fix-loop/attempt/other-invocation/1": OTHER_HEAD,
+        }
+        report = self._detect(before, after)
+        self.assertEqual([], report.candidate_mutations)
+        self.assertEqual([], report.mutation_attempts)
+        self.assertTrue(
+            any(
+                m.startswith("refs:") and "added" in m
+                for m in report.observed_ref_changes
+            )
+        )
+
+    def test_unrelated_local_ref_advance_is_tier_two_by_default(self):
+        # A reviewer that runs `git stash`, or a concurrent worktree/
+        # background process that force-moves an unrelated branch, is
+        # unattributable from the ref map alone when the ref store may be
+        # shared — this is exactly the false-positive this ticket fixes.
         before = copy.deepcopy(self.CLEAN_STATE)
         before["refs"] = {"refs/heads/main": HEAD}
         after = copy.deepcopy(before)
         after["refs"] = {"refs/heads/main": HEAD, "refs/stash": OTHER_HEAD}
-        mutations = ORCH.detect_worktree_mutation(before, after)
-        self.assertTrue(any(m.startswith("refs:") and "added" in m for m in mutations))
-
-    def test_force_moved_local_ref_is_detected(self):
-        before = copy.deepcopy(self.CLEAN_STATE)
-        before["refs"] = {"refs/heads/evil": HEAD}
-        after = copy.deepcopy(self.CLEAN_STATE)
-        after["refs"] = {"refs/heads/evil": OTHER_HEAD}
-        mutations = ORCH.detect_worktree_mutation(before, after)
+        report = self._detect(before, after)
+        self.assertEqual([], report.candidate_mutations)
+        self.assertEqual([], report.mutation_attempts)
         self.assertTrue(
-            any(m.startswith("refs:") and "changed" in m for m in mutations)
+            any(
+                m.startswith("refs:") and "added" in m
+                for m in report.observed_ref_changes
+            )
         )
 
-    def test_removed_local_ref_is_detected(self):
+    def test_unrelated_local_ref_removal_is_tier_two_by_default(self):
         before = copy.deepcopy(self.CLEAN_STATE)
-        before["refs"] = {"refs/heads/evil": HEAD}
+        before["refs"] = {"refs/heads/main": HEAD, "refs/heads/scratch": HEAD}
         after = copy.deepcopy(self.CLEAN_STATE)
-        after["refs"] = {}
-        mutations = ORCH.detect_worktree_mutation(before, after)
+        after["refs"] = {"refs/heads/main": HEAD}
+        report = self._detect(before, after)
+        self.assertEqual([], report.candidate_mutations)
         self.assertTrue(
-            any(m.startswith("refs:") and "removed" in m for m in mutations)
+            any(
+                m.startswith("refs:") and "removed" in m
+                for m in report.observed_ref_changes
+            )
         )
+
+    def test_exclusive_ref_store_folds_tier_two_into_mutation_attempts(self):
+        # `exclusive_ref_store=True` reproduces pre-tiering behavior exactly:
+        # any local ref change is a mutation attempt, even one that would be
+        # Tier 2 (non-gating) by default.
+        before = copy.deepcopy(self.CLEAN_STATE)
+        before["refs"] = {"refs/heads/main": HEAD}
+        after = copy.deepcopy(before)
+        after["refs"] = {"refs/heads/main": HEAD, "refs/stash": OTHER_HEAD}
+        report = self._detect(before, after, exclusive_ref_store=True)
+        self.assertEqual([], report.candidate_mutations)
+        self.assertEqual([], report.observed_ref_changes)
+        self.assertTrue(
+            any(
+                m.startswith("refs:") and "added" in m for m in report.mutation_attempts
+            )
+        )
+
+    def test_exclusive_ref_store_does_not_change_candidate_ref_classification(self):
+        # A candidate-bound ref change stays Tier 1 (`candidate_mutations`)
+        # regardless of `exclusive_ref_store` — the flag only governs whether
+        # a Tier 2 ref can be trusted, not what counts as candidate-bound.
+        before = copy.deepcopy(self.CLEAN_STATE)
+        before["refs"] = {self.CANDIDATE_BRANCH_REF: HEAD}
+        after = copy.deepcopy(self.CLEAN_STATE)
+        after["refs"] = {self.CANDIDATE_BRANCH_REF: OTHER_HEAD}
+        report = self._detect(before, after, exclusive_ref_store=True)
+        self.assertTrue(
+            any(
+                m.startswith("refs:") and "changed" in m
+                for m in report.candidate_mutations
+            )
+        )
+        self.assertEqual([], report.mutation_attempts)
 
     def test_remote_tracking_ref_change_alone_is_not_flagged(self):
         # Excluded from comparison: an unattributed remote-tracking-ref
@@ -415,7 +540,27 @@ class DetectWorktreeMutationTests(unittest.TestCase):
         before["refs"] = {"refs/remotes/origin/main": HEAD}
         after = copy.deepcopy(self.CLEAN_STATE)
         after["refs"] = {"refs/remotes/origin/main": OTHER_HEAD}
-        self.assertEqual([], ORCH.detect_worktree_mutation(before, after))
+        report = self._detect(before, after)
+        self.assertEqual([], report.candidate_mutations)
+        self.assertEqual([], report.mutation_attempts)
+        self.assertEqual([], report.observed_ref_changes)
+
+    def test_no_candidate_ref_supplied_treats_every_ref_as_tier_two(self):
+        # Callers that don't supply candidate_branch_ref/attempt_namespace_
+        # prefix (both default None/empty) get no Tier 1 ref classification
+        # at all — every local ref change is Tier 2.
+        before = copy.deepcopy(self.CLEAN_STATE)
+        before["refs"] = {"refs/heads/evil": HEAD}
+        after = copy.deepcopy(self.CLEAN_STATE)
+        after["refs"] = {"refs/heads/evil": OTHER_HEAD}
+        report = ORCH.detect_worktree_mutation(before, after)
+        self.assertEqual([], report.candidate_mutations)
+        self.assertTrue(
+            any(
+                m.startswith("refs:") and "changed" in m
+                for m in report.observed_ref_changes
+            )
+        )
 
     def test_missing_refs_key_raises_instead_of_silently_passing(self):
         # Fails closed: a snapshot that never captured refs at all must not
@@ -426,14 +571,14 @@ class DetectWorktreeMutationTests(unittest.TestCase):
         del before["refs"]
         after = copy.deepcopy(self.CLEAN_STATE)
         with self.assertRaises(ValueError):
-            ORCH.detect_worktree_mutation(before, after)
+            self._detect(before, after)
 
     def test_missing_head_sha_key_raises_instead_of_silently_passing(self):
         before = copy.deepcopy(self.CLEAN_STATE)
         after = copy.deepcopy(self.CLEAN_STATE)
         del after["head_sha"]
         with self.assertRaises(ValueError):
-            ORCH.detect_worktree_mutation(before, after)
+            self._detect(before, after)
 
     def test_missing_ignored_key_raises_even_though_ignored_is_uncompared(self):
         # ignored is required-but-uncompared: still fails closed on its
@@ -443,11 +588,11 @@ class DetectWorktreeMutationTests(unittest.TestCase):
         after = copy.deepcopy(self.CLEAN_STATE)
         del after["ignored"]
         with self.assertRaises(ValueError):
-            ORCH.detect_worktree_mutation(before, after)
+            self._detect(before, after)
 
     def test_empty_snapshots_raise_rather_than_report_no_mutation(self):
         with self.assertRaises(ValueError):
-            ORCH.detect_worktree_mutation({}, {})
+            self._detect({}, {})
 
 
 class BuildReviewRecordTests(unittest.TestCase):
@@ -472,6 +617,7 @@ class BuildReviewRecordTests(unittest.TestCase):
                 "aggregate_verdict": "clean",
                 "finding_dispositions": [],
                 "mutation_attempts": [],
+                "integrity_evidence": "surface_only",
             },
             record,
         )
@@ -503,6 +649,76 @@ class BuildReviewRecordTests(unittest.TestCase):
         )
         self.assertEqual("violated", record["write_isolation"])
         self.assertEqual(["staged: added ['evil.py']"], record["mutation_attempts"])
+
+    def test_observed_ref_changes_recorded_without_affecting_write_isolation(self):
+        record = ORCH.build_review_record(
+            sequence=1,
+            packet=VALID_PACKET,
+            result=CLEAN_AGGREGATE,
+            expected_head=HEAD,
+            expected_base=BASE,
+            independence="fresh_subagent",
+            reviewer_identity="fresh-subagent-review-1",
+            observed_ref_changes=["refs: added ['refs/heads/main']"],
+        )
+        self.assertEqual("enforced", record["write_isolation"])
+        self.assertEqual([], record["mutation_attempts"])
+        self.assertEqual(
+            ["refs: added ['refs/heads/main']"], record["observed_ref_changes"]
+        )
+
+    def test_observed_ref_changes_omitted_when_empty(self):
+        record = ORCH.build_review_record(
+            sequence=1,
+            packet=VALID_PACKET,
+            result=CLEAN_AGGREGATE,
+            expected_head=HEAD,
+            expected_base=BASE,
+            independence="fresh_subagent",
+            reviewer_identity="fresh-subagent-review-1",
+        )
+        self.assertNotIn("observed_ref_changes", record)
+
+    def test_integrity_evidence_defaults_to_surface_only(self):
+        record = ORCH.build_review_record(
+            sequence=1,
+            packet=VALID_PACKET,
+            result=CLEAN_AGGREGATE,
+            expected_head=HEAD,
+            expected_base=BASE,
+            independence="fresh_subagent",
+            reviewer_identity="fresh-subagent-review-1",
+        )
+        self.assertEqual("surface_only", record["integrity_evidence"])
+
+    def test_integrity_evidence_records_tool_trace_when_supplied(self):
+        record = ORCH.build_review_record(
+            sequence=1,
+            packet=VALID_PACKET,
+            result=CLEAN_AGGREGATE,
+            expected_head=HEAD,
+            expected_base=BASE,
+            independence="fresh_subagent",
+            reviewer_identity="fresh-subagent-review-1",
+            integrity_evidence="tool_trace",
+        )
+        self.assertEqual("tool_trace", record["integrity_evidence"])
+
+    def test_observed_ref_changes_and_integrity_evidence_match_schema(self):
+        record = ORCH.build_review_record(
+            sequence=1,
+            packet=VALID_PACKET,
+            result=CLEAN_AGGREGATE,
+            expected_head=HEAD,
+            expected_base=BASE,
+            independence="fresh_subagent",
+            reviewer_identity="fresh-subagent-review-1",
+            observed_ref_changes=["refs: added ['refs/heads/scratch']"],
+            integrity_evidence="tool_trace",
+        )
+        schema = VALIDATE._load_schema("checkpoint")
+        item_schema = schema["properties"]["review_records"]["items"]
+        self.assertEqual([], VALIDATE.validate_schema(record, item_schema))
 
     def test_mutation_record_fails_a_converged_terminal_result_closed(self):
         """Integration: a mutation-tainted record cannot certify convergence.

--- a/skills/review-fix-loop/scripts/tests/test_reviewer_orchestration.py
+++ b/skills/review-fix-loop/scripts/tests/test_reviewer_orchestration.py
@@ -325,8 +325,8 @@ class DetectWorktreeMutationTests(unittest.TestCase):
     Tier 1 (`head_sha`, the candidate branch ref, and this invocation's own
     attempt namespace) lands in `candidate_mutations`; worktree path state
     lands in `mutation_attempts` exactly as before this tiering existed; every
-    other local ref (Tier 2) lands in `observed_ref_changes` by default, or
-    folds into `mutation_attempts` under `exclusive_ref_store=True`.
+    other local ref (Tier 2) lands in `observed_ref_changes`, always
+    non-gating.
     """
 
     CLEAN_STATE = {
@@ -497,40 +497,6 @@ class DetectWorktreeMutationTests(unittest.TestCase):
                 for m in report.observed_ref_changes
             )
         )
-
-    def test_exclusive_ref_store_folds_tier_two_into_mutation_attempts(self):
-        # `exclusive_ref_store=True` reproduces pre-tiering behavior exactly:
-        # any local ref change is a mutation attempt, even one that would be
-        # Tier 2 (non-gating) by default.
-        before = copy.deepcopy(self.CLEAN_STATE)
-        before["refs"] = {"refs/heads/main": HEAD}
-        after = copy.deepcopy(before)
-        after["refs"] = {"refs/heads/main": HEAD, "refs/stash": OTHER_HEAD}
-        report = self._detect(before, after, exclusive_ref_store=True)
-        self.assertEqual([], report.candidate_mutations)
-        self.assertEqual([], report.observed_ref_changes)
-        self.assertTrue(
-            any(
-                m.startswith("refs:") and "added" in m for m in report.mutation_attempts
-            )
-        )
-
-    def test_exclusive_ref_store_does_not_change_candidate_ref_classification(self):
-        # A candidate-bound ref change stays Tier 1 (`candidate_mutations`)
-        # regardless of `exclusive_ref_store` — the flag only governs whether
-        # a Tier 2 ref can be trusted, not what counts as candidate-bound.
-        before = copy.deepcopy(self.CLEAN_STATE)
-        before["refs"] = {self.CANDIDATE_BRANCH_REF: HEAD}
-        after = copy.deepcopy(self.CLEAN_STATE)
-        after["refs"] = {self.CANDIDATE_BRANCH_REF: OTHER_HEAD}
-        report = self._detect(before, after, exclusive_ref_store=True)
-        self.assertTrue(
-            any(
-                m.startswith("refs:") and "changed" in m
-                for m in report.candidate_mutations
-            )
-        )
-        self.assertEqual([], report.mutation_attempts)
 
     def test_remote_tracking_ref_change_alone_is_not_flagged(self):
         # Excluded from comparison: an unattributed remote-tracking-ref


### PR DESCRIPTION
## Summary

`review-fix-loop`'s `detect_worktree_mutation` compared the entire local ref
map (minus `refs/remotes/*`) before and after each reviewer pass, and any
difference forced `write_isolation: "violated"` — making `converged`
unreachable. In a checkout where several worktrees share one ref store, or
where background automation touches any branch, that inference ("it changed
while the reviewer ran" → "the reviewer did it") is false, and an unrelated
advance killed a valid review.

This replaces the flat comparison with a tiered `WorktreeMutationReport`:

- **Tier 1 — candidate-bound refs** (`HEAD`, the candidate branch ref, this
  invocation's own `refs/heads/review-fix-loop/attempt/<invocation_id>/*`
  namespace): still invalidates the candidate regardless of who caused it —
  now its own distinct `blocked/candidate_integrity_failure`, not
  `write_isolation`.
- **Tier 2 — every other local ref**: always a non-gating
  `observed_ref_changes` observation. `write_isolation` stays `enforced` and
  the pass can still converge.
- **Tier 3 — host-supplied tool-trace evidence**: the only remaining
  attributable channel for `write_isolation: "violated"` /
  `blocked/reviewer_integrity_failure`, alongside worktree path state
  (unchanged — never shared across worktrees).

A new `integrity_evidence` field (`tool_trace` | `surface_only`) records
whether the host actually performed tool-trace inspection for a clean pass.

**Deviation from the ticket's literal text:** the ticket as written also
specifies a `review_execution.exclusive_ref_store` invocation flag that would
restore the old flat comparison for "a dedicated clone the loop genuinely
owns." Review feedback was that shipping an opt-in path back to the exact
comparison this ticket exists to fix made no sense, so it was removed —
every Tier 2 ref change is unconditionally non-gating now, with no
configuration to change that. This needs the ticket body reconciled
separately (see comment below); it isn't silently swept under the PR.

## Changes

- `skills/review-fix-loop/scripts/reviewer_orchestration.py`: tiered
  `detect_worktree_mutation` (now returns `WorktreeMutationReport`), extended
  `build_review_record` with `observed_ref_changes`/`integrity_evidence`.
- `skills/review-fix-loop/scripts/local_commit.py`: the review-phase call
  site short-circuits to `candidate_integrity_failure` on a Tier 1 change,
  otherwise merges Tier 2/tool-trace evidence as before; `ReviewPass` gains
  `tool_trace_available`.
- `skills/review-fix-loop/scripts/local_execution.py`: new
  `attempt_namespace_ref_prefix` helper.
- `checkpoint.schema.json` / `terminal-result.schema.json`: add
  `observed_ref_changes` and `integrity_evidence` to `review_records` items.
- `references/reviewer-orchestration.md`, `references/CONTRACT.md`,
  `references/local-commit.md`, `SKILL.md`: describe the tiering and its
  attribution limit.
- Eval corpus: new `lc_unattributed_ref_advance_converges` scenario alongside
  the existing reviewer-mutation one, with independently-derived Git
  evidence (`test_evals.py` updated).
- Extensive new unit/end-to-end coverage in `test_reviewer_orchestration.py`
  and `test_local_commit.py` for every tier and `integrity_evidence`.
- `evals/results/`: before/after deterministic eval-corpus summaries per the
  eval-backed change norm (no real-model executor exists for this skill);
  the after-stage run was re-recorded once more after the
  `exclusive_ref_store` removal.
- `CHANGELOG.md`: today's entries (one per commit), plus backfilling the
  nine still-SHA-less entries left by the prior merged PR (#247), per the
  repo's backfill-before-adding convention.

## Why

Observed in practice: this repository's checkout has six worktrees sharing
one ref store, and a background `pull --ff-only --quiet` of `main` during a
review pass produced `blocked/reviewer_integrity_failure` with
`refs: changed ['refs/heads/main']` — while the reviewer's own transcript
contained four git commands and no `pull`/`fetch`/`checkout`/`reset`/`merge`.

## Verification

- `python3 -m unittest skills.review-fix-loop.scripts.tests.test_reviewer_orchestration` — pass (68 cases)
- `python3 -m unittest skills.review-fix-loop.scripts.tests.test_validate` — pass (116 cases)
- `python3 -m unittest discover -s skills/review-fix-loop/scripts/tests -p 'test_local_commit.py'` — pass (28 cases). Note: the ticket's literal `python3 -m unittest skills.review-fix-loop.scripts.tests.test_local_commit` form errors with `ModuleNotFoundError: No module named 'helpers'` — a pre-existing, `AGENTS.md`-documented gap (this skill's `scripts/tests/` doesn't carry the `sys.path` shim yet and is discovery-only), unrelated to this change.
- `just eval-review-fix-loop` — 21/21 pass (up from 20; new unattributed-ref-advance scenario included)
- `just format`, `just lint`, `just test` — all pass
- `just eval-record review-fix-loop --stage before` and `--stage after` — both recorded and committed; deterministic tier, gap text present (no real-model executor for this skill); the after run was re-recorded at the final shipping head after `exclusive_ref_store` was removed (21/21, unchanged)
- Fresh-subagent `review-code-change` initial review, twice (before and after removing `exclusive_ref_store`): **clean** across all three lenses (solution_simplicity, correctness, code_simplicity), zero findings both times

The ticket's one **post-merge** required verification item —
"Confirm on a checkout with several worktrees sharing one ref store that a
concurrent branch advance during a review pass no longer terminates the
run" — remains open after merge; using non-closing reference below on
purpose.

Refs #245
